### PR TITLE
return internal s3 signed url if client request has header X-OPENCSG-…

### DIFF
--- a/api/handler/git_http.go
+++ b/api/handler/git_http.go
@@ -175,6 +175,11 @@ func (h *GitHTTPHandler) LfsBatch(ctx *gin.Context) {
 		return
 	}
 
+	s3Internal := ctx.GetHeader("X-OPENCSG-S3-Internal")
+	if s3Internal == "true" {
+		ctx.Set("X-OPENCSG-S3-Internal", true)
+	}
+
 	objectResponse, err := h.c.BuildObjectResponse(ctx, batchRequest, isUpload)
 	if err != nil {
 		if errors.Is(err, component.ErrUnauthorized) {
@@ -234,6 +239,11 @@ func (h *GitHTTPHandler) LfsDownload(ctx *gin.Context) {
 	downloadRequest.RepoType = types.RepositoryType(ctx.GetString("repo_type"))
 	downloadRequest.CurrentUser = httpbase.GetCurrentUser(ctx)
 	downloadRequest.SaveAs = ctx.Query("save_as")
+
+	s3Internal := ctx.GetHeader("X-OPENCSG-S3-Internal")
+	if s3Internal == "true" {
+		ctx.Set("X-OPENCSG-S3-Internal", true)
+	}
 
 	url, err := h.c.LfsDownload(ctx, downloadRequest)
 	if err != nil {

--- a/api/handler/repo.go
+++ b/api/handler/repo.go
@@ -380,6 +380,11 @@ func (h *RepoHandler) DownloadFile(ctx *gin.Context) {
 			return
 		}
 	}
+
+	s3Internal := ctx.GetHeader("X-OPENCSG-S3-Internal")
+	if s3Internal == "true" {
+		ctx.Set("X-OPENCSG-S3-Internal", true)
+	}
 	reader, size, url, err := h.c.DownloadFile(ctx, req, currentUser)
 	if err != nil {
 		slog.Error("Failed to download repo file", slog.String("repo_type", string(req.RepoType)), slog.Any("error", err))
@@ -835,6 +840,12 @@ func (h *RepoHandler) handleDownload(ctx *gin.Context, isResolve bool) {
 	} else {
 		branch = ctx.Param("branch")
 	}
+
+	s3Internal := ctx.GetHeader("X-OPENCSG-S3-Internal")
+	if s3Internal == "true" {
+		ctx.Set("X-OPENCSG-S3-Internal", true)
+	}
+
 	req := &types.GetFileReq{
 		Namespace: namespace,
 		Name:      name,

--- a/builder/deploy/common/deploy_config.go
+++ b/builder/deploy/common/deploy_config.go
@@ -1,0 +1,17 @@
+package common
+
+import "time"
+
+type DeployConfig struct {
+	ImageBuilderURL         string
+	ImageRunnerURL          string
+	MonitorInterval         time.Duration
+	InternalRootDomain      string
+	SpaceDeployTimeoutInMin int
+	ModelDeployTimeoutInMin int
+	ModelDownloadEndpoint   string
+	PublicRootDomain        string
+	SSHDomain               string
+	//download lfs object from internal s3 address
+	S3Internal bool
+}

--- a/builder/deploy/init.go
+++ b/builder/deploy/init.go
@@ -2,8 +2,8 @@ package deploy
 
 import (
 	"fmt"
-	"time"
 
+	"opencsg.com/csghub-server/builder/deploy/common"
 	"opencsg.com/csghub-server/builder/deploy/imagebuilder"
 	"opencsg.com/csghub-server/builder/deploy/imagerunner"
 	"opencsg.com/csghub-server/builder/deploy/scheduler"
@@ -14,7 +14,7 @@ var (
 	defaultDeployer Deployer
 )
 
-func Init(c DeployConfig) error {
+func Init(c common.DeployConfig) error {
 	// ib := imagebuilder.NewLocalBuilder()
 	ib, err := imagebuilder.NewRemoteBuilder(c.ImageBuilderURL)
 	if err != nil {
@@ -25,7 +25,7 @@ func Init(c DeployConfig) error {
 		panic(fmt.Errorf("failed to create image runner:%w", err))
 	}
 
-	fifoScheduler = scheduler.NewFIFOScheduler(ib, ir, c.SpaceDeployTimeoutInMin, c.ModelDeployTimeoutInMin, c.ModelDownloadEndpoint, c.PublicRootDomain)
+	fifoScheduler = scheduler.NewFIFOScheduler(ib, ir, c)
 	deployer, err := newDeployer(fifoScheduler, ib, ir)
 	if err != nil {
 		return fmt.Errorf("failed to create deployer:%w", err)
@@ -38,15 +38,4 @@ func Init(c DeployConfig) error {
 
 func NewDeployer() Deployer {
 	return defaultDeployer
-}
-
-type DeployConfig struct {
-	ImageBuilderURL         string
-	ImageRunnerURL          string
-	MonitorInterval         time.Duration
-	InternalRootDomain      string
-	SpaceDeployTimeoutInMin int
-	ModelDeployTimeoutInMin int
-	ModelDownloadEndpoint   string
-	PublicRootDomain        string
 }

--- a/builder/store/s3/minio.go
+++ b/builder/store/s3/minio.go
@@ -1,16 +1,64 @@
 package s3
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"time"
+
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"opencsg.com/csghub-server/common/config"
 )
 
-func NewMinio(cfg *config.Config) (*minio.Client, error) {
-	return minio.New(cfg.S3.Endpoint, &minio.Options{
+func NewMinio(cfg *config.Config) (*Client, error) {
+	minioClient, err := minio.New(cfg.S3.Endpoint, &minio.Options{
 		Creds:        credentials.NewStaticV4(cfg.S3.AccessKeyID, cfg.S3.AccessKeySecret, ""),
 		Secure:       cfg.S3.EnableSSL,
 		BucketLookup: minio.BucketLookupAuto,
 		Region:       cfg.S3.Region,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init s3 client, error:%w", err)
+	}
+	client := &Client{
+		Client: minioClient,
+	}
+	if len(cfg.S3.InternalEndpoint) > 0 {
+		minioClientInternal, err := minio.New(cfg.S3.InternalEndpoint, &minio.Options{
+			Creds:        credentials.NewStaticV4(cfg.S3.AccessKeyID, cfg.S3.AccessKeySecret, ""),
+			Secure:       cfg.S3.EnableSSL,
+			BucketLookup: minio.BucketLookupAuto,
+			Region:       cfg.S3.Region,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to init s3 internal client, error:%w", err)
+		}
+		client.internalClient = minioClientInternal
+	}
+	return client, nil
+}
+
+type Client struct {
+	*minio.Client
+	internalClient *minio.Client
+}
+
+// PresignedGetObject is a wrapper around minio.Client.PresignedGetObject that adds some extra customization.
+func (c *Client) PresignedGetObject(ctx context.Context, bucketName, objectName string, expires time.Duration, reqParams url.Values) (*url.URL, error) {
+	if c.useInternalClient(ctx) && c.internalClient != nil {
+		slog.Info("use internal s3 client for presigned get object", slog.String("bucket_name", bucketName), slog.String("object_name", objectName))
+		return c.internalClient.PresignedGetObject(ctx, bucketName, objectName, expires, reqParams)
+	}
+	return c.Client.PresignedGetObject(ctx, bucketName, objectName, expires, reqParams)
+}
+
+func (c *Client) useInternalClient(ctx context.Context) bool {
+	v, success := ctx.Value("X-OPENCSG-S3-Internal").(bool)
+	if !success {
+		return false
+	}
+
+	return v
 }

--- a/builder/store/s3/minio_test.go
+++ b/builder/store/s3/minio_test.go
@@ -1,0 +1,24 @@
+package s3
+
+import (
+	"context"
+	"testing"
+)
+
+// test for useInternalClient
+func Test_useInternalClient(t *testing.T) {
+	c := &Client{}
+	ctx := context.Background()
+	if c.useInternalClient(ctx) != false {
+		t.Errorf("should not use internal s3 client if context not defined")
+	}
+	ctxWrongValue := context.WithValue(ctx, "X-OPENCSG-S3-Internal", "test")
+	if c.useInternalClient(ctxWrongValue) != false {
+		t.Errorf("should not use internal s3 client if context value is not 'true'")
+	}
+	ctxWithRightValue := context.WithValue(ctx, "X-OPENCSG-S3-Internal", true)
+	if c.useInternalClient(ctxWithRightValue) != true {
+		t.Errorf("should not use internal s3 client if context value is 'true'")
+	}
+
+}

--- a/cmd/csghub-server/cmd/git/generate_lfs_meta_objects.go
+++ b/cmd/csghub-server/cmd/git/generate_lfs_meta_objects.go
@@ -94,7 +94,7 @@ var generateLfsMetaObjectsCmd = &cobra.Command{
 	},
 }
 
-func fetchAllPointersForRepo(config *config.Config, gitServer gitserver.GitServer, s3Client *minio.Client, lfsMetaObjectStore *database.LfsMetaObjectStore, repo database.Repository) error {
+func fetchAllPointersForRepo(config *config.Config, gitServer gitserver.GitServer, s3Client *s3.Client, lfsMetaObjectStore *database.LfsMetaObjectStore, repo database.Repository) error {
 	namespace := strings.Split(repo.Path, "/")[0]
 	name := strings.Split(repo.Path, "/")[1]
 	ref := repo.DefaultBranch
@@ -124,7 +124,7 @@ func fetchAllPointersForRepo(config *config.Config, gitServer gitserver.GitServe
 	return nil
 }
 
-func checkAndUpdateLfsMetaObjects(config *config.Config, s3Client *minio.Client, lfsMetaObjectStore *database.LfsMetaObjectStore, repo database.Repository, pointer *types.Pointer) {
+func checkAndUpdateLfsMetaObjects(config *config.Config, s3Client *s3.Client, lfsMetaObjectStore *database.LfsMetaObjectStore, repo database.Repository, pointer *types.Pointer) {
 	var exists bool
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()

--- a/cmd/csghub-server/cmd/start/server.go
+++ b/cmd/csghub-server/cmd/start/server.go
@@ -8,6 +8,7 @@ import (
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/api/router"
 	"opencsg.com/csghub-server/builder/deploy"
+	"opencsg.com/csghub-server/builder/deploy/common"
 	"opencsg.com/csghub-server/builder/event"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
@@ -60,7 +61,8 @@ var serverCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("fail to initialize message queue, %w", err)
 		}
-		deploy.Init(deploy.DeployConfig{
+		s3Internal := len(cfg.S3.InternalEndpoint) > 0
+		deploy.Init(common.DeployConfig{
 			ImageBuilderURL:         cfg.Space.BuilderEndpoint,
 			ImageRunnerURL:          cfg.Space.RunnerEndpoint,
 			MonitorInterval:         10 * time.Second,
@@ -69,6 +71,7 @@ var serverCmd = &cobra.Command{
 			ModelDeployTimeoutInMin: cfg.Model.DeployTimeoutInMin,
 			ModelDownloadEndpoint:   cfg.Model.DownloadEndpoint,
 			PublicRootDomain:        cfg.Space.PublicRootDomain,
+			S3Internal:              s3Internal,
 		})
 		r, err := router.NewRouter(cfg, enableSwagger)
 		if err != nil {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -79,9 +79,11 @@ type Config struct {
 		AccessKeyID     string `envconfig:"STARHUB_SERVER_S3_ACCESS_KEY_ID"`
 		AccessKeySecret string `envconfig:"STARHUB_SERVER_S3_ACCESS_KEY_SECRET"`
 		Region          string `envconfig:"STARHUB_SERVER_S3_REGION"`
-		Endpoint        string `envconfig:"STARHUB_SERVER_S3_ENDPOINT" default:"oss-cn-beijing.aliyuncs.com"`
-		Bucket          string `envconfig:"STARHUB_SERVER_S3_BUCKET" default:"opencsg-test"`
-		EnableSSL       bool   `envconfig:"STARHUB_SERVER_S3_ENABLE_SSL" default:"false"`
+		Endpoint        string `envconfig:"STARHUB_SERVER_S3_ENDPOINT" default:"localhost:9000"`
+		//for better performance of LFS downloading from s3. (can ignore if S3.Endpoint is alreay an internal domain or ip address)
+		InternalEndpoint string `envconfig:"STARHUB_SERVER_S3_INTERNAL_ENDPOINT" default:"localhost:9000"`
+		Bucket           string `envconfig:"STARHUB_SERVER_S3_BUCKET" default:"opencsg-test"`
+		EnableSSL        bool   `envconfig:"STARHUB_SERVER_S3_ENABLE_SSL" default:"false"`
 	}
 
 	SensitiveCheck struct {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -81,7 +81,7 @@ type Config struct {
 		Region          string `envconfig:"STARHUB_SERVER_S3_REGION"`
 		Endpoint        string `envconfig:"STARHUB_SERVER_S3_ENDPOINT" default:"localhost:9000"`
 		//for better performance of LFS downloading from s3. (can ignore if S3.Endpoint is alreay an internal domain or ip address)
-		InternalEndpoint string `envconfig:"STARHUB_SERVER_S3_INTERNAL_ENDPOINT" default:"localhost:9000"`
+		InternalEndpoint string `envconfig:"STARHUB_SERVER_S3_INTERNAL_ENDPOINT" default:""`
 		Bucket           string `envconfig:"STARHUB_SERVER_S3_BUCKET" default:"opencsg-test"`
 		EnableSSL        bool   `envconfig:"STARHUB_SERVER_S3_ENABLE_SSL" default:"false"`
 	}

--- a/component/git_http.go
+++ b/component/git_http.go
@@ -28,7 +28,7 @@ import (
 type GitHTTPComponent struct {
 	git                gitserver.GitServer
 	config             *config.Config
-	s3Client           *minio.Client
+	s3Client           *s3.Client
 	lfsMetaObjectStore *database.LfsMetaObjectStore
 	lfsLockStore       *database.LfsLockStore
 	repo               *database.RepoStore
@@ -719,4 +719,3 @@ func buildLFSLockList(lfsLocks []database.LfsLock) *types.LFSLockList {
 		Locks: locks,
 	}
 }
-

--- a/component/mirror.go
+++ b/component/mirror.go
@@ -27,7 +27,7 @@ type MirrorComponent struct {
 	saas               bool
 	repoComp           *RepoComponent
 	git                gitserver.GitServer
-	s3Client           *minio.Client
+	s3Client           *s3.Client
 	lfsBucket          string
 	modelStore         *database.ModelStore
 	datasetStore       *database.DatasetStore

--- a/component/repo.go
+++ b/component/repo.go
@@ -50,7 +50,7 @@ type RepoComponent struct {
 	rel                *database.RepoRelationsStore
 	mirror             *database.MirrorStore
 	git                gitserver.GitServer
-	s3Client           *minio.Client
+	s3Client           *s3.Client
 	userSvcClient      rpc.UserSvcClient
 	lfsBucket          string
 	uls                *database.UserLikesStore

--- a/mirror/lfssyncer/minio.go
+++ b/mirror/lfssyncer/minio.go
@@ -26,7 +26,7 @@ type MinioLFSSyncWorker struct {
 	mirrorStore        *database.MirrorStore
 	repoStore          *database.RepoStore
 	lfsMetaObjectStore *database.LfsMetaObjectStore
-	s3Client           *minio.Client
+	s3Client           *s3.Client
 	config             *config.Config
 	numWorkers         int
 }


### PR DESCRIPTION
a new ENV `STARHUB_SERVER_S3_INTERNAL_ENDPOINT` for service `csghub_server` which defines the internal ip address of s3 storage (like minio).

If request from client like `csghub-sdk` has http header `X-OPENCSG-S3-Internal`, csghub-server will return presigned url with internal `s3` ip, to avoid download `LFS` object through public network.