### PR TITLE
Fix the bug that only can call mirror/repos with API key

### DIFF
--- a/api/router/api.go
+++ b/api/router/api.go
@@ -256,7 +256,6 @@ func NewRouter(config *config.Config, enableSwagger bool) (*gin.Engine, error) {
 
 	apiGroup.GET("/mirrors", mirrorHandler.Index)
 	mirror := apiGroup.Group("/mirror")
-	mirror.Use(needAPIKey)
 	{
 		mirror.GET("/sources", msHandler.Index)
 		mirror.POST("/sources", msHandler.Create)


### PR DESCRIPTION
- Fix the bug that only can call mirror/repos with API key

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request fixes a bug that restricted API calls to `mirror/repos` to those with an API key. The key change involves removing the API key requirement for accessing mirror sources within the API router configuration. This adjustment allows for broader access to mirror sources without the necessity of an API key.

Key updates:
1. Removed the API key middleware from the mirror routes, enabling unrestricted access to mirror sources.

<!-- @codegpt description end -->