### PR TITLE
Make the swagger host configurable

### DIFF
--- a/cmd/csghub-server/cmd/start/server.go
+++ b/cmd/csghub-server/cmd/start/server.go
@@ -38,7 +38,7 @@ var serverCmd = &cobra.Command{
 			docs.SwaggerInfo.Title = "CSGHub Server API"
 			docs.SwaggerInfo.Description = "CSGHub Server API."
 			docs.SwaggerInfo.Version = "1.0"
-			docs.SwaggerInfo.Host = "localhost:8080"
+			docs.SwaggerInfo.Host = cfg.APIServer.ExternalHost
 			docs.SwaggerInfo.BasePath = "/api/v1"
 			docs.SwaggerInfo.Schemes = []string{"http", "https"}
 		}

--- a/cmd/csghub-server/cmd/start/server.go
+++ b/cmd/csghub-server/cmd/start/server.go
@@ -38,7 +38,7 @@ var serverCmd = &cobra.Command{
 			docs.SwaggerInfo.Title = "CSGHub Server API"
 			docs.SwaggerInfo.Description = "CSGHub Server API."
 			docs.SwaggerInfo.Version = "1.0"
-			docs.SwaggerInfo.Host = cfg.APIServer.ExternalHost
+			docs.SwaggerInfo.Host = cfg.APIServer.PublicDomain
 			docs.SwaggerInfo.BasePath = "/api/v1"
 			docs.SwaggerInfo.Schemes = []string{"http", "https"}
 		}

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -9,7 +9,7 @@ type Config struct {
 
 	APIServer struct {
 		Port         int    `envconfig:"STARHUB_SERVER_SERVER_PORT" default:"8080"`
-		ExternalHost string `envconfig:"STARHUB_SERVER_SERVER_EXTERNAL_HOST" default:"http://localhost"`
+		ExternalHost string `envconfig:"STARHUB_SERVER_SERVER_EXTERNAL_HOST" default:"localhost:8080"`
 	}
 
 	DocsHost string `envconfig:"STARHUB_SERVER_SERVER_DOCS_HOST" default:"http://localhost:6636"`

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -9,7 +9,7 @@ type Config struct {
 
 	APIServer struct {
 		Port         int    `envconfig:"STARHUB_SERVER_SERVER_PORT" default:"8080"`
-		ExternalHost string `envconfig:"STARHUB_SERVER_SERVER_EXTERNAL_HOST" default:"localhost:8080"`
+		PublicDomain string `envconfig:"STARHUB_SERVER_PUBLIC_DOMAIN" default:"localhost:8080"`
 	}
 
 	DocsHost string `envconfig:"STARHUB_SERVER_SERVER_DOCS_HOST" default:"http://localhost:6636"`


### PR DESCRIPTION
- Make the swagger host configurable, the default value is `localhost:8080`.