### PR TITLE
Prevent panic when TOML fields are missing from struct definition

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"os"
+	"reflect"
 
 	"github.com/naoina/toml"
 	"github.com/sethvargo/go-envconfig"
@@ -240,6 +241,10 @@ func SetConfigFile(file string) {
 
 func LoadConfig() (*Config, error) {
 	cfg := &Config{}
+
+	toml.DefaultConfig.MissingField = func(typ reflect.Type, key string) error {
+		return nil
+	}
 
 	if configFile != "" {
 		f, err := os.Open(configFile)


### PR DESCRIPTION
**What is this feature?**

Currently, the TOML config loader panics if a field exists in the TOML file but is not defined in the corresponding struct. This PR disables that behavior, allowing us to ignore or remove unused fields without panic.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**
