### PR TITLE
Fix swagger API url bug

### DIFF
--- a/cmd/csghub-server/cmd/start/server.go
+++ b/cmd/csghub-server/cmd/start/server.go
@@ -2,6 +2,7 @@ package start
 
 import (
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -40,10 +41,14 @@ var serverCmd = &cobra.Command{
 			//	@in                         header
 			//	@name                       Authorization
 			//	@description                Bearer token
+			publicDomain, err := url.Parse(cfg.APIServer.PublicDomain)
+			if err != nil {
+				return fmt.Errorf("failed to parse api server public domain: %v", err)
+			}
 			docs.SwaggerInfo.Title = "CSGHub Server API"
 			docs.SwaggerInfo.Description = "CSGHub Server API."
 			docs.SwaggerInfo.Version = "1.0"
-			docs.SwaggerInfo.Host = cfg.APIServer.PublicDomain
+			docs.SwaggerInfo.Host = publicDomain.Host
 			docs.SwaggerInfo.BasePath = "/api/v1"
 			docs.SwaggerInfo.Schemes = []string{"http", "https"}
 		}


### PR DESCRIPTION
- Fix the swagger url has repeat `https://` prefix bug