### PR TITLE
add org prompts list

### DIFF
--- a/api/router/api.go
+++ b/api/router/api.go
@@ -210,6 +210,7 @@ func NewRouter(config *config.Config, enableSwagger bool) (*gin.Engine, error) {
 		apiGroup.GET("/organization/:namespace/codes", orgHandler.Codes)
 		apiGroup.GET("/organization/:namespace/spaces", orgHandler.Spaces)
 		apiGroup.GET("/organization/:namespace/collections", orgHandler.Collections)
+		apiGroup.GET("/organization/:namespace/prompts", orgHandler.Prompts)
 	}
 
 	{

--- a/builder/git/membership/role.go
+++ b/builder/git/membership/role.go
@@ -3,14 +3,14 @@ package membership
 type Role string
 
 const (
-	RoleUnkown Role = ""
-	RoleRead   Role = "read"
-	RoleWrite  Role = "write"
-	RoleAdmin  Role = "admin"
+	RoleUnknown Role = ""
+	RoleRead    Role = "read"
+	RoleWrite   Role = "write"
+	RoleAdmin   Role = "admin"
 )
 
 func (r Role) CanRead() bool {
-	return r != RoleUnkown
+	return r != RoleUnknown
 }
 
 func (r Role) CanWrite() bool {

--- a/builder/rpc/user_svc_client.go
+++ b/builder/rpc/user_svc_client.go
@@ -30,15 +30,15 @@ func (c *UserSvcHttpClient) GetMemberRole(ctx context.Context, orgName, userName
 	// write code to call user service api "/api/v1/organization/{orgName}/members/{userName}"
 	url := fmt.Sprintf("/api/v1/organization/%s/members/%s?current_user=%s", orgName, userName, userName)
 	var r httpbase.R
-	r.Data = membership.RoleUnkown
+	r.Data = membership.RoleUnknown
 	err := c.hc.Get(ctx, url, &r)
 	if err != nil {
-		return membership.RoleUnkown, fmt.Errorf("failed to get member role: %w", err)
+		return membership.RoleUnknown, fmt.Errorf("failed to get member role: %w", err)
 	}
 
 	role, ok := r.Data.(string)
 	if !ok {
-		return membership.RoleUnkown, fmt.Errorf("failed to convert r.Data '%v' to membership.Role", r.Data)
+		return membership.RoleUnknown, fmt.Errorf("failed to convert r.Data '%v' to membership.Role", r.Data)
 	}
 	return membership.Role(role), nil
 }

--- a/common/types/organization.go
+++ b/common/types/organization.go
@@ -107,6 +107,7 @@ type (
 	OrgCodesReq       = OrgDatasetsReq
 	OrgSpacesReq      = OrgDatasetsReq
 	OrgCollectionsReq = OrgDatasetsReq
+	OrgPromptsReq     = OrgDatasetsReq
 )
 
 type Organization struct {

--- a/component/code.go
+++ b/component/code.go
@@ -366,7 +366,7 @@ func (c *CodeComponent) getRelations(ctx context.Context, repoID int64, currentU
 func (c *CodeComponent) OrgCodes(ctx context.Context, req *types.OrgCodesReq) ([]types.Code, int, error) {
 	var resCodes []types.Code
 	var err error
-	r := membership.RoleUnkown
+	r := membership.RoleUnknown
 	if req.CurrentUser != "" {
 		r, err = c.userSvcClient.GetMemberRole(ctx, req.Namespace, req.CurrentUser)
 		// log error, and treat user as unkown role in org

--- a/component/collection.go
+++ b/component/collection.go
@@ -266,7 +266,7 @@ func (cc *CollectionComponent) getUserCollectionPermission(ctx context.Context, 
 
 func (c *CollectionComponent) OrgCollections(ctx context.Context, req *types.OrgCollectionsReq) ([]types.Collection, int, error) {
 	var err error
-	r := membership.RoleUnkown
+	r := membership.RoleUnknown
 	if req.CurrentUser != "" {
 		r, err = c.userSvcClient.GetMemberRole(ctx, req.Namespace, req.CurrentUser)
 		// log error, and treat user as unkown role in org

--- a/component/dataset.go
+++ b/component/dataset.go
@@ -486,7 +486,7 @@ func (c *DatasetComponent) getRelations(ctx context.Context, repoID int64, curre
 func (c *DatasetComponent) OrgDatasets(ctx context.Context, req *types.OrgDatasetsReq) ([]types.Dataset, int, error) {
 	var resDatasets []types.Dataset
 	var err error
-	r := membership.RoleUnkown
+	r := membership.RoleUnknown
 	if req.CurrentUser != "" {
 		r, err = c.userSvcClient.GetMemberRole(ctx, req.Namespace, req.CurrentUser)
 		// log error, and treat user as unkown role in org

--- a/component/model.go
+++ b/component/model.go
@@ -1104,7 +1104,7 @@ func (c *ModelComponent) ListModelsOfRuntimeFrameworks(ctx context.Context, curr
 func (c *ModelComponent) OrgModels(ctx context.Context, req *types.OrgModelsReq) ([]types.Model, int, error) {
 	var resModels []types.Model
 	var err error
-	r := membership.RoleUnkown
+	r := membership.RoleUnknown
 	if req.CurrentUser != "" {
 		r, err = c.userSvcClient.GetMemberRole(ctx, req.Namespace, req.CurrentUser)
 		// log error, and treat user as unkown role in org

--- a/component/space.go
+++ b/component/space.go
@@ -382,7 +382,7 @@ func (c *SpaceComponent) Index(ctx context.Context, filter *types.RepoFilter, pe
 func (c *SpaceComponent) OrgSpaces(ctx context.Context, req *types.OrgSpacesReq) ([]types.Space, int, error) {
 	var resSpaces []types.Space
 	var err error
-	r := membership.RoleUnkown
+	r := membership.RoleUnknown
 	if req.CurrentUser != "" {
 		r, err = c.userSvcClient.GetMemberRole(ctx, req.Namespace, req.CurrentUser)
 		// log error, and treat user as unkown role in org

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5998,6 +5998,92 @@ const docTemplate = `{
                 }
             }
         },
+        "/organization/{namespace}/prompts": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKey": []
+                    }
+                ],
+                "description": "get organization prompts",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Organization"
+                ],
+                "summary": "Get organization prompts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "org name",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "current user name",
+                        "name": "current_user",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "page size",
+                        "name": "per",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "current page number",
+                        "name": "page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/types.ResponseWithTotal"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/types.PromptRes"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIBadRequest"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIInternalServerError"
+                        }
+                    }
+                }
+            }
+        },
         "/organization/{namespace}/spaces": {
             "get": {
                 "security": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5987,6 +5987,92 @@
                 }
             }
         },
+        "/organization/{namespace}/prompts": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKey": []
+                    }
+                ],
+                "description": "get organization prompts",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Organization"
+                ],
+                "summary": "Get organization prompts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "org name",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "current user name",
+                        "name": "current_user",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "page size",
+                        "name": "per",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "current page number",
+                        "name": "page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/types.ResponseWithTotal"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/types.PromptRes"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIBadRequest"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIInternalServerError"
+                        }
+                    }
+                }
+            }
+        },
         "/organization/{namespace}/spaces": {
             "get": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -7844,6 +7844,59 @@ paths:
       summary: Get organization models
       tags:
       - Organization
+  /organization/{namespace}/prompts:
+    get:
+      consumes:
+      - application/json
+      description: get organization prompts
+      parameters:
+      - description: org name
+        in: path
+        name: namespace
+        required: true
+        type: string
+      - description: current user name
+        in: query
+        name: current_user
+        required: true
+        type: string
+      - description: page size
+        in: query
+        name: per
+        type: integer
+      - description: current page number
+        in: query
+        name: page
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/types.ResponseWithTotal'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/types.PromptRes'
+                  type: array
+                total:
+                  type: integer
+              type: object
+        "400":
+          description: Bad request
+          schema:
+            $ref: '#/definitions/types.APIBadRequest'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/types.APIInternalServerError'
+      security:
+      - ApiKey: []
+      summary: Get organization prompts
+      tags:
+      - Organization
   /organization/{namespace}/spaces:
     get:
       consumes:

--- a/user/component/member.go
+++ b/user/component/member.go
@@ -136,18 +136,18 @@ func (c *MemberComponent) GetMemberRole(ctx context.Context, orgName, userName s
 	)
 	org, err = c.orgStore.FindByPath(ctx, orgName)
 	if err != nil {
-		return membership.RoleUnkown, fmt.Errorf("failed to find org,caused by:%w", err)
+		return membership.RoleUnknown, fmt.Errorf("failed to find org,caused by:%w", err)
 	}
 	user, err = c.userStore.FindByUsername(ctx, userName)
 	if err != nil {
-		return membership.RoleUnkown, fmt.Errorf("failed to find user,caused by:%w", err)
+		return membership.RoleUnknown, fmt.Errorf("failed to find user,caused by:%w", err)
 	}
 	m, err := c.memberStore.Find(ctx, org.ID, user.ID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return membership.RoleUnkown, fmt.Errorf("failed to check memberhsip existance,caused by:%w", err)
+		return membership.RoleUnknown, fmt.Errorf("failed to check memberhsip existance,caused by:%w", err)
 	}
 	if m == nil {
-		return membership.RoleUnkown, nil
+		return membership.RoleUnknown, nil
 	}
 	return c.toGitRole(m.Role), nil
 }
@@ -272,6 +272,6 @@ func (c *MemberComponent) toGitRole(role string) membership.Role {
 	case "read":
 		return membership.RoleRead
 	default:
-		return membership.RoleUnkown
+		return membership.RoleUnknown
 	}
 }


### PR DESCRIPTION


<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request adds a new feature to list organization prompts, enhancing the API with endpoints for retrieving prompts associated with an organization. Key updates include:

1. Implemented a new endpoint `/organization/{namespace}/prompts` for fetching organization prompts, including security, parameters, and response details in Swagger documentation.
2. Added functionality in various components (`PromptComponent`, `OrganizationHandler`, etc.) to support fetching and handling organization prompts.
3. Corrected typos in role names from "RoleUnkown" to "RoleUnknown" across multiple files to ensure consistency and correct behavior.
4. Updated Swagger documentation to reflect the new API endpoint changes.

<!-- @codegpt description end -->