### PR TITLE
ce,ee allow create public dataset

### DIFF
--- a/api/handler/dataset.go
+++ b/api/handler/dataset.go
@@ -76,6 +76,10 @@ func (h *DatasetHandler) Create(ctx *gin.Context) {
 		httpbase.BadRequest(ctx, fmt.Errorf("sensitive check failed: %w", err).Error())
 		return
 	}
+	if !req.Private && !h.allowCreatePublic() {
+		httpbase.BadRequest(ctx, "creating public dataset is not allowed")
+		return
+	}
 	req.Username = currentUser
 
 	dataset, err := h.dataset.Create(ctx, req)

--- a/api/handler/dataset_ce.go
+++ b/api/handler/dataset_ce.go
@@ -1,0 +1,7 @@
+//go:build !saas
+
+package handler
+
+func (h *DatasetHandler) allowCreatePublic() bool {
+	return true
+}

--- a/api/handler/dataset_ce_test.go
+++ b/api/handler/dataset_ce_test.go
@@ -1,0 +1,58 @@
+//go:build !saas
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"opencsg.com/csghub-server/common/types"
+)
+
+func TestDatasetHandler_Create(t *testing.T) {
+	t.Run("no public", func(t *testing.T) {
+
+		tester := NewDatasetTester(t).WithHandleFunc(func(h *DatasetHandler) gin.HandlerFunc {
+			return h.Create
+		})
+		tester.RequireUser(t)
+
+		tester.mocks.sensitive.EXPECT().CheckRequestV2(tester.ctx, &types.CreateDatasetReq{
+			CreateRepoReq: types.CreateRepoReq{Private: true},
+		}).Return(true, nil)
+		tester.mocks.dataset.EXPECT().Create(tester.ctx, &types.CreateDatasetReq{
+			CreateRepoReq: types.CreateRepoReq{Private: true, Username: "u"},
+		}).Return(&types.Dataset{Name: "d"}, nil)
+		tester.WithBody(t, &types.CreateDatasetReq{
+			CreateRepoReq: types.CreateRepoReq{Private: true},
+		}).Execute()
+
+		tester.ResponseEqSimple(t, 200, gin.H{
+			"data": &types.Dataset{Name: "d"},
+		})
+
+	})
+
+	t.Run("public", func(t *testing.T) {
+
+		tester := NewDatasetTester(t).WithHandleFunc(func(h *DatasetHandler) gin.HandlerFunc {
+			return h.Create
+		})
+		tester.RequireUser(t)
+
+		tester.mocks.sensitive.EXPECT().CheckRequestV2(tester.ctx, &types.CreateDatasetReq{
+			CreateRepoReq: types.CreateRepoReq{Private: false},
+		}).Return(true, nil)
+		tester.mocks.dataset.EXPECT().Create(tester.ctx, &types.CreateDatasetReq{
+			CreateRepoReq: types.CreateRepoReq{Private: false, Username: "u"},
+		}).Return(&types.Dataset{Name: "d"}, nil)
+		tester.WithBody(t, &types.CreateDatasetReq{
+			CreateRepoReq: types.CreateRepoReq{Private: false},
+		}).Execute()
+
+		tester.ResponseEqSimple(t, 200, gin.H{
+			"data": &types.Dataset{Name: "d"},
+		})
+	})
+
+}

--- a/api/handler/dataset_test.go
+++ b/api/handler/dataset_test.go
@@ -41,32 +41,6 @@ func (t *DatasetTester) WithHandleFunc(fn func(h *DatasetHandler) gin.HandlerFun
 	return t
 }
 
-func TestDatasetHandler_Create(t *testing.T) {
-
-	t.Run("public", func(t *testing.T) {
-
-		tester := NewDatasetTester(t).WithHandleFunc(func(h *DatasetHandler) gin.HandlerFunc {
-			return h.Create
-		})
-		tester.RequireUser(t)
-
-		tester.mocks.sensitive.EXPECT().CheckRequestV2(tester.ctx, &types.CreateDatasetReq{
-			CreateRepoReq: types.CreateRepoReq{Private: true},
-		}).Return(true, nil)
-		tester.mocks.dataset.EXPECT().Create(tester.ctx, &types.CreateDatasetReq{
-			CreateRepoReq: types.CreateRepoReq{Private: true, Username: "u"},
-		}).Return(&types.Dataset{Name: "d"}, nil)
-		tester.WithBody(t, &types.CreateDatasetReq{
-			CreateRepoReq: types.CreateRepoReq{Private: true},
-		}).Execute()
-
-		tester.ResponseEqSimple(t, 200, gin.H{
-			"data": &types.Dataset{Name: "d"},
-		})
-	})
-
-}
-
 func TestDatasetHandler_Index(t *testing.T) {
 	cases := []struct {
 		sort   string


### PR DESCRIPTION
**What is this feature?**

allow user to create public dataset

**Why do we need this feature?**

open-source users want public datasets.

**Who is this feature for?**



**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

This Merge Request introduces the ability for users to create public datasets, addressing the needs of open-source users. It includes backend changes to enforce permissions and conditions for creating public datasets. Key updates are:

1. Added a condition in `Create` method to prevent unauthorized creation of public datasets.
2. Introduced `allowCreatePublic` method in `dataset_ce.go` to enable public dataset creation, with a default return value of `true`.
3. Implemented tests in `dataset_ce_test.go` to verify both private and public dataset creation flows.
4. Adjusted existing tests in `dataset_test.go` to align with the new feature implementation.

<!-- @codegpt description end -->