### PR TITLE
fix workflow status did not updated for failed activity

### DIFF
--- a/dataviewer/common/types.go
+++ b/dataviewer/common/types.go
@@ -169,6 +169,6 @@ type UpdateCardReq struct {
 
 type UpdateWorkflowStatusReq struct {
 	Req                types.UpdateViewerReq
-	WorkflowErr        error
+	WorkflowErrMsg     string
 	ShouldUpdateViewer bool
 }

--- a/dataviewer/component/dataset_viewer.go
+++ b/dataviewer/component/dataset_viewer.go
@@ -253,11 +253,13 @@ func (c *datasetViewerComponentImpl) getViewerCardData(ctx context.Context, repo
 		return nil, nil, fmt.Errorf("failed to get viewer by repo_id %d, error: %w", repoID, err)
 	}
 
-	if viewer == nil || viewer.DataviewerJob == nil || len(viewer.DataviewerJob.CardData) < 1 {
+	if viewer == nil || viewer.DataviewerJob == nil {
 		return nil, nil, fmt.Errorf("viewer card data is empty")
 	}
 
-	if viewer.DataviewerJob.Status == types.WorkflowPending || viewer.DataviewerJob.Status == types.WorkflowFailed {
+	if len(viewer.DataviewerJob.CardData) < 1 &&
+		(viewer.DataviewerJob.Status == types.WorkflowPending ||
+			viewer.DataviewerJob.Status == types.WorkflowFailed) {
 		return &dvCom.CataLogRespone{
 			Status: viewer.DataviewerJob.Status,
 			Logs:   viewer.DataviewerJob.Logs,

--- a/dataviewer/workflows/workflow.go
+++ b/dataviewer/workflows/workflow.go
@@ -221,10 +221,14 @@ func updateWorkflowStatus(sessionCtx workflow.Context,
 	wfErr error,
 	shouldUpdateViewer bool,
 ) {
+	errMsg := ""
+	if wfErr != nil {
+		errMsg = wfErr.Error()
+	}
 	err := workflow.ExecuteActivity(sessionCtx, DataViewerActivity.UpdateWorkflowStatus,
 		dvCom.UpdateWorkflowStatusReq{
 			Req:                updateWorkflow.Req,
-			WorkflowErr:        wfErr,
+			WorkflowErrMsg:     errMsg,
 			ShouldUpdateViewer: shouldUpdateViewer,
 		},
 	).Get(sessionCtx, nil)

--- a/dataviewer/workflows/workflow_test.go
+++ b/dataviewer/workflows/workflow_test.go
@@ -128,7 +128,7 @@ func TestWorkflow_DataviewerWorkflow(t *testing.T) {
 
 		tester.mocks.mockact.EXPECT().UpdateWorkflowStatus(mock.Anything, dvCom.UpdateWorkflowStatusReq{
 			Req:                req,
-			WorkflowErr:        nil,
+			WorkflowErrMsg:     "",
 			ShouldUpdateViewer: true,
 		}).Return(nil)
 
@@ -206,7 +206,7 @@ func TestWorkflow_DataviewerWorkflow(t *testing.T) {
 
 		tester.mocks.mockact.EXPECT().UpdateWorkflowStatus(mock.Anything, dvCom.UpdateWorkflowStatusReq{
 			Req:                req,
-			WorkflowErr:        nil,
+			WorkflowErrMsg:     "",
 			ShouldUpdateViewer: true,
 		}).Return(nil)
 


### PR DESCRIPTION
**What is this feature?**

bug fix for workflow status did not updated and no readme.md for repo

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

This Merge Request addresses a bug where the workflow status was not updated for failed activities. It also adds missing `readme.md` documentation to the repository. Key changes include:

1. Modification in error handling to replace `WorkflowErr` with `WorkflowErrMsg` as a string to better capture and log workflow errors.
2. Adjustments in workflow and activity implementations to ensure the workflow status is correctly updated upon failure.
3. Updates in test cases to align with the changes in error handling and workflow status updates.
4. Introduction of logging warnings instead of returning errors when `readme.md` content is invalid or missing, ensuring the workflow continues with default configurations.

These changes aim to enhance error handling and status reporting in the data viewer's workflow management, improving reliability and maintainability.

<!-- @codegpt description end -->