### PR TITLE
Fix repository permission check bug

### DIFF
--- a/component/repo.go
+++ b/component/repo.go
@@ -1429,12 +1429,9 @@ func (c *repoComponentImpl) AllowReadAccess(ctx context.Context, repoType types.
 }
 
 func (c *repoComponentImpl) AllowWriteAccess(ctx context.Context, repoType types.RepositoryType, namespace, name, username string) (bool, error) {
-	repo, err := c.repoStore.FindByPath(ctx, repoType, namespace, name)
+	_, err := c.repoStore.FindByPath(ctx, repoType, namespace, name)
 	if err != nil {
 		return false, fmt.Errorf("failed to find repo, error: %w", err)
-	}
-	if !repo.Private {
-		return true, nil
 	}
 
 	if username == "" {
@@ -1445,12 +1442,9 @@ func (c *repoComponentImpl) AllowWriteAccess(ctx context.Context, repoType types
 }
 
 func (c *repoComponentImpl) AllowAdminAccess(ctx context.Context, repoType types.RepositoryType, namespace, name, username string) (bool, error) {
-	repo, err := c.repoStore.FindByPath(ctx, repoType, namespace, name)
+	_, err := c.repoStore.FindByPath(ctx, repoType, namespace, name)
 	if err != nil {
 		return false, fmt.Errorf("failed to find repo, error: %w", err)
-	}
-	if !repo.Private {
-		return true, nil
 	}
 
 	if username == "" {


### PR DESCRIPTION
**What is this feature?**

- Fix repository permission check bug

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

This Merge Request addresses a bug in the repository permission check mechanism. It simplifies the permission check logic by removing unnecessary checks for a repository's privacy status during write and admin access validations. The changes ensure that the existence of the repository is verified without directly checking its privacy status, streamlining the process for granting write and admin access.

Key updates:
1. Removed redundant checks for repository privacy in `AllowWriteAccess` and `AllowAdminAccess` functions.
2. Ensured repository existence is checked without assessing its privacy status for access permissions.

<!-- @codegpt description end -->