### PR TITLE
Create working directory with 777 permission before docker compose up

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ CSGHub Server是开源、可信的大模型资产管理平台[CSGHub](https://gi
 ```shell
 # API token 长度至少为128个字符，发往 csghub-server 的 http 请求需要将 API token 作为 Bearer token 来做身份验证
 export STARHUB_SERVER_API_TOKEN=<API token>
+mkdir -m 777 gitea minio_data
 curl -L https://raw.githubusercontent.com/OpenCSGs/csghub-server/main/docker-compose.yml -o docker-compose.yml
 docker compose -f docker-compose.yml up -d
 ```

--- a/README_en.md
+++ b/README_en.md
@@ -27,6 +27,7 @@ You can quickly deploy the localized `CSGHub Server` service through docker-comp
 ```shell
 # The API token should be at least 128 characters long, and HTTP requests to csghub-server require the API token to be sent as a Bearer token for authentication.
 export STARHUB_SERVER_API_TOKEN=<API token>
+mkdir -m 777 gitea minio_data
 curl -L https://raw.githubusercontent.com/OpenCSGs/csghub-server/main/docker-compose.yml -o docker-compose.yml
 docker-compose -f docker-compose.yml up -d
 ```


### PR DESCRIPTION
- Add `mkdir` command to docker compose command to create the directories needed to mount the docker images