### PR TITLE
[Tag] add tag category management api 

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_TagStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_TagStore.go
@@ -24,6 +24,65 @@ func (_m *MockTagStore) EXPECT() *MockTagStore_Expecter {
 	return &MockTagStore_Expecter{mock: &_m.Mock}
 }
 
+// AllCategories provides a mock function with given fields: ctx, scope
+func (_m *MockTagStore) AllCategories(ctx context.Context, scope database.TagScope) ([]database.TagCategory, error) {
+	ret := _m.Called(ctx, scope)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AllCategories")
+	}
+
+	var r0 []database.TagCategory
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope) ([]database.TagCategory, error)); ok {
+		return rf(ctx, scope)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope) []database.TagCategory); ok {
+		r0 = rf(ctx, scope)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.TagCategory)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, database.TagScope) error); ok {
+		r1 = rf(ctx, scope)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockTagStore_AllCategories_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllCategories'
+type MockTagStore_AllCategories_Call struct {
+	*mock.Call
+}
+
+// AllCategories is a helper method to define mock.On call
+//   - ctx context.Context
+//   - scope database.TagScope
+func (_e *MockTagStore_Expecter) AllCategories(ctx interface{}, scope interface{}) *MockTagStore_AllCategories_Call {
+	return &MockTagStore_AllCategories_Call{Call: _e.mock.On("AllCategories", ctx, scope)}
+}
+
+func (_c *MockTagStore_AllCategories_Call) Run(run func(ctx context.Context, scope database.TagScope)) *MockTagStore_AllCategories_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(database.TagScope))
+	})
+	return _c
+}
+
+func (_c *MockTagStore_AllCategories_Call) Return(_a0 []database.TagCategory, _a1 error) *MockTagStore_AllCategories_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockTagStore_AllCategories_Call) RunAndReturn(run func(context.Context, database.TagScope) ([]database.TagCategory, error)) *MockTagStore_AllCategories_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AllCodeCategories provides a mock function with given fields: ctx
 func (_m *MockTagStore) AllCodeCategories(ctx context.Context) ([]database.TagCategory, error) {
 	ret := _m.Called(ctx)
@@ -781,6 +840,65 @@ func (_c *MockTagStore_AllTagsByScopeAndCategory_Call) RunAndReturn(run func(con
 	return _c
 }
 
+// CreateCategory provides a mock function with given fields: ctx, category
+func (_m *MockTagStore) CreateCategory(ctx context.Context, category database.TagCategory) (*database.TagCategory, error) {
+	ret := _m.Called(ctx, category)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateCategory")
+	}
+
+	var r0 *database.TagCategory
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, database.TagCategory) (*database.TagCategory, error)); ok {
+		return rf(ctx, category)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, database.TagCategory) *database.TagCategory); ok {
+		r0 = rf(ctx, category)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.TagCategory)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, database.TagCategory) error); ok {
+		r1 = rf(ctx, category)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockTagStore_CreateCategory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateCategory'
+type MockTagStore_CreateCategory_Call struct {
+	*mock.Call
+}
+
+// CreateCategory is a helper method to define mock.On call
+//   - ctx context.Context
+//   - category database.TagCategory
+func (_e *MockTagStore_Expecter) CreateCategory(ctx interface{}, category interface{}) *MockTagStore_CreateCategory_Call {
+	return &MockTagStore_CreateCategory_Call{Call: _e.mock.On("CreateCategory", ctx, category)}
+}
+
+func (_c *MockTagStore_CreateCategory_Call) Run(run func(ctx context.Context, category database.TagCategory)) *MockTagStore_CreateCategory_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(database.TagCategory))
+	})
+	return _c
+}
+
+func (_c *MockTagStore_CreateCategory_Call) Return(_a0 *database.TagCategory, _a1 error) *MockTagStore_CreateCategory_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockTagStore_CreateCategory_Call) RunAndReturn(run func(context.Context, database.TagCategory) (*database.TagCategory, error)) *MockTagStore_CreateCategory_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateTag provides a mock function with given fields: ctx, category, name, group, scope
 func (_m *MockTagStore) CreateTag(ctx context.Context, category string, name string, group string, scope database.TagScope) (database.Tag, error) {
 	ret := _m.Called(ctx, category, name, group, scope)
@@ -837,6 +955,53 @@ func (_c *MockTagStore_CreateTag_Call) Return(_a0 database.Tag, _a1 error) *Mock
 }
 
 func (_c *MockTagStore_CreateTag_Call) RunAndReturn(run func(context.Context, string, string, string, database.TagScope) (database.Tag, error)) *MockTagStore_CreateTag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteCategory provides a mock function with given fields: ctx, id
+func (_m *MockTagStore) DeleteCategory(ctx context.Context, id int64) error {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteCategory")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockTagStore_DeleteCategory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteCategory'
+type MockTagStore_DeleteCategory_Call struct {
+	*mock.Call
+}
+
+// DeleteCategory is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id int64
+func (_e *MockTagStore_Expecter) DeleteCategory(ctx interface{}, id interface{}) *MockTagStore_DeleteCategory_Call {
+	return &MockTagStore_DeleteCategory_Call{Call: _e.mock.On("DeleteCategory", ctx, id)}
+}
+
+func (_c *MockTagStore_DeleteCategory_Call) Run(run func(ctx context.Context, id int64)) *MockTagStore_DeleteCategory_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockTagStore_DeleteCategory_Call) Return(_a0 error) *MockTagStore_DeleteCategory_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockTagStore_DeleteCategory_Call) RunAndReturn(run func(context.Context, int64) error) *MockTagStore_DeleteCategory_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1331,6 +1496,65 @@ func (_c *MockTagStore_SetMetaTags_Call) Return(repoTags []*database.RepositoryT
 }
 
 func (_c *MockTagStore_SetMetaTags_Call) RunAndReturn(run func(context.Context, types.RepositoryType, string, string, []*database.Tag) ([]*database.RepositoryTag, error)) *MockTagStore_SetMetaTags_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateCategory provides a mock function with given fields: ctx, category
+func (_m *MockTagStore) UpdateCategory(ctx context.Context, category database.TagCategory) (*database.TagCategory, error) {
+	ret := _m.Called(ctx, category)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateCategory")
+	}
+
+	var r0 *database.TagCategory
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, database.TagCategory) (*database.TagCategory, error)); ok {
+		return rf(ctx, category)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, database.TagCategory) *database.TagCategory); ok {
+		r0 = rf(ctx, category)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.TagCategory)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, database.TagCategory) error); ok {
+		r1 = rf(ctx, category)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockTagStore_UpdateCategory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateCategory'
+type MockTagStore_UpdateCategory_Call struct {
+	*mock.Call
+}
+
+// UpdateCategory is a helper method to define mock.On call
+//   - ctx context.Context
+//   - category database.TagCategory
+func (_e *MockTagStore_Expecter) UpdateCategory(ctx interface{}, category interface{}) *MockTagStore_UpdateCategory_Call {
+	return &MockTagStore_UpdateCategory_Call{Call: _e.mock.On("UpdateCategory", ctx, category)}
+}
+
+func (_c *MockTagStore_UpdateCategory_Call) Run(run func(ctx context.Context, category database.TagCategory)) *MockTagStore_UpdateCategory_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(database.TagCategory))
+	})
+	return _c
+}
+
+func (_c *MockTagStore_UpdateCategory_Call) Return(_a0 *database.TagCategory, _a1 error) *MockTagStore_UpdateCategory_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockTagStore_UpdateCategory_Call) RunAndReturn(run func(context.Context, database.TagCategory) (*database.TagCategory, error)) *MockTagStore_UpdateCategory_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/_mocks/opencsg.com/csghub-server/component/mock_TagComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_TagComponent.go
@@ -24,6 +24,64 @@ func (_m *MockTagComponent) EXPECT() *MockTagComponent_Expecter {
 	return &MockTagComponent_Expecter{mock: &_m.Mock}
 }
 
+// AllCategories provides a mock function with given fields: ctx
+func (_m *MockTagComponent) AllCategories(ctx context.Context) ([]database.TagCategory, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AllCategories")
+	}
+
+	var r0 []database.TagCategory
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) ([]database.TagCategory, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) []database.TagCategory); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.TagCategory)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockTagComponent_AllCategories_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllCategories'
+type MockTagComponent_AllCategories_Call struct {
+	*mock.Call
+}
+
+// AllCategories is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockTagComponent_Expecter) AllCategories(ctx interface{}) *MockTagComponent_AllCategories_Call {
+	return &MockTagComponent_AllCategories_Call{Call: _e.mock.On("AllCategories", ctx)}
+}
+
+func (_c *MockTagComponent_AllCategories_Call) Run(run func(ctx context.Context)) *MockTagComponent_AllCategories_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockTagComponent_AllCategories_Call) Return(_a0 []database.TagCategory, _a1 error) *MockTagComponent_AllCategories_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockTagComponent_AllCategories_Call) RunAndReturn(run func(context.Context) ([]database.TagCategory, error)) *MockTagComponent_AllCategories_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AllTagsByScopeAndCategory provides a mock function with given fields: ctx, scope, category
 func (_m *MockTagComponent) AllTagsByScopeAndCategory(ctx context.Context, scope string, category string) ([]*database.Tag, error) {
 	ret := _m.Called(ctx, scope, category)
@@ -133,6 +191,66 @@ func (_c *MockTagComponent_ClearMetaTags_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// CreateCategory provides a mock function with given fields: ctx, username, req
+func (_m *MockTagComponent) CreateCategory(ctx context.Context, username string, req types.CreateCategory) (*database.TagCategory, error) {
+	ret := _m.Called(ctx, username, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateCategory")
+	}
+
+	var r0 *database.TagCategory
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, types.CreateCategory) (*database.TagCategory, error)); ok {
+		return rf(ctx, username, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, types.CreateCategory) *database.TagCategory); ok {
+		r0 = rf(ctx, username, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.TagCategory)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, types.CreateCategory) error); ok {
+		r1 = rf(ctx, username, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockTagComponent_CreateCategory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateCategory'
+type MockTagComponent_CreateCategory_Call struct {
+	*mock.Call
+}
+
+// CreateCategory is a helper method to define mock.On call
+//   - ctx context.Context
+//   - username string
+//   - req types.CreateCategory
+func (_e *MockTagComponent_Expecter) CreateCategory(ctx interface{}, username interface{}, req interface{}) *MockTagComponent_CreateCategory_Call {
+	return &MockTagComponent_CreateCategory_Call{Call: _e.mock.On("CreateCategory", ctx, username, req)}
+}
+
+func (_c *MockTagComponent_CreateCategory_Call) Run(run func(ctx context.Context, username string, req types.CreateCategory)) *MockTagComponent_CreateCategory_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(types.CreateCategory))
+	})
+	return _c
+}
+
+func (_c *MockTagComponent_CreateCategory_Call) Return(_a0 *database.TagCategory, _a1 error) *MockTagComponent_CreateCategory_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockTagComponent_CreateCategory_Call) RunAndReturn(run func(context.Context, string, types.CreateCategory) (*database.TagCategory, error)) *MockTagComponent_CreateCategory_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateTag provides a mock function with given fields: ctx, username, req
 func (_m *MockTagComponent) CreateTag(ctx context.Context, username string, req types.CreateTag) (*database.Tag, error) {
 	ret := _m.Called(ctx, username, req)
@@ -189,6 +307,54 @@ func (_c *MockTagComponent_CreateTag_Call) Return(_a0 *database.Tag, _a1 error) 
 }
 
 func (_c *MockTagComponent_CreateTag_Call) RunAndReturn(run func(context.Context, string, types.CreateTag) (*database.Tag, error)) *MockTagComponent_CreateTag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteCategory provides a mock function with given fields: ctx, username, id
+func (_m *MockTagComponent) DeleteCategory(ctx context.Context, username string, id int64) error {
+	ret := _m.Called(ctx, username, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteCategory")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64) error); ok {
+		r0 = rf(ctx, username, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockTagComponent_DeleteCategory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteCategory'
+type MockTagComponent_DeleteCategory_Call struct {
+	*mock.Call
+}
+
+// DeleteCategory is a helper method to define mock.On call
+//   - ctx context.Context
+//   - username string
+//   - id int64
+func (_e *MockTagComponent_Expecter) DeleteCategory(ctx interface{}, username interface{}, id interface{}) *MockTagComponent_DeleteCategory_Call {
+	return &MockTagComponent_DeleteCategory_Call{Call: _e.mock.On("DeleteCategory", ctx, username, id)}
+}
+
+func (_c *MockTagComponent_DeleteCategory_Call) Run(run func(ctx context.Context, username string, id int64)) *MockTagComponent_DeleteCategory_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(int64))
+	})
+	return _c
+}
+
+func (_c *MockTagComponent_DeleteCategory_Call) Return(_a0 error) *MockTagComponent_DeleteCategory_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockTagComponent_DeleteCategory_Call) RunAndReturn(run func(context.Context, string, int64) error) *MockTagComponent_DeleteCategory_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -297,6 +463,67 @@ func (_c *MockTagComponent_GetTagByID_Call) Return(_a0 *database.Tag, _a1 error)
 }
 
 func (_c *MockTagComponent_GetTagByID_Call) RunAndReturn(run func(context.Context, string, int64) (*database.Tag, error)) *MockTagComponent_GetTagByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateCategory provides a mock function with given fields: ctx, username, req, id
+func (_m *MockTagComponent) UpdateCategory(ctx context.Context, username string, req types.UpdateCategory, id int64) (*database.TagCategory, error) {
+	ret := _m.Called(ctx, username, req, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateCategory")
+	}
+
+	var r0 *database.TagCategory
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, types.UpdateCategory, int64) (*database.TagCategory, error)); ok {
+		return rf(ctx, username, req, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, types.UpdateCategory, int64) *database.TagCategory); ok {
+		r0 = rf(ctx, username, req, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.TagCategory)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, types.UpdateCategory, int64) error); ok {
+		r1 = rf(ctx, username, req, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockTagComponent_UpdateCategory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateCategory'
+type MockTagComponent_UpdateCategory_Call struct {
+	*mock.Call
+}
+
+// UpdateCategory is a helper method to define mock.On call
+//   - ctx context.Context
+//   - username string
+//   - req types.UpdateCategory
+//   - id int64
+func (_e *MockTagComponent_Expecter) UpdateCategory(ctx interface{}, username interface{}, req interface{}, id interface{}) *MockTagComponent_UpdateCategory_Call {
+	return &MockTagComponent_UpdateCategory_Call{Call: _e.mock.On("UpdateCategory", ctx, username, req, id)}
+}
+
+func (_c *MockTagComponent_UpdateCategory_Call) Run(run func(ctx context.Context, username string, req types.UpdateCategory, id int64)) *MockTagComponent_UpdateCategory_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(types.UpdateCategory), args[3].(int64))
+	})
+	return _c
+}
+
+func (_c *MockTagComponent_UpdateCategory_Call) Return(_a0 *database.TagCategory, _a1 error) *MockTagComponent_UpdateCategory_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockTagComponent_UpdateCategory_Call) RunAndReturn(run func(context.Context, string, types.UpdateCategory, int64) (*database.TagCategory, error)) *MockTagComponent_UpdateCategory_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/api/handler/tag.go
+++ b/api/handler/tag.go
@@ -19,12 +19,12 @@ func NewTagHandler(config *config.Config) (*TagsHandler, error) {
 		return nil, err
 	}
 	return &TagsHandler{
-		tc: tc,
+		tag: tc,
 	}, nil
 }
 
 type TagsHandler struct {
-	tc component.TagComponent
+	tag component.TagComponent
 }
 
 // GetAllTags godoc
@@ -44,7 +44,7 @@ func (t *TagsHandler) AllTags(ctx *gin.Context) {
 	//TODO:validate inputs
 	category := ctx.Query("category")
 	scope := ctx.Query("scope")
-	tags, err := t.tc.AllTagsByScopeAndCategory(ctx, scope, category)
+	tags, err := t.tag.AllTagsByScopeAndCategory(ctx, scope, category)
 	if err != nil {
 		slog.Error("Failed to load tags", slog.Any("category", category), slog.Any("scope", scope), slog.Any("error", err))
 		httpbase.ServerError(ctx, err)
@@ -80,7 +80,7 @@ func (t *TagsHandler) CreateTag(ctx *gin.Context) {
 		httpbase.BadRequest(ctx, err.Error())
 		return
 	}
-	tag, err := t.tc.CreateTag(ctx, userName, req)
+	tag, err := t.tag.CreateTag(ctx, userName, req)
 	if err != nil {
 		slog.Error("Failed to create tag", slog.Any("req", req), slog.Any("error", err))
 		httpbase.ServerError(ctx, err)
@@ -113,7 +113,7 @@ func (t *TagsHandler) GetTagByID(ctx *gin.Context) {
 		httpbase.BadRequest(ctx, err.Error())
 		return
 	}
-	tag, err := t.tc.GetTagByID(ctx, userName, id)
+	tag, err := t.tag.GetTagByID(ctx, userName, id)
 	if err != nil {
 		slog.Error("Failed to get tag", slog.Int64("id", id), slog.Any("error", err))
 		httpbase.ServerError(ctx, err)
@@ -153,7 +153,7 @@ func (t *TagsHandler) UpdateTag(ctx *gin.Context) {
 		httpbase.BadRequest(ctx, err.Error())
 		return
 	}
-	tag, err := t.tc.UpdateTag(ctx, userName, id, req)
+	tag, err := t.tag.UpdateTag(ctx, userName, id, req)
 	if err != nil {
 		slog.Error("Failed to update tag", slog.Int64("id", id), slog.Any("error", err))
 		httpbase.ServerError(ctx, err)
@@ -186,7 +186,7 @@ func (t *TagsHandler) DeleteTag(ctx *gin.Context) {
 		httpbase.BadRequest(ctx, err.Error())
 		return
 	}
-	err = t.tc.DeleteTag(ctx, userName, id)
+	err = t.tag.DeleteTag(ctx, userName, id)
 	if err != nil {
 		slog.Error("Failed to delete tag", slog.Int64("id", id), slog.Any("error", err))
 		httpbase.ServerError(ctx, err)

--- a/api/handler/tag_test.go
+++ b/api/handler/tag_test.go
@@ -22,7 +22,7 @@ func NewTestTagHandler(
 	tagComp component.TagComponent,
 ) (*TagsHandler, error) {
 	return &TagsHandler{
-		tc: tagComp,
+		tag: tagComp,
 	}, nil
 }
 

--- a/api/handler/tag_test.go
+++ b/api/handler/tag_test.go
@@ -195,3 +195,142 @@ func TestTagHandler_DeleteTag(t *testing.T) {
 	require.Equal(t, "", resp.Msg)
 	require.Nil(t, resp.Data)
 }
+
+func TestTagHandler_AllCategories(t *testing.T) {
+	var categories []database.TagCategory
+	categories = append(categories, database.TagCategory{ID: 1, Name: "test1", Scope: database.TagScope("scope")})
+
+	req := httptest.NewRequest("get", "/tags/categories", nil)
+
+	hr := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(hr)
+	ginContext.Request = req
+
+	tagComp := mockcom.NewMockTagComponent(t)
+	tagComp.EXPECT().AllCategories(ginContext).Return(categories, nil)
+
+	tagHandler, err := NewTestTagHandler(tagComp)
+	require.Nil(t, err)
+
+	tagHandler.AllCategories(ginContext)
+
+	require.Equal(t, http.StatusOK, hr.Code)
+
+	var resp httpbase.R
+
+	err = json.Unmarshal(hr.Body.Bytes(), &resp)
+	require.Nil(t, err)
+
+	require.Equal(t, 0, resp.Code)
+	require.Equal(t, "", resp.Msg)
+	require.NotNil(t, resp.Data)
+}
+
+func TestTagHandler_CreateCategory(t *testing.T) {
+	username := "testuser"
+	data := types.CreateCategory{
+		Name:  "testcate",
+		Scope: "testscope",
+	}
+
+	reqBody, _ := json.Marshal(data)
+
+	req := httptest.NewRequest("post", "/tags/categories", bytes.NewBuffer(reqBody))
+
+	hr := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(hr)
+	ginContext.Set("currentUser", username)
+	ginContext.Request = req
+
+	tagComp := mockcom.NewMockTagComponent(t)
+	tagComp.EXPECT().CreateCategory(ginContext, username, data).Return(
+		&database.TagCategory{ID: 1, Name: "testcate", Scope: database.TagScope("testscope")},
+		nil,
+	)
+
+	tagHandler, err := NewTestTagHandler(tagComp)
+	require.Nil(t, err)
+
+	tagHandler.CreateCategory(ginContext)
+
+	require.Equal(t, http.StatusOK, hr.Code)
+
+	var resp httpbase.R
+
+	err = json.Unmarshal(hr.Body.Bytes(), &resp)
+	require.Nil(t, err)
+
+	require.Equal(t, 0, resp.Code)
+	require.Equal(t, "", resp.Msg)
+	require.NotNil(t, resp.Data)
+}
+
+func TestTagHandler_UpdateCategory(t *testing.T) {
+	username := "testuser"
+	data := types.UpdateCategory{
+		Name:  "testcate",
+		Scope: "testscope",
+	}
+
+	reqBody, _ := json.Marshal(data)
+
+	req := httptest.NewRequest("put", "/tags/categories/1", bytes.NewBuffer(reqBody))
+
+	hr := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(hr)
+	ginContext.Set("currentUser", username)
+	ginContext.AddParam("id", "1")
+	ginContext.Request = req
+
+	tagComp := mockcom.NewMockTagComponent(t)
+	tagComp.EXPECT().UpdateCategory(ginContext, username, data, int64(1)).Return(
+		&database.TagCategory{ID: 1, Name: "testcate", Scope: database.TagScope("testscope")},
+		nil,
+	)
+
+	tagHandler, err := NewTestTagHandler(tagComp)
+	require.Nil(t, err)
+
+	tagHandler.UpdateCategory(ginContext)
+
+	require.Equal(t, http.StatusOK, hr.Code)
+
+	var resp httpbase.R
+
+	err = json.Unmarshal(hr.Body.Bytes(), &resp)
+	require.Nil(t, err)
+
+	require.Equal(t, 0, resp.Code)
+	require.Equal(t, "", resp.Msg)
+	require.NotNil(t, resp.Data)
+}
+
+func TestTagHandler_DeleteCategory(t *testing.T) {
+	username := "testuser"
+
+	req := httptest.NewRequest("delete", "/tags/categories/1", nil)
+
+	hr := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(hr)
+	ginContext.Set("currentUser", username)
+	ginContext.AddParam("id", "1")
+	ginContext.Request = req
+
+	tagComp := mockcom.NewMockTagComponent(t)
+	tagComp.EXPECT().DeleteCategory(ginContext, username, int64(1)).Return(nil)
+
+	tagHandler, err := NewTestTagHandler(tagComp)
+	require.Nil(t, err)
+
+	tagHandler.DeleteCategory(ginContext)
+
+	require.Equal(t, http.StatusOK, hr.Code)
+
+	var resp httpbase.R
+
+	err = json.Unmarshal(hr.Body.Bytes(), &resp)
+	require.Nil(t, err)
+
+	require.Equal(t, 0, resp.Code)
+	require.Equal(t, "", resp.Msg)
+}

--- a/api/router/api.go
+++ b/api/router/api.go
@@ -771,6 +771,13 @@ func createPromptRoutes(apiGroup *gin.RouterGroup, promptHandler *handler.Prompt
 func createTagsRoutes(apiGroup *gin.RouterGroup, tagHandler *handler.TagsHandler) {
 	tagsGrp := apiGroup.Group("/tags")
 	{
+		categoryGrp := tagsGrp.Group("/categories")
+		{
+			categoryGrp.GET("", tagHandler.AllCategories)
+			categoryGrp.POST("", tagHandler.CreateCategory)
+			categoryGrp.PUT("/:id", tagHandler.UpdateCategory)
+			categoryGrp.DELETE("/:id", tagHandler.DeleteCategory)
+		}
 		tagsGrp.GET("", tagHandler.AllTags)
 		tagsGrp.POST("", tagHandler.CreateTag)
 		tagsGrp.GET("/:id", tagHandler.GetTagByID)

--- a/builder/store/database/tag_test.go
+++ b/builder/store/database/tag_test.go
@@ -625,3 +625,49 @@ func TestTagStore_DeleteTagByID(t *testing.T) {
 	require.NotEmpty(t, err)
 
 }
+
+func TestTagStore_Category_CURD(t *testing.T) {
+	db := tests.InitTestDB()
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ts := database.NewTagStoreWithDB(db)
+
+	categories, err := ts.AllCategories(ctx, "")
+	require.Empty(t, err)
+	require.NotEmpty(t, categories)
+
+	total := len(categories)
+
+	catetory, err := ts.CreateCategory(ctx, database.TagCategory{
+		Name:  "test-category",
+		Scope: "test-scope",
+	})
+	require.Empty(t, err)
+	require.NotEmpty(t, catetory)
+
+	id := catetory.ID
+
+	catetory, err = ts.UpdateCategory(ctx, database.TagCategory{
+		ID:    1,
+		Name:  "test-category1",
+		Scope: "test-scope1",
+	})
+	require.Empty(t, err)
+	require.NotEmpty(t, catetory)
+
+	categories, err = ts.AllCategories(ctx, "")
+	require.Empty(t, err)
+	require.NotEmpty(t, categories)
+	require.Equal(t, "test-category1", categories[0].Name)
+	require.Equal(t, "test-scope1", string(categories[0].Scope))
+
+	err = ts.DeleteCategory(ctx, id)
+	require.Empty(t, err)
+
+	categories, err = ts.AllCategories(ctx, "")
+	require.Empty(t, err)
+	require.Equal(t, total, len(categories))
+}

--- a/common/types/tag.go
+++ b/common/types/tag.go
@@ -35,3 +35,10 @@ type CreateTag struct {
 }
 
 type UpdateTag CreateTag
+
+type CreateCategory struct {
+	Name  string `json:"name" binding:"required"`
+	Scope string `json:"scope" binding:"required"`
+}
+
+type UpdateCategory CreateCategory

--- a/component/tag_test.go
+++ b/component/tag_test.go
@@ -235,3 +235,132 @@ func TestTagComponent_UpdateRepoTagsByCategory(t *testing.T) {
 	err := tc.UpdateRepoTagsByCategory(ctx, database.DatasetTagScope, 1, "c", []string{"t1"})
 	require.Nil(t, err)
 }
+
+func TestTagComponent_AllCategories(t *testing.T) {
+	ctx := context.TODO()
+	tc := initializeTestTagComponent(ctx, t)
+
+	tc.mocks.stores.TagMock().EXPECT().AllCategories(ctx, database.TagScope("")).Return([]database.TagCategory{}, nil)
+
+	categories, err := tc.AllCategories(ctx)
+	require.Nil(t, err)
+	require.Equal(t, []database.TagCategory{}, categories)
+}
+
+func TestTagComponent_CreateCategory(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("admin", func(t *testing.T) {
+		tc := initializeTestTagComponent(ctx, t)
+
+		tc.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "admin").Return(database.User{
+			Username: "admin",
+			RoleMask: "admin",
+		}, nil)
+		tc.mocks.stores.TagMock().EXPECT().CreateCategory(ctx, database.TagCategory{
+			Name:  "test-cate",
+			Scope: database.TagScope("test-scope"),
+		}).Return(&database.TagCategory{
+			ID:    1,
+			Name:  "test-cate",
+			Scope: "test-scope",
+		}, nil)
+
+		category, err := tc.CreateCategory(ctx, "admin", types.CreateCategory{
+			Name:  "test-cate",
+			Scope: "test-scope",
+		})
+		require.Nil(t, err)
+		require.NotNil(t, category)
+	})
+
+	t.Run("user", func(t *testing.T) {
+		tc := initializeTestTagComponent(ctx, t)
+
+		tc.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "user").Return(database.User{
+			Username: "user",
+			RoleMask: "user",
+		}, nil)
+
+		category, err := tc.CreateCategory(ctx, "user", types.CreateCategory{
+			Name:  "test-cate",
+			Scope: "test-scope",
+		})
+		require.NotNil(t, err)
+		require.Nil(t, category)
+	})
+}
+
+func TestTagComponent_UpdateCategory(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("admin", func(t *testing.T) {
+		tc := initializeTestTagComponent(ctx, t)
+
+		tc.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "admin").Return(database.User{
+			Username: "admin",
+			RoleMask: "admin",
+		}, nil)
+		tc.mocks.stores.TagMock().EXPECT().UpdateCategory(ctx, database.TagCategory{
+			ID:    int64(1),
+			Name:  "test-cate",
+			Scope: database.TagScope("test-scope"),
+		}).Return(&database.TagCategory{
+			ID:    1,
+			Name:  "test-cate",
+			Scope: "test-scope",
+		}, nil)
+
+		category, err := tc.UpdateCategory(ctx, "admin", types.UpdateCategory{
+			Name:  "test-cate",
+			Scope: "test-scope",
+		}, int64(1))
+		require.Nil(t, err)
+		require.NotNil(t, category)
+	})
+
+	t.Run("user", func(t *testing.T) {
+		tc := initializeTestTagComponent(ctx, t)
+
+		tc.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "user").Return(database.User{
+			Username: "user",
+			RoleMask: "user",
+		}, nil)
+
+		category, err := tc.UpdateCategory(ctx, "user", types.UpdateCategory{
+			Name:  "test-cate",
+			Scope: "test-scope",
+		}, int64(1))
+		require.NotNil(t, err)
+		require.Nil(t, category)
+	})
+}
+
+func TestTagComponent_DeleteCategory(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("admin", func(t *testing.T) {
+		tc := initializeTestTagComponent(ctx, t)
+
+		tc.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "admin").Return(database.User{
+			Username: "admin",
+			RoleMask: "admin",
+		}, nil)
+		tc.mocks.stores.TagMock().EXPECT().DeleteCategory(ctx, int64(1)).Return(nil)
+
+		err := tc.DeleteCategory(ctx, "admin", int64(1))
+		require.Nil(t, err)
+	})
+
+	t.Run("user", func(t *testing.T) {
+		tc := initializeTestTagComponent(ctx, t)
+
+		tc.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "user").Return(database.User{
+			Username: "user",
+			RoleMask: "user",
+		}, nil)
+
+		err := tc.DeleteCategory(ctx, "user", int64(1))
+		require.NotNil(t, err)
+	})
+}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -10144,6 +10144,199 @@ const docTemplate = `{
                 }
             }
         },
+        "/tags/categories": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKey": []
+                    }
+                ],
+                "description": "Get all Categories",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tag"
+                ],
+                "summary": "Get all Categories",
+                "responses": {
+                    "200": {
+                        "description": "categores",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/types.ResponseWithTotal"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/database.TagCategory"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIBadRequest"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIInternalServerError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKey": []
+                    }
+                ],
+                "description": "Create new category",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tag"
+                ],
+                "summary": "Create new category",
+                "parameters": [
+                    {
+                        "description": "body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.CreateCategory"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIBadRequest"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIInternalServerError"
+                        }
+                    }
+                }
+            }
+        },
+        "/tags/categories/id": {
+            "put": {
+                "security": [
+                    {
+                        "ApiKey": []
+                    }
+                ],
+                "description": "Create new category",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tag"
+                ],
+                "summary": "Create new category",
+                "parameters": [
+                    {
+                        "description": "body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UpdateCategory"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIBadRequest"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIInternalServerError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKey": []
+                    }
+                ],
+                "description": "Delete a category by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tag"
+                ],
+                "summary": "Delete a category by id",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIBadRequest"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIInternalServerError"
+                        }
+                    }
+                }
+            }
+        },
         "/tags/{id}": {
             "get": {
                 "security": [
@@ -15990,6 +16183,20 @@ const docTemplate = `{
                 }
             }
         },
+        "database.TagCategory": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "scope": {
+                    "$ref": "#/definitions/database.TagScope"
+                }
+            }
+        },
         "database.TagScope": {
             "type": "string",
             "enum": [
@@ -16632,6 +16839,21 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "uuid": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.CreateCategory": {
+            "type": "object",
+            "required": [
+                "name",
+                "scope"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "scope": {
                     "type": "string"
                 }
             }
@@ -18569,6 +18791,21 @@ const docTemplate = `{
                 "TaskTypeComparison",
                 "TaskTypeLeaderBoard"
             ]
+        },
+        "types.UpdateCategory": {
+            "type": "object",
+            "required": [
+                "name",
+                "scope"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "scope": {
+                    "type": "string"
+                }
+            }
         },
         "types.UpdateCodeReq": {
             "type": "object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -10133,6 +10133,199 @@
                 }
             }
         },
+        "/tags/categories": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKey": []
+                    }
+                ],
+                "description": "Get all Categories",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tag"
+                ],
+                "summary": "Get all Categories",
+                "responses": {
+                    "200": {
+                        "description": "categores",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/types.ResponseWithTotal"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/database.TagCategory"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIBadRequest"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIInternalServerError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKey": []
+                    }
+                ],
+                "description": "Create new category",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tag"
+                ],
+                "summary": "Create new category",
+                "parameters": [
+                    {
+                        "description": "body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.CreateCategory"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIBadRequest"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIInternalServerError"
+                        }
+                    }
+                }
+            }
+        },
+        "/tags/categories/id": {
+            "put": {
+                "security": [
+                    {
+                        "ApiKey": []
+                    }
+                ],
+                "description": "Create new category",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tag"
+                ],
+                "summary": "Create new category",
+                "parameters": [
+                    {
+                        "description": "body",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UpdateCategory"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIBadRequest"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIInternalServerError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKey": []
+                    }
+                ],
+                "description": "Delete a category by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tag"
+                ],
+                "summary": "Delete a category by id",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIBadRequest"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/types.APIInternalServerError"
+                        }
+                    }
+                }
+            }
+        },
         "/tags/{id}": {
             "get": {
                 "security": [
@@ -15979,6 +16172,20 @@
                 }
             }
         },
+        "database.TagCategory": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "scope": {
+                    "$ref": "#/definitions/database.TagScope"
+                }
+            }
+        },
         "database.TagScope": {
             "type": "string",
             "enum": [
@@ -16621,6 +16828,21 @@
                     "type": "string"
                 },
                 "uuid": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.CreateCategory": {
+            "type": "object",
+            "required": [
+                "name",
+                "scope"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "scope": {
                     "type": "string"
                 }
             }
@@ -18558,6 +18780,21 @@
                 "TaskTypeComparison",
                 "TaskTypeLeaderBoard"
             ]
+        },
+        "types.UpdateCategory": {
+            "type": "object",
+            "required": [
+                "name",
+                "scope"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "scope": {
+                    "type": "string"
+                }
+            }
         },
         "types.UpdateCodeReq": {
             "type": "object",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -463,6 +463,15 @@ definitions:
       updated_at:
         type: string
     type: object
+  database.TagCategory:
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+      scope:
+        $ref: '#/definitions/database.TagScope'
+    type: object
   database.TagScope:
     enum:
     - model
@@ -899,6 +908,16 @@ definitions:
     required:
     - title
     - uuid
+    type: object
+  types.CreateCategory:
+    properties:
+      name:
+        type: string
+      scope:
+        type: string
+    required:
+    - name
+    - scope
     type: object
   types.CreateCodeReq:
     properties:
@@ -2216,6 +2235,16 @@ definitions:
     - TaskTypeTraining
     - TaskTypeComparison
     - TaskTypeLeaderBoard
+  types.UpdateCategory:
+    properties:
+      name:
+        type: string
+      scope:
+        type: string
+    required:
+    - name
+    - scope
+    type: object
   types.UpdateCodeReq:
     properties:
       description:
@@ -10685,6 +10714,125 @@ paths:
       security:
       - ApiKey: []
       summary: Update a tag by id
+      tags:
+      - Tag
+  /tags/categories:
+    get:
+      consumes:
+      - application/json
+      description: Get all Categories
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: categores
+          schema:
+            allOf:
+            - $ref: '#/definitions/types.ResponseWithTotal'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/database.TagCategory'
+                  type: array
+              type: object
+        "400":
+          description: Bad request
+          schema:
+            $ref: '#/definitions/types.APIBadRequest'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/types.APIInternalServerError'
+      security:
+      - ApiKey: []
+      summary: Get all Categories
+      tags:
+      - Tag
+    post:
+      consumes:
+      - application/json
+      description: Create new category
+      parameters:
+      - description: body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/types.CreateCategory'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Response'
+        "400":
+          description: Bad request
+          schema:
+            $ref: '#/definitions/types.APIBadRequest'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/types.APIInternalServerError'
+      security:
+      - ApiKey: []
+      summary: Create new category
+      tags:
+      - Tag
+  /tags/categories/id:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a category by id
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Response'
+        "400":
+          description: Bad request
+          schema:
+            $ref: '#/definitions/types.APIBadRequest'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/types.APIInternalServerError'
+      security:
+      - ApiKey: []
+      summary: Delete a category by id
+      tags:
+      - Tag
+    put:
+      consumes:
+      - application/json
+      description: Create new category
+      parameters:
+      - description: body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/types.UpdateCategory'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Response'
+        "400":
+          description: Bad request
+          schema:
+            $ref: '#/definitions/types.APIBadRequest'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/types.APIInternalServerError'
+      security:
+      - ApiKey: []
+      summary: Create new category
       tags:
       - Tag
   /telemetry/usage:


### PR DESCRIPTION
**What is this feature?**

tag management

**Why do we need this feature?**

support portal

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request adds tag category management APIs to support portal functionalities. It introduces the ability to create, update, and delete tag categories through new endpoints in the system. This feature is essential for organizing and managing tags more efficiently in the portal.

Key updates:
1. Implemented endpoints for creating, updating, and deleting tag categories.
2. Enhanced the tag management component to support category operations.
3. Added unit tests for the new functionalities to ensure reliability.
4. Updated documentation and Swagger API specs to reflect the new endpoints.

<!-- @codegpt description end -->