### PR TITLE
Fix common/utils/common/repo_test.go

### DIFF
--- a/common/utils/common/repo_test.go
+++ b/common/utils/common/repo_test.go
@@ -130,9 +130,9 @@ func TestBuildCloneInfo(t *testing.T) {
 			args: args{
 				config: &config.Config{
 					APIServer: struct {
-						Port         int    `envconfig:"STARHUB_SERVER_SERVER_PORT" default:"8080"`
-						PublicDomain string `envconfig:"STARHUB_SERVER_PUBLIC_DOMAIN" default:"http://localhost:8080"`
-						SSHDomain    string `envconfig:"STARHUB_SERVER_SSH_DOMAIN" default:"ssh://git@localhost:2222"`
+						Port         int    `env:"STARHUB_SERVER_SERVER_PORT, default=8080"`
+						PublicDomain string `env:"STARHUB_SERVER_PUBLIC_DOMAIN, default=http://localhost:8080"`
+						SSHDomain    string `env:"STARHUB_SERVER_SSH_DOMAIN, default=git@localhost:2222"`
 					}{
 						Port:         8080,
 						PublicDomain: "https://opencsg.com",
@@ -154,9 +154,9 @@ func TestBuildCloneInfo(t *testing.T) {
 			args: args{
 				config: &config.Config{
 					APIServer: struct {
-						Port         int    `envconfig:"STARHUB_SERVER_SERVER_PORT" default:"8080"`
-						PublicDomain string `envconfig:"STARHUB_SERVER_PUBLIC_DOMAIN" default:"http://localhost:8080"`
-						SSHDomain    string `envconfig:"STARHUB_SERVER_SSH_DOMAIN" default:"ssh://git@localhost:2222"`
+						Port         int    `env:"STARHUB_SERVER_SERVER_PORT, default=8080"`
+						PublicDomain string `env:"STARHUB_SERVER_PUBLIC_DOMAIN, default=http://localhost:8080"`
+						SSHDomain    string `env:"STARHUB_SERVER_SSH_DOMAIN, default=git@localhost:2222"`
 					}{
 						Port:         8080,
 						PublicDomain: "https://opencsg.com",


### PR DESCRIPTION
- Fix the test file ` common/utils/common/repo_test.go`

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR addresses a test file `common/utils/common/repo_test.go` by updating environment variable configurations within test functions. Key updates include:
1. Changing environment variable annotations from `envconfig` to `env` for `Port`, `PublicDomain`, and `SSHDomain`.
2. Setting default values directly in the `env` tag for these variables.

This modification simplifies the configuration management in test scenarios, ensuring consistency and clarity in environment variable usage.

<!-- @codegpt description end -->