### PR TITLE
Fix last commit API with empty repository

### DIFF
--- a/builder/git/gitserver/gitaly/commit.go
+++ b/builder/git/gitserver/gitaly/commit.go
@@ -96,7 +96,7 @@ func (c *Client) GetRepoLastCommit(ctx context.Context, req gitserver.GetRepoLas
 	if err != nil {
 		return nil, err
 	}
-	if resp != nil {
+	if resp != nil && resp.Commit != nil {
 		commit = types.Commit{
 			ID:             string(resp.Commit.Id),
 			CommitterName:  string(resp.Commit.Committer.Name),

--- a/component/model.go
+++ b/component/model.go
@@ -484,7 +484,7 @@ func (c *ModelComponent) SDKModelInfo(ctx context.Context, namespace, name, ref,
 		return nil, ErrUnauthorized
 	}
 
-	var pipelineTag, libraryTag string
+	var pipelineTag, libraryTag, sha string
 	var tags []string
 	for _, tag := range model.Repository.Tags {
 		tags = append(tags, tag.Name)
@@ -528,10 +528,14 @@ func (c *ModelComponent) SDKModelInfo(ctx context.Context, namespace, name, ref,
 		spaceNames[idx] = s.Name
 	}
 
+	if lastCommit != nil {
+		sha = lastCommit.ID
+	}
+
 	resModel := &types.SDKModelInfo{
 		ID:               model.Repository.Path,
 		Author:           model.Repository.User.Username,
-		Sha:              lastCommit.ID,
+		Sha:              sha,
 		CreatedAt:        model.Repository.CreatedAt,
 		LastModified:     model.Repository.UpdatedAt,
 		Private:          model.Repository.Private,


### PR DESCRIPTION
Related to issue https://github.com/OpenCSGs/csghub/issues/768

- Fix the bug that call the `last_commit` API in an empty repository will case a panic.

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request addresses a bug related to the `last_commit` API call on an empty repository, which previously caused a panic. The fix involves ensuring the API handles empty repositories gracefully without crashing. Key updates include:

1. Modified the `GetRepoLastCommit` function in `commit.go` to check if the response and the commit object are not nil before proceeding.
2. Updated the `SDKModelInfo` function in `model.go` to handle cases where the last commit might be nil, preventing potential null pointer exceptions by introducing a check before assigning the commit ID.

<!-- @codegpt description end -->