### PR TITLE
Fix ssh clone url when ssh domain has port

### DIFF
--- a/common/utils/common/repo.go
+++ b/common/utils/common/repo.go
@@ -68,5 +68,10 @@ func buildHTTPCloneURL(domain string, repoType types.RepositoryType, path string
 
 func buildSSHCloneURL(domain string, repoType types.RepositoryType, path string) string {
 	sshDomainWithoutPrefix := strings.TrimPrefix(domain, "ssh://")
-	return fmt.Sprintf("%s:%ss/%s.git", strings.TrimSuffix(sshDomainWithoutPrefix, "/"), repoType, path)
+	hasPort := strings.Contains(sshDomainWithoutPrefix, ":")
+	if hasPort {
+		return fmt.Sprintf("ssh://%s/%ss/%s.git", strings.TrimSuffix(sshDomainWithoutPrefix, "/"), repoType, path)
+	} else {
+		return fmt.Sprintf("%s:%ss/%s.git", strings.TrimSuffix(sshDomainWithoutPrefix, "/"), repoType, path)
+	}
 }

--- a/common/utils/common/repo_test.go
+++ b/common/utils/common/repo_test.go
@@ -173,6 +173,30 @@ func TestBuildCloneInfo(t *testing.T) {
 				SSHCloneURL:  "git@opencsg.com:models/abc/def.git",
 			},
 		},
+		{
+			name: "Test BuildCloneInfo when SSHDomain without ssh:// prefix and port",
+			args: args{
+				config: &config.Config{
+					APIServer: struct {
+						Port         int    `env:"STARHUB_SERVER_SERVER_PORT, default=8080"`
+						PublicDomain string `env:"STARHUB_SERVER_PUBLIC_DOMAIN, default=http://localhost:8080"`
+						SSHDomain    string `env:"STARHUB_SERVER_SSH_DOMAIN, default=git@localhost:2222"`
+					}{
+						Port:         8080,
+						PublicDomain: "https://opencsg.com",
+						SSHDomain:    "ssh://git@opencsg.com:2222",
+					},
+				},
+				repository: &database.Repository{
+					RepositoryType: types.ModelRepo,
+					Path:           "abc/def",
+				},
+			},
+			want: types.Repository{
+				HTTPCloneURL: "https://opencsg.com/models/abc/def.git",
+				SSHCloneURL:  "ssh://git@opencsg.com:2222/models/abc/def.git",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- Fix ssh clone url when ssh domain has port

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

This Merge Request addresses the issue of generating SSH clone URLs when the SSH domain includes a port. It modifies the logic for building SSH clone URLs to correctly handle domains with ports, ensuring the URL format is consistent and correct regardless of whether the domain contains a port. Key updates include:
1. Adjusting the `buildSSHCloneURL` function to check for a port in the SSH domain and format the URL accordingly.
2. Adding a test case to verify the correct SSH clone URL is generated when the SSH domain includes a port.

<!-- @codegpt description end -->