### PR TITLE
Update repository sync status in repo syncer and lfs syncer

### DIFF
--- a/mirror/reposyncer/local_woker.go
+++ b/mirror/reposyncer/local_woker.go
@@ -170,7 +170,7 @@ func (w *LocalMirrorWoker) SyncRepo(ctx context.Context, task queue.MirrorTask) 
 		if err != nil {
 			return fmt.Errorf("failed to update mirror and repository: %w", err)
 		}
-		return fmt.Errorf("failed to sync lfs files: %v", err)
+		return fmt.Errorf("failed to generate lfs meta objects: %v", err)
 	}
 	if lfsFileCount > 0 {
 		mirror.Status = types.MirrorRepoSynced
@@ -182,9 +182,15 @@ func (w *LocalMirrorWoker) SyncRepo(ctx context.Context, task queue.MirrorTask) 
 		})
 	} else {
 		mirror.Status = types.MirrorFinished
+		mirror.Repository.SyncStatus = types.SyncStatusCompleted
+		_, err = w.repoStore.UpdateRepo(ctx, *mirror.Repository)
+		if err != nil {
+			return fmt.Errorf("failed to update repo sync status to completed: %w", err)
+		}
 	}
 	// Update mirror last updated at
 	mirror.LastUpdatedAt = time.Now()
+
 	err = w.mirrorStore.Update(ctx, mirror)
 	if err != nil {
 		return fmt.Errorf("failed to update mirror: %w", err)


### PR DESCRIPTION
- Update repository sync status in repo syncer  and lfs syncer

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request updates the repository and LFS (Large File Storage) synchronization status in both the repo syncer and LFS syncer components. Key changes include:

1. Adjustments in `MinioLFSSyncWorker` to handle LFS synchronization, including error handling improvements and ensuring the repository sync status is updated upon completion.
2. Modifications in `LocalMirrorWoker` to enhance the synchronization process, specifically updating the repository sync status to completed once the mirror status is set to finished.
3. Error messages have been refined to provide clearer insights into the nature of the failures during the sync processes.

These updates aim to improve the reliability and clarity of the synchronization status reporting within the system.

<!-- @codegpt description end -->