### PR TITLE
Add click_download_count to repository_downloads

### DIFF
--- a/api/handler/dataset.go
+++ b/api/handler/dataset.go
@@ -692,11 +692,11 @@ func (h *DatasetHandler) UpdateDownloads(ctx *gin.Context) {
 
 	err = h.c.UpdateDownloads(ctx, req)
 	if err != nil {
-		slog.Error("Failed to update dataset download count", slog.Any("error", err), slog.String("namespace", namespace), slog.String("name", name), slog.Time("date", date), slog.Int64("download_count", req.CloneCount))
+		slog.Error("Failed to update dataset download count", slog.Any("error", err), slog.String("namespace", namespace), slog.String("name", name), slog.Time("date", date), slog.Int64("clone_count", req.CloneCount))
 		ctx.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
 		return
 	}
-	slog.Info("Update dataset download count succeed", slog.String("namespace", namespace), slog.String("name", name), slog.Int64("download_count", req.CloneCount))
+	slog.Info("Update dataset download count succeed", slog.String("namespace", namespace), slog.String("name", name), slog.Int64("clone_count", req.CloneCount))
 	httpbase.OK(ctx, nil)
 }
 

--- a/api/handler/dataset.go
+++ b/api/handler/dataset.go
@@ -692,11 +692,11 @@ func (h *DatasetHandler) UpdateDownloads(ctx *gin.Context) {
 
 	err = h.c.UpdateDownloads(ctx, req)
 	if err != nil {
-		slog.Error("Failed to update dataset download count", slog.Any("error", err), slog.String("namespace", namespace), slog.String("name", name), slog.Time("date", date), slog.Int64("download_count", req.DownloadCount))
+		slog.Error("Failed to update dataset download count", slog.Any("error", err), slog.String("namespace", namespace), slog.String("name", name), slog.Time("date", date), slog.Int64("download_count", req.CloneCount))
 		ctx.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
 		return
 	}
-	slog.Info("Update dataset download count succeed", slog.String("namespace", namespace), slog.String("name", name), slog.Int64("download_count", req.DownloadCount))
+	slog.Info("Update dataset download count succeed", slog.String("namespace", namespace), slog.String("name", name), slog.Int64("download_count", req.CloneCount))
 	httpbase.OK(ctx, nil)
 }
 

--- a/api/handler/model.go
+++ b/api/handler/model.go
@@ -687,11 +687,11 @@ func (h *ModelHandler) UpdateDownloads(ctx *gin.Context) {
 
 	err = h.c.UpdateDownloads(ctx, req)
 	if err != nil {
-		slog.Error("Failed to update model download count", slog.Any("error", err), slog.String("namespace", namespace), slog.String("name", name), slog.Time("date", date), slog.Int64("download_count", req.CloneCount))
+		slog.Error("Failed to update model download count", slog.Any("error", err), slog.String("namespace", namespace), slog.String("name", name), slog.Time("date", date), slog.Int64("clone_count", req.CloneCount))
 		ctx.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
 		return
 	}
-	slog.Info("Update model download count succeed", slog.String("namespace", namespace), slog.String("name", name), slog.Int64("download_count", req.CloneCount))
+	slog.Info("Update model download count succeed", slog.String("namespace", namespace), slog.String("name", name), slog.Int64("clone_count", req.CloneCount))
 	httpbase.OK(ctx, nil)
 }
 

--- a/api/handler/model.go
+++ b/api/handler/model.go
@@ -687,11 +687,11 @@ func (h *ModelHandler) UpdateDownloads(ctx *gin.Context) {
 
 	err = h.c.UpdateDownloads(ctx, req)
 	if err != nil {
-		slog.Error("Failed to update model download count", slog.Any("error", err), slog.String("namespace", namespace), slog.String("name", name), slog.Time("date", date), slog.Int64("download_count", req.DownloadCount))
+		slog.Error("Failed to update model download count", slog.Any("error", err), slog.String("namespace", namespace), slog.String("name", name), slog.Time("date", date), slog.Int64("download_count", req.CloneCount))
 		ctx.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
 		return
 	}
-	slog.Info("Update model download count succeed", slog.String("namespace", namespace), slog.String("name", name), slog.Int64("download_count", req.DownloadCount))
+	slog.Info("Update model download count succeed", slog.String("namespace", namespace), slog.String("name", name), slog.Int64("download_count", req.CloneCount))
 	httpbase.OK(ctx, nil)
 }
 

--- a/builder/store/database/dataset.go
+++ b/builder/store/database/dataset.go
@@ -258,7 +258,7 @@ func (s *DatasetStore) Update(ctx context.Context, dataset *Dataset, repo *Repos
 	return
 }
 
-func (s *DatasetStore) UpdateRepoFileDownloads(ctx context.Context, dataset *Dataset, date time.Time, downloadCount int64) (err error) {
+func (s *DatasetStore) UpdateRepoFileDownloads(ctx context.Context, dataset *Dataset, date time.Time, clickDownloadCount int64) (err error) {
 	rd := new(RepositoryDownload)
 	err = s.db.Operator.Core.NewSelect().
 		Model(rd).
@@ -269,7 +269,7 @@ func (s *DatasetStore) UpdateRepoFileDownloads(ctx context.Context, dataset *Dat
 	}
 
 	if errors.Is(err, sql.ErrNoRows) {
-		rd.DownloadCount = downloadCount
+		rd.ClickDownloadCount = clickDownloadCount
 		rd.Date = date
 		rd.RepositoryID = dataset.RepositoryID
 		err = s.db.Operator.Core.NewInsert().
@@ -279,7 +279,7 @@ func (s *DatasetStore) UpdateRepoFileDownloads(ctx context.Context, dataset *Dat
 			return
 		}
 	} else {
-		rd.DownloadCount = rd.DownloadCount + downloadCount
+		rd.ClickDownloadCount = rd.ClickDownloadCount + clickDownloadCount
 		rd.UpdatedAt = time.Now()
 		query := s.db.Operator.Core.NewUpdate().
 			Model(rd).
@@ -343,7 +343,7 @@ func (s *DatasetStore) UpdateRepoCloneDownloads(ctx context.Context, dataset *Da
 func (s *DatasetStore) UpdateDownloads(ctx context.Context, dataset *Dataset) error {
 	var downloadCount int64
 	err := s.db.Operator.Core.NewSelect().
-		ColumnExpr("(SUM(clone_count)+SUM(download_count)) AS total_count").
+		ColumnExpr("(SUM(clone_count)+SUM(click_download_count)) AS total_count").
 		Model(&RepositoryDownload{}).
 		Where("repository_id=?", dataset.RepositoryID).
 		Scan(ctx, &downloadCount)

--- a/builder/store/database/migrations/20240131084249_add_download_count_to_repository_downloads.down.sql
+++ b/builder/store/database/migrations/20240131084249_add_download_count_to_repository_downloads.down.sql
@@ -2,7 +2,7 @@ SET statement_timeout = 0;
 
 --bun:split
 
-ALTER TABLE repository_downloads DROP COLUMN download_count;
+ALTER TABLE repository_downloads DROP COLUMN click_download_count;
 
 --bun:split
 

--- a/builder/store/database/migrations/20240131084249_add_download_count_to_repository_downloads.down.sql
+++ b/builder/store/database/migrations/20240131084249_add_download_count_to_repository_downloads.down.sql
@@ -1,0 +1,9 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE repository_downloads DROP COLUMN download_count;
+
+--bun:split
+
+ALTER TABLE repository_downloads RENAME COLUMN clone_count TO count;

--- a/builder/store/database/migrations/20240131084249_add_download_count_to_repository_downloads.up.sql
+++ b/builder/store/database/migrations/20240131084249_add_download_count_to_repository_downloads.up.sql
@@ -1,0 +1,9 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE repository_downloads ADD download_count INT DEFAULT 0;
+
+--bun:split
+
+ALTER TABLE repository_downloads RENAME COLUMN count TO clone_count;

--- a/builder/store/database/migrations/20240131084249_add_download_count_to_repository_downloads.up.sql
+++ b/builder/store/database/migrations/20240131084249_add_download_count_to_repository_downloads.up.sql
@@ -2,7 +2,7 @@ SET statement_timeout = 0;
 
 --bun:split
 
-ALTER TABLE repository_downloads ADD download_count INT DEFAULT 0;
+ALTER TABLE repository_downloads ADD click_download_count INT DEFAULT 0;
 
 --bun:split
 

--- a/builder/store/database/model.go
+++ b/builder/store/database/model.go
@@ -255,7 +255,7 @@ func (s *ModelStore) Update(ctx context.Context, model *Model, repo *Repository)
 	return
 }
 
-func (s *ModelStore) UpdateRepoDownloads(ctx context.Context, model *Model, date time.Time, downloads int64) (err error) {
+func (s *ModelStore) UpdateRepoFileDownloads(ctx context.Context, model *Model, date time.Time, downloadCount int64) (err error) {
 	rd := new(RepositoryDownload)
 	err = s.db.Operator.Core.NewSelect().
 		Model(rd).
@@ -266,7 +266,7 @@ func (s *ModelStore) UpdateRepoDownloads(ctx context.Context, model *Model, date
 	}
 
 	if errors.Is(err, sql.ErrNoRows) {
-		rd.Count = downloads
+		rd.DownloadCount = downloadCount
 		rd.Date = date
 		rd.RepositoryID = model.RepositoryID
 		err = s.db.Operator.Core.NewInsert().
@@ -276,7 +276,48 @@ func (s *ModelStore) UpdateRepoDownloads(ctx context.Context, model *Model, date
 			return
 		}
 	} else {
-		rd.Count = downloads
+		rd.DownloadCount = rd.DownloadCount + downloadCount
+		rd.UpdatedAt = time.Now()
+		query := s.db.Operator.Core.NewUpdate().
+			Model(rd).
+			WherePK()
+		slog.Debug(query.String())
+
+		_, err = query.Exec(ctx)
+		if err != nil {
+			return
+		}
+	}
+	err = s.UpdateDownloads(ctx, model)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (s *ModelStore) UpdateRepoCloneDownloads(ctx context.Context, model *Model, date time.Time, cloneCount int64) (err error) {
+	rd := new(RepositoryDownload)
+	err = s.db.Operator.Core.NewSelect().
+		Model(rd).
+		Where("date = ? AND repository_id = ?", date.Format("2006-01-02"), model.RepositoryID).
+		Scan(ctx)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		rd.CloneCount = cloneCount
+		rd.Date = date
+		rd.RepositoryID = model.RepositoryID
+		err = s.db.Operator.Core.NewInsert().
+			Model(rd).
+			Scan(ctx)
+		if err != nil {
+			return
+		}
+	} else {
+		rd.CloneCount = cloneCount
 		rd.UpdatedAt = time.Now()
 		query := s.db.Operator.Core.NewUpdate().
 			Model(rd).
@@ -299,7 +340,7 @@ func (s *ModelStore) UpdateRepoDownloads(ctx context.Context, model *Model, date
 func (s *ModelStore) UpdateDownloads(ctx context.Context, model *Model) error {
 	var downloadCount int64
 	err := s.db.Operator.Core.NewSelect().
-		ColumnExpr("SUM(count)").
+		ColumnExpr("(SUM(clone_count)+SUM(download_count)) AS total_count").
 		Model(&RepositoryDownload{}).
 		Where("repository_id=?", model.RepositoryID).
 		Scan(ctx, &downloadCount)

--- a/builder/store/database/model.go
+++ b/builder/store/database/model.go
@@ -255,7 +255,7 @@ func (s *ModelStore) Update(ctx context.Context, model *Model, repo *Repository)
 	return
 }
 
-func (s *ModelStore) UpdateRepoFileDownloads(ctx context.Context, model *Model, date time.Time, downloadCount int64) (err error) {
+func (s *ModelStore) UpdateRepoFileDownloads(ctx context.Context, model *Model, date time.Time, clickDownloadCount int64) (err error) {
 	rd := new(RepositoryDownload)
 	err = s.db.Operator.Core.NewSelect().
 		Model(rd).
@@ -266,7 +266,7 @@ func (s *ModelStore) UpdateRepoFileDownloads(ctx context.Context, model *Model, 
 	}
 
 	if errors.Is(err, sql.ErrNoRows) {
-		rd.DownloadCount = downloadCount
+		rd.ClickDownloadCount = clickDownloadCount
 		rd.Date = date
 		rd.RepositoryID = model.RepositoryID
 		err = s.db.Operator.Core.NewInsert().
@@ -276,7 +276,7 @@ func (s *ModelStore) UpdateRepoFileDownloads(ctx context.Context, model *Model, 
 			return
 		}
 	} else {
-		rd.DownloadCount = rd.DownloadCount + downloadCount
+		rd.ClickDownloadCount = rd.ClickDownloadCount + clickDownloadCount
 		rd.UpdatedAt = time.Now()
 		query := s.db.Operator.Core.NewUpdate().
 			Model(rd).
@@ -340,7 +340,7 @@ func (s *ModelStore) UpdateRepoCloneDownloads(ctx context.Context, model *Model,
 func (s *ModelStore) UpdateDownloads(ctx context.Context, model *Model) error {
 	var downloadCount int64
 	err := s.db.Operator.Core.NewSelect().
-		ColumnExpr("(SUM(clone_count)+SUM(download_count)) AS total_count").
+		ColumnExpr("(SUM(clone_count)+SUM(click_download_count)) AS total_count").
 		Model(&RepositoryDownload{}).
 		Where("repository_id=?", model.RepositoryID).
 		Scan(ctx, &downloadCount)

--- a/builder/store/database/repository_download.go
+++ b/builder/store/database/repository_download.go
@@ -3,10 +3,11 @@ package database
 import "time"
 
 type RepositoryDownload struct {
-	ID           int64       `bun:",pk,autoincrement" json:"id"`
-	RepositoryID int64       `bun:",notnull" json:"repository_id"`
-	Date         time.Time   `bun:",notnull,type:date" json:"date"`
-	Count        int64       `bun:",notnull" json:"user_id"`
-	Repository   *Repository `bun:"rel:belongs-to,join:repository_id=id"`
+	ID            int64       `bun:",pk,autoincrement" json:"id"`
+	RepositoryID  int64       `bun:",notnull" json:"repository_id"`
+	Date          time.Time   `bun:",notnull,type:date" json:"date"`
+	CloneCount    int64       `bun:",notnull" json:"user_id"`
+	DownloadCount int64       `bun:",notnull" json:"download_count"`
+	Repository    *Repository `bun:"rel:belongs-to,join:repository_id=id"`
 	times
 }

--- a/builder/store/database/repository_download.go
+++ b/builder/store/database/repository_download.go
@@ -3,11 +3,11 @@ package database
 import "time"
 
 type RepositoryDownload struct {
-	ID            int64       `bun:",pk,autoincrement" json:"id"`
-	RepositoryID  int64       `bun:",notnull" json:"repository_id"`
-	Date          time.Time   `bun:",notnull,type:date" json:"date"`
-	CloneCount    int64       `bun:",notnull" json:"user_id"`
-	DownloadCount int64       `bun:",notnull" json:"download_count"`
-	Repository    *Repository `bun:"rel:belongs-to,join:repository_id=id"`
+	ID                 int64       `bun:",pk,autoincrement" json:"id"`
+	RepositoryID       int64       `bun:",notnull" json:"repository_id"`
+	Date               time.Time   `bun:",notnull,type:date" json:"date"`
+	CloneCount         int64       `bun:",notnull" json:"user_id"`
+	ClickDownloadCount int64       `bun:",notnull" json:"click_download_count"`
+	Repository         *Repository `bun:"rel:belongs-to,join:repository_id=id"`
 	times
 }

--- a/cmd/csghub-server/cmd/logscan/logscan.go
+++ b/cmd/csghub-server/cmd/logscan/logscan.go
@@ -132,7 +132,7 @@ var initCmd = &cobra.Command{
 							continue
 						}
 						pDate, _ := time.Parse("2006/01/02", date)
-						err = ds.UpdateRepoDownloads(cmd.Context(), dataset, pDate, count)
+						err = ds.UpdateRepoCloneDownloads(cmd.Context(), dataset, pDate, count)
 						if err != nil {
 							fmt.Printf("Error updating dataset: %s, Date: %s, Count: %d error: %v\n", path, date, count, err)
 						}
@@ -145,7 +145,7 @@ var initCmd = &cobra.Command{
 							continue
 						}
 						pDate, _ := time.Parse("2006/01/02", date)
-						err = ms.UpdateRepoDownloads(cmd.Context(), model, pDate, count)
+						err = ms.UpdateRepoCloneDownloads(cmd.Context(), model, pDate, count)
 						if err != nil {
 							fmt.Printf("Error updating model: %s, Date: %s, Count: %d error: %v\n", path, date, count, err)
 						}

--- a/common/types/model.go
+++ b/common/types/model.go
@@ -64,9 +64,9 @@ type UpdateModelReq struct {
 }
 
 type UpdateDownloadsReq struct {
-	Namespace     string `json:"namespace"`
-	Name          string `json:"name"`
-	ReqDate       string `json:"date"`
-	Date          time.Time
-	DownloadCount int64 `json:"download_count"`
+	Namespace  string `json:"namespace"`
+	Name       string `json:"name"`
+	ReqDate    string `json:"date"`
+	Date       time.Time
+	CloneCount int64 `json:"download_count"`
 }

--- a/component/dataset.go
+++ b/component/dataset.go
@@ -479,6 +479,10 @@ func (c *DatasetComponent) DownloadFile(ctx context.Context, req *types.GetFileR
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to find dataset, error: %w", err)
 	}
+	err = c.ds.UpdateRepoFileDownloads(ctx, dataset, time.Now(), 1)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to update dataset file download count, error: %w", err)
+	}
 	if req.Ref == "" {
 		req.Ref = dataset.Repository.DefaultBranch
 	}
@@ -549,7 +553,7 @@ func (c *DatasetComponent) UpdateDownloads(ctx context.Context, req *types.Updat
 		return fmt.Errorf("failed to find dataset, error: %w", err)
 	}
 
-	err = c.ds.UpdateRepoDownloads(ctx, dataset, req.Date, req.DownloadCount)
+	err = c.ds.UpdateRepoCloneDownloads(ctx, dataset, req.Date, req.CloneCount)
 	if err != nil {
 		return fmt.Errorf("failed to update dataset download count, error: %w", err)
 	}

--- a/component/model.go
+++ b/component/model.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/minio/minio-go/v7"
 	"opencsg.com/csghub-server/builder/git"
@@ -439,6 +440,10 @@ func (c *ModelComponent) DownloadFile(ctx context.Context, req *types.GetFileReq
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to find model, error: %w", err)
 	}
+	err = c.ms.UpdateRepoFileDownloads(ctx, model, time.Now(), 1)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to update model file download count, error: %w", err)
+	}
 	if req.Ref == "" {
 		req.Ref = model.Repository.DefaultBranch
 	}
@@ -508,7 +513,7 @@ func (c *ModelComponent) UpdateDownloads(ctx context.Context, req *types.UpdateD
 		return fmt.Errorf("failed to find model, error: %w", err)
 	}
 
-	err = c.ms.UpdateRepoDownloads(ctx, model, req.Date, req.DownloadCount)
+	err = c.ms.UpdateRepoCloneDownloads(ctx, model, req.Date, req.CloneCount)
 	if err != nil {
 		return fmt.Errorf("failed to update model download count, error: %w", err)
 	}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3957,6 +3957,9 @@ const docTemplate = `{
         "database.RepositoryDownload": {
             "type": "object",
             "properties": {
+                "click_download_count": {
+                    "type": "integer"
+                },
                 "created_at": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3946,6 +3946,9 @@
         "database.RepositoryDownload": {
             "type": "object",
             "properties": {
+                "click_download_count": {
+                    "type": "integer"
+                },
                 "created_at": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -184,6 +184,8 @@ definitions:
     type: object
   database.RepositoryDownload:
     properties:
+      click_download_count:
+        type: integer
       created_at:
         type: string
       date:


### PR DESCRIPTION
- Add `click_download_count` to `repository_downloads` table
- Rename the column `count`  of `repository_downloads` table to `clone_count`
- Count download count after called download file API