### PR TITLE
Admin access repo permission update

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoStore.go
@@ -1437,9 +1437,9 @@ func (_c *MockRepoStore_ListRepoPublicToUserByRepoIDs_Call) RunAndReturn(run fun
 	return _c
 }
 
-// PublicToUser provides a mock function with given fields: ctx, repoType, userIDs, filter, per, page
-func (_m *MockRepoStore) PublicToUser(ctx context.Context, repoType types.RepositoryType, userIDs []int64, filter *types.RepoFilter, per int, page int) ([]*database.Repository, int, error) {
-	ret := _m.Called(ctx, repoType, userIDs, filter, per, page)
+// PublicToUser provides a mock function with given fields: ctx, repoType, userIDs, filter, per, page, isAdmin
+func (_m *MockRepoStore) PublicToUser(ctx context.Context, repoType types.RepositoryType, userIDs []int64, filter *types.RepoFilter, per int, page int, isAdmin bool) ([]*database.Repository, int, error) {
+	ret := _m.Called(ctx, repoType, userIDs, filter, per, page, isAdmin)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PublicToUser")
@@ -1448,25 +1448,25 @@ func (_m *MockRepoStore) PublicToUser(ctx context.Context, repoType types.Reposi
 	var r0 []*database.Repository
 	var r1 int
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int) ([]*database.Repository, int, error)); ok {
-		return rf(ctx, repoType, userIDs, filter, per, page)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int, bool) ([]*database.Repository, int, error)); ok {
+		return rf(ctx, repoType, userIDs, filter, per, page, isAdmin)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int) []*database.Repository); ok {
-		r0 = rf(ctx, repoType, userIDs, filter, per, page)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int, bool) []*database.Repository); ok {
+		r0 = rf(ctx, repoType, userIDs, filter, per, page, isAdmin)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*database.Repository)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int) int); ok {
-		r1 = rf(ctx, repoType, userIDs, filter, per, page)
+	if rf, ok := ret.Get(1).(func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int, bool) int); ok {
+		r1 = rf(ctx, repoType, userIDs, filter, per, page, isAdmin)
 	} else {
 		r1 = ret.Get(1).(int)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int) error); ok {
-		r2 = rf(ctx, repoType, userIDs, filter, per, page)
+	if rf, ok := ret.Get(2).(func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int, bool) error); ok {
+		r2 = rf(ctx, repoType, userIDs, filter, per, page, isAdmin)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -1486,13 +1486,14 @@ type MockRepoStore_PublicToUser_Call struct {
 //   - filter *types.RepoFilter
 //   - per int
 //   - page int
-func (_e *MockRepoStore_Expecter) PublicToUser(ctx interface{}, repoType interface{}, userIDs interface{}, filter interface{}, per interface{}, page interface{}) *MockRepoStore_PublicToUser_Call {
-	return &MockRepoStore_PublicToUser_Call{Call: _e.mock.On("PublicToUser", ctx, repoType, userIDs, filter, per, page)}
+//   - isAdmin bool
+func (_e *MockRepoStore_Expecter) PublicToUser(ctx interface{}, repoType interface{}, userIDs interface{}, filter interface{}, per interface{}, page interface{}, isAdmin interface{}) *MockRepoStore_PublicToUser_Call {
+	return &MockRepoStore_PublicToUser_Call{Call: _e.mock.On("PublicToUser", ctx, repoType, userIDs, filter, per, page, isAdmin)}
 }
 
-func (_c *MockRepoStore_PublicToUser_Call) Run(run func(ctx context.Context, repoType types.RepositoryType, userIDs []int64, filter *types.RepoFilter, per int, page int)) *MockRepoStore_PublicToUser_Call {
+func (_c *MockRepoStore_PublicToUser_Call) Run(run func(ctx context.Context, repoType types.RepositoryType, userIDs []int64, filter *types.RepoFilter, per int, page int, isAdmin bool)) *MockRepoStore_PublicToUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(types.RepositoryType), args[2].([]int64), args[3].(*types.RepoFilter), args[4].(int), args[5].(int))
+		run(args[0].(context.Context), args[1].(types.RepositoryType), args[2].([]int64), args[3].(*types.RepoFilter), args[4].(int), args[5].(int), args[6].(bool))
 	})
 	return _c
 }
@@ -1502,7 +1503,7 @@ func (_c *MockRepoStore_PublicToUser_Call) Return(repos []*database.Repository, 
 	return _c
 }
 
-func (_c *MockRepoStore_PublicToUser_Call) RunAndReturn(run func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int) ([]*database.Repository, int, error)) *MockRepoStore_PublicToUser_Call {
+func (_c *MockRepoStore_PublicToUser_Call) RunAndReturn(run func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int, bool) ([]*database.Repository, int, error)) *MockRepoStore_PublicToUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/builder/store/database/repository_test.go
+++ b/builder/store/database/repository_test.go
@@ -325,7 +325,7 @@ func TestRepoStore_PublicToUserSimple(t *testing.T) {
 		Sort: "recently_update",
 	}
 	// case 1: one tag
-	repos, _, err := rs.PublicToUser(ctx, repo.RepositoryType, []int64{1}, filter, 20, 1)
+	repos, _, err := rs.PublicToUser(ctx, repo.RepositoryType, []int64{1}, filter, 20, 1, false)
 	require.Nil(t, err)
 	require.NotNil(t, repos)
 
@@ -338,7 +338,7 @@ func TestRepoStore_PublicToUserSimple(t *testing.T) {
 		Sort: "recently_update",
 	}
 	// case 2: two tag
-	repos, _, err = rs.PublicToUser(ctx, repo.RepositoryType, []int64{1}, filter, 20, 1)
+	repos, _, err = rs.PublicToUser(ctx, repo.RepositoryType, []int64{1}, filter, 20, 1, false)
 	require.Nil(t, err)
 	require.NotNil(t, repos)
 }
@@ -444,7 +444,7 @@ func TestRepoStore_PublicToUser(t *testing.T) {
 				Sort:   c.sort,
 				Search: c.search,
 				Source: c.source,
-			}, 10, 1)
+			}, 10, 1, c.admin)
 			require.Nil(t, err)
 			names := []string{}
 			for _, r := range rs {

--- a/builder/store/database/repository_test.go
+++ b/builder/store/database/repository_test.go
@@ -364,7 +364,7 @@ func TestRepoStore_PublicToUser(t *testing.T) {
 		},
 		{
 			admin: true, repoType: types.CodeRepo,
-			expected: []string{"rp1", "rp2", "rp4", "rp5", "rp6"},
+			expected: []string{"rp1", "rp2", "rp3", "rp4", "rp5", "rp6"},
 		},
 		{
 			admin: false, repoType: types.CodeRepo, search: "rp4",

--- a/component/repo.go
+++ b/component/repo.go
@@ -435,7 +435,7 @@ func (c *repoComponentImpl) PublicToUser(ctx context.Context, repoType types.Rep
 
 		isAdmin = dbUser.CanAdmin()
 
-		if !dbUser.CanAdmin() {
+		if !isAdmin {
 			repoOwnerIDs = append(repoOwnerIDs, user.ID)
 			//get user's orgs
 			for _, org := range user.Orgs {

--- a/component/repo.go
+++ b/component/repo.go
@@ -1466,7 +1466,7 @@ func (c *repoComponentImpl) GetUserRepoPermission(ctx context.Context, userName 
 		return &types.UserRepoPermission{CanRead: !repo.Private, CanWrite: false, CanAdmin: false}, nil
 	}
 
-	user, err := c.user.FindByUsername(ctx, userName)
+	user, err := c.userStore.FindByUsername(ctx, userName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find user '%s' when get user repo permission, error: %w", userName, err)
 	}

--- a/component/repo.go
+++ b/component/repo.go
@@ -429,14 +429,13 @@ func (c *repoComponentImpl) PublicToUser(ctx context.Context, repoType types.Rep
 			return nil, 0, fmt.Errorf("failed to get user info, error: %w", err)
 		}
 
-		for _, role := range user.Roles {
-			if role == "admin" || role == "super_user" {
-				isAdmin = true
-				break
-			}
+		dbUser := &database.User{
+			RoleMask: strings.Join(user.Roles, ","),
 		}
 
-		if !isAdmin {
+		isAdmin = dbUser.CanAdmin()
+
+		if !dbUser.CanAdmin() {
 			repoOwnerIDs = append(repoOwnerIDs, user.ID)
 			//get user's orgs
 			for _, org := range user.Orgs {


### PR DESCRIPTION
**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

This Merge Request introduces an enhancement to the repository access control system, specifically targeting admin-level access. It modifies the behavior of the `PublicToUser` function across multiple files (`mock_RepoStore.go`, `repository.go`, and `repository_test.go`) to include an `isAdmin` boolean parameter. This change allows the system to differentiate between admin and non-admin users, granting broader access rights to admins. Additionally, the MR includes updates to the `repoComponentImpl` component to utilize this new parameter, ensuring that admin users are correctly identified and granted appropriate access. Key updates include:
1. Addition of an `isAdmin` parameter to the `PublicToUser` method in the `RepoStore` interface and its implementations.
2. Modification of test cases in `repository_test.go` to accommodate the new parameter.
3. Enhancement of the `PublicToUser` method in `repoComponentImpl` to identify admin users and grant them broader access.
4. Implementation of logic in `repoComponentImpl` to determine if a user has admin rights based on their role.

<!-- @codegpt description end -->