### PR TITLE
[DO NOT MERGE] GetRepoFileTreeV2

### DIFF
--- a/builder/git/gitserver/gitaly/file_test.go
+++ b/builder/git/gitserver/gitaly/file_test.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	// The context timeout is 5 second,
-	// 200 should be a reasonable number. Can cnage there value
-	// based on gitaly performance.
+	// The context timeout is set to 5 seconds.
+	// A value of 200 should be reasonable, but it can be adjusted
+	// based on Gitaly performance.
 	SHOW_COMMIT_FILE_COUNT_LIMIT = 200
 	GET_REPO_FILE_TREE_TIMEOUT   = 5 * time.Second
 )

--- a/builder/git/gitserver/gitaly/file_test.go
+++ b/builder/git/gitserver/gitaly/file_test.go
@@ -1,0 +1,266 @@
+package gitaly
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	gitalyclient "gitlab.com/gitlab-org/gitaly/v16/client"
+	"gitlab.com/gitlab-org/gitaly/v16/proto/go/gitalypb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"opencsg.com/csghub-server/builder/git/gitserver"
+	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/types"
+)
+
+func (c *Client) GetRepoFileTreeV2(ctx context.Context, req gitserver.GetRepoInfoByPathReq) ([]*types.File, bool, error) {
+
+	withCommit := false
+	repository := &gitalypb.Repository{
+		StorageName:  c.config.GitalyServer.Storge,
+		RelativePath: "dronescapes/.git",
+	}
+	if !req.File {
+		req.Path = req.Path + "/"
+	}
+
+	if req.Ref == "" {
+		req.Ref = "main"
+	}
+
+	// first get the last commit for tree,
+	// this will be the snapshot because we will call gitaly API
+	// 3 times and repo might change duraing 3 calls if use
+	// something like main as the ref.
+	resp, err := c.commitClient.LastCommitForPath(ctx, &gitalypb.LastCommitForPathRequest{
+		Repository: repository,
+		Revision:   []byte(req.Ref),
+	})
+	if err != nil {
+		return nil, withCommit, err
+	}
+	req.Ref = resp.Commit.Id
+
+	var files []*types.File
+	ctx, cancel := context.WithTimeout(ctx, time.Second*3)
+	defer cancel()
+
+	// get all files first
+	entryStream, err := c.commitClient.GetTreeEntries(ctx, &gitalypb.GetTreeEntriesRequest{
+		Repository: repository,
+		Revision:   []byte(req.Ref),
+		Path:       []byte(req.Path),
+		PaginationParams: &gitalypb.PaginationParameter{
+			Limit: 1000,
+		},
+	})
+	if err != nil {
+		return nil, withCommit, err
+	}
+	pathFileMap := map[string]*types.File{}
+	var revisionPaths []*gitalypb.GetBlobsRequest_RevisionPath
+	for {
+		resp, err := entryStream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+		}
+		if len(resp.Entries) > 0 {
+			for _, entry := range resp.Entries {
+				var fileType string
+				if entry.Type == gitalypb.TreeEntry_BLOB {
+					fileType = "file"
+				} else {
+					fileType = "dir"
+				}
+				file := &types.File{
+					Name: filepath.Base(string(entry.Path)),
+					Type: fileType,
+					Path: string(entry.Path),
+					Mode: strconv.Itoa(int(entry.Mode)),
+				}
+				files = append(files, file)
+				pathFileMap[file.Path] = file
+				revisionPaths = append(revisionPaths, &gitalypb.GetBlobsRequest_RevisionPath{
+					Revision: req.Ref,
+					Path:     entry.Path,
+				})
+			}
+
+		}
+	}
+
+	if len(files) <= 1000 {
+		// Get last commit for tree. Even though this is a
+		// streaming request, gitaly actually first retrive all commits
+		// then start sending, which means when first item received from stram,
+		// all data are already prepared.
+		req := &gitalypb.ListLastCommitsForTreeRequest{
+			Repository: repository,
+			Revision:   req.Ref,
+			Path:       []byte(req.Path),
+			Limit:      1000,
+		}
+
+		commitStream, err := c.commitClient.ListLastCommitsForTree(ctx, req)
+		if err != nil {
+			return nil, withCommit, err
+		}
+		wc := 0
+		for {
+			commitResp, err := commitStream.Recv()
+			if err != nil {
+				if err == io.EOF {
+					withCommit = true
+					fmt.Println("==== total wc", wc)
+					break
+				}
+			}
+			if commitResp == nil {
+				return nil, withCommit, errors.New("bad request")
+			}
+			wc++
+			commits := commitResp.Commits
+			fmt.Println("rcc", len(commits))
+			if len(commits) > 0 {
+				for _, r := range commits {
+					f, ok := pathFileMap[string(r.PathBytes)]
+					if ok {
+						commit := r.Commit
+						f.Commit = types.Commit{
+							ID:             commit.Id,
+							CommitterName:  string(commit.Committer.Name),
+							CommitterEmail: string(commit.Committer.Email),
+							CommitterDate:  commit.Committer.Date.AsTime().Format(time.RFC3339),
+							CreatedAt:      commit.Committer.Date.AsTime().Format(time.RFC3339),
+							Message:        string(commit.Subject),
+							AuthorName:     string(commit.Author.Name),
+							AuthorEmail:    string(commit.Author.Email),
+							AuthoredDate:   commit.Author.Date.AsTime().Format(time.RFC3339),
+						}
+						f.LastCommitSHA = commit.Id
+					}
+				}
+			}
+		}
+	}
+
+	listBlobsReq := &gitalypb.GetBlobsRequest{
+		Repository:    repository,
+		RevisionPaths: revisionPaths,
+		Limit:         1024,
+	}
+
+	// Get blobs with file size
+	listBlobsStream, err := c.blobClient.GetBlobs(ctx, listBlobsReq)
+	if err != nil {
+		return nil, withCommit, err
+	}
+	for {
+		listBlobResp, err := listBlobsStream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, withCommit, err
+		}
+		if listBlobResp != nil {
+			var (
+				fileSize        int64
+				isLfs           bool
+				lfsPointerSize  int
+				LfsRelativePath string
+			)
+			fileSize = listBlobResp.Size
+			if listBlobResp.Size <= 1024 {
+				p, _ := ReadPointerFromBuffer(listBlobResp.Data)
+				if p.Valid() {
+					fileSize = p.Size
+					isLfs = true
+					LfsRelativePath = p.RelativePath()
+					lfsPointerSize = int(listBlobResp.Size)
+				}
+			}
+
+			f, ok := pathFileMap[string(listBlobResp.Path)]
+			if ok {
+
+				f.Size = fileSize
+				f.Lfs = isLfs
+				f.LfsPointerSize = lfsPointerSize
+				f.LfsRelativePath = LfsRelativePath
+				f.SHA = listBlobResp.Oid
+			}
+		}
+	}
+
+	return files, withCommit, nil
+}
+
+func newTestClient() (*Client, error) {
+	var sidechannelRegistry *gitalyclient.SidechannelRegistry
+	accessLogger := log.New()
+	accessLogger.SetLevel(log.InfoLevel)
+	sidechannelRegistry = gitalyclient.NewSidechannelRegistry(log.NewEntry(accessLogger))
+	connOpts := append(gitalyclient.DefaultDialOpts,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		gitalyclient.WithGitalyDNSResolver(gitalyclient.DefaultDNSResolverBuilderConfig()),
+	)
+
+	conn, connErr := gitalyclient.DialSidechannel(context.Background(), "tcp://127.0.0.1:3297", sidechannelRegistry, connOpts)
+	repoClient := gitalypb.NewRepositoryServiceClient(conn)
+	commitClient := gitalypb.NewCommitServiceClient(conn)
+	blobClient := gitalypb.NewBlobServiceClient(conn)
+	refClient := gitalypb.NewRefServiceClient(conn)
+	diffClient := gitalypb.NewDiffServiceClient(conn)
+	operationClient := gitalypb.NewOperationServiceClient(conn)
+	smartHttpClient := gitalypb.NewSmartHTTPServiceClient(conn)
+	remoteClient := gitalypb.NewRemoteServiceClient(conn)
+
+	if connErr != nil {
+		return nil, connErr
+	}
+
+	config := &config.Config{}
+	config.GitalyServer.Storge = "default"
+
+	return &Client{
+		config:              config,
+		sidechannelRegistry: sidechannelRegistry,
+		repoClient:          repoClient,
+		commitClient:        commitClient,
+		blobClient:          blobClient,
+		refClient:           refClient,
+		diffClient:          diffClient,
+		operationClient:     operationClient,
+		smartHttpClient:     smartHttpClient,
+		remoteClient:        remoteClient,
+	}, nil
+}
+
+func TestFileTree(t *testing.T) {
+	client, err := newTestClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := client.GetRepoFileTree(context.TODO(), gitserver.GetRepoInfoByPathReq{
+		Namespace: "",
+		Name:      "dronescapes",
+		Ref:       "main",
+		Path:      "data/semisupervised_set/depth_dpt/part0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println("fetch all commits success")
+	fmt.Println(len(files))
+	t.FailNow()
+}


### PR DESCRIPTION
**The Problem**  
Crash occurs when visiting this page: [Dronescapes Depth Data](https://opencsg.com/datasets/AIWizards/dronescapes/files/main/data/semisupervised_set/depth_dpt/part0).

**The Cause**  
The API call at this endpoint returns a 500 error:  
[API Call](https://hub.opencsg.com/api/v1/datasets/AIWizards/dronescapes/tree?path=data/semisupervised_set/depth_dpt/part0&ref=main).  
This API utilizes the `GetRepoFileTree` method, which is slow when there are many files in the specified path. Specifically, `GetRepoFileTree` internally calls two Gitaly APIs. The first, `ListLastCommitsForTree`, retrieves the latest commit for each file, while the second, `GetBlobs`, fetches blob sizes for each file. 

The `ListLastCommitsForTree` method is notably slow when processing 1000 files, taking around 15 seconds, while the timeout is set to 3 seconds. This leads to a 500 error and causes the page to crash. The slowdown is due to this code:  
[Relevant Code](https://gitlab.com/gitlab-org/gitaly/-/blob/master/internal/gitaly/service/commit/list_last_commits_for_tree.go?ref_type=heads#L70), which processes entries one by one and calls the `git log` command for each file. Consequently, for 1000 files, this results in 1000 OS exec calls, which is costly and inefficient. On my Mac, retrieving the latest commit for a single file with `git log` takes about 0.03 seconds.

**The Solution**  
To improve performance, we can look at how GitHub handles similar situations. For example, in this [repository](https://github.com/S2-group/mobilesoft-2020-iam-replication-package/tree/master/dataset/Top%20APKs%20Java%20Files), GitHub displays file names without showing commit details and includes a warning banner at the top. I believe adopting a similar approach would be beneficial, which involves:
1. First calling the API to retrieve file names.
2. Then calling another API to get commit information for those files.

**What This PR Does**  
**This is a draft PR for demonstration purposes only.** It introduces a new method, `GetRepoFileTreeV2`, which operates as follows:
- Retrieves tree files using the Gitaly `GetTreeEntries` API. This provides file paths, but not commit or size information.
- If the file count is below a specified threshold, it calls the `ListLastCommitsForTree` API to obtain commit data. Note that even if the count is below the threshold, timeouts can still result in missing commit information.
- Calls the Gitaly `GetBlobs` API to get file sizes.

This method returns three values instead of two: the first and last parameters are the same as in the old method, while the middle parameter indicates whether commit information is fully updated. Although this could be split into two separate APIs, I kept everything together for demonstration.

Also ran some simple tests locally and all passed:
```
=== RUN   TestFileTree
=== RUN   TestFileTree/main:
=== RUN   TestFileTree/main:dronescapes_reader
=== RUN   TestFileTree/450f959b4e29efaad2d9e0ef90330dd80201f8bb:
=== RUN   TestFileTree/450f959b4e29efaad2d9e0ef90330dd80201f8bb:dronescapes_reader
=== RUN   TestFileTree/large
--- PASS: TestFileTree (4.73s)
    --- PASS: TestFileTree/main: (0.50s)
    --- PASS: TestFileTree/main:dronescapes_reader (0.27s)
    --- PASS: TestFileTree/450f959b4e29efaad2d9e0ef90330dd80201f8bb: (0.45s)
    --- PASS: TestFileTree/450f959b4e29efaad2d9e0ef90330dd80201f8bb:dronescapes_reader (0.26s)
    --- PASS: TestFileTree/large (3.24s)
```

**Further Improvements**  
The Gitaly `listLastCommitsForTree` method could be enhanced by retrieving file commits in parallel, though this may not scale linearly. A simple test showed that using 10 goroutines reduced the time from 15 seconds to 9 seconds. However, since the number of files in a directory can vary unpredictably, the overall benefit of this improvement may be limited.

Another potential solution is to use pagination for the file listing page, but seems no one is doing this way.