### PR TITLE
Remove only API key auth for mirrors

### DIFF
--- a/api/router/api.go
+++ b/api/router/api.go
@@ -252,7 +252,6 @@ func NewRouter(config *config.Config, enableSwagger bool) (*gin.Engine, error) {
 
 	apiGroup.GET("/mirrors", mirrorHandler.Index)
 	mirror := apiGroup.Group("/mirror")
-	mirror.Use(needAPIKey)
 	{
 		mirror.GET("/sources", msHandler.Index)
 		mirror.POST("/sources", msHandler.Create)


### PR DESCRIPTION
- Remove only API key auth for mirrors