### PR TITLE
Use BZPopMax instead of ZPopMax

### DIFF
--- a/builder/store/cache/cache.go
+++ b/builder/store/cache/cache.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -56,6 +57,6 @@ func (c *Cache) ZAdd(ctx context.Context, key string, z redis.Z) error {
 	return err
 }
 
-func (c *Cache) ZPopMax(ctx context.Context, key string, count int64) ([]redis.Z, error) {
-	return c.core.ZPopMax(ctx, key, count).Result()
+func (c *Cache) BZPopMax(ctx context.Context, key string) (*redis.ZWithKey, error) {
+	return c.core.BZPopMax(ctx, time.Second*10, key).Result()
 }

--- a/mirror/queue/queue.go
+++ b/mirror/queue/queue.go
@@ -65,12 +65,12 @@ func (mq *MirrorQueue) Push(t *MirrorTask) {
 }
 
 func (mq *MirrorQueue) Pop() *MirrorTask {
-	r, _ := mq.redis.ZPopMax(context.Background(), mq.QueueName, 1)
-	if len(r) == 0 {
+	r, err := mq.redis.BZPopMax(context.Background(), mq.QueueName)
+	if err != nil {
 		return nil
 	}
 	var task MirrorTask
-	json.Unmarshal([]byte(r[0].Member.(string)), &task)
+	json.Unmarshal([]byte(r.Member.(string)), &task)
 	return &task
 }
 


### PR DESCRIPTION
- Use `BZPopMax` instead of `ZPopMax` to solve the problem that redis occupies too much cpu when reading tasks from the redis queue