### PR TITLE
Optimize build ssh clone url method

### DIFF
--- a/common/utils/common/repo.go
+++ b/common/utils/common/repo.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"opencsg.com/csghub-server/builder/store/database"
@@ -67,11 +68,15 @@ func buildHTTPCloneURL(domain string, repoType types.RepositoryType, path string
 }
 
 func buildSSHCloneURL(domain string, repoType types.RepositoryType, path string) string {
+	parsedURL, err := url.Parse(domain)
+	if err != nil {
+		return ""
+	}
 	sshDomainWithoutPrefix := strings.TrimPrefix(domain, "ssh://")
-	hasPort := strings.Contains(sshDomainWithoutPrefix, ":")
-	if hasPort {
-		return fmt.Sprintf("ssh://%s/%ss/%s.git", strings.TrimSuffix(sshDomainWithoutPrefix, "/"), repoType, path)
-	} else {
+
+	if parsedURL.Port() == "" {
 		return fmt.Sprintf("%s:%ss/%s.git", strings.TrimSuffix(sshDomainWithoutPrefix, "/"), repoType, path)
+	} else {
+		return fmt.Sprintf("ssh://%s/%ss/%s.git", strings.TrimSuffix(sshDomainWithoutPrefix, "/"), repoType, path)
 	}
 }

--- a/common/utils/common/repo_test.go
+++ b/common/utils/common/repo_test.go
@@ -197,6 +197,30 @@ func TestBuildCloneInfo(t *testing.T) {
 				SSHCloneURL:  "ssh://git@opencsg.com:2222/models/abc/def.git",
 			},
 		},
+		{
+			name: "Test BuildCloneInfo when SSHDomain is IPv6 with ssh:// prefix and port",
+			args: args{
+				config: &config.Config{
+					APIServer: struct {
+						Port         int    `env:"STARHUB_SERVER_SERVER_PORT, default=8080"`
+						PublicDomain string `env:"STARHUB_SERVER_PUBLIC_DOMAIN, default=http://localhost:8080"`
+						SSHDomain    string `env:"STARHUB_SERVER_SSH_DOMAIN, default=git@localhost:2222"`
+					}{
+						Port:         8080,
+						PublicDomain: "https://opencsg.com",
+						SSHDomain:    "ssh://[2001:db8::8a2e:370:7334]:2222",
+					},
+				},
+				repository: &database.Repository{
+					RepositoryType: types.ModelRepo,
+					Path:           "abc/def",
+				},
+			},
+			want: types.Repository{
+				HTTPCloneURL: "https://opencsg.com/models/abc/def.git",
+				SSHCloneURL:  "ssh://[2001:db8::8a2e:370:7334]:2222/models/abc/def.git",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- Optimize build ssh clone url method

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request optimizes the method for building SSH clone URLs in the repository utility code. Key updates include:
1. Added URL parsing to handle different domain formats.
2. Improved logic to construct SSH URLs based on whether the domain includes a port.
3. Removed outdated logic that checked for a port in a less efficient manner.

<!-- @codegpt description end -->