### PR TITLE
LFS API Refactor & Security Enhancement

### DIFF
--- a/_mocks/opencsg.com/csghub-server/component/mock_GitHTTPComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_GitHTTPComponent.go
@@ -28,66 +28,6 @@ func (_m *MockGitHTTPComponent) EXPECT() *MockGitHTTPComponent_Expecter {
 	return &MockGitHTTPComponent_Expecter{mock: &_m.Mock}
 }
 
-// BuildObjectResponse provides a mock function with given fields: ctx, req, isUpload
-func (_m *MockGitHTTPComponent) BuildObjectResponse(ctx context.Context, req types.BatchRequest, isUpload bool) (*types.BatchResponse, error) {
-	ret := _m.Called(ctx, req, isUpload)
-
-	if len(ret) == 0 {
-		panic("no return value specified for BuildObjectResponse")
-	}
-
-	var r0 *types.BatchResponse
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.BatchRequest, bool) (*types.BatchResponse, error)); ok {
-		return rf(ctx, req, isUpload)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, types.BatchRequest, bool) *types.BatchResponse); ok {
-		r0 = rf(ctx, req, isUpload)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.BatchResponse)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, types.BatchRequest, bool) error); ok {
-		r1 = rf(ctx, req, isUpload)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockGitHTTPComponent_BuildObjectResponse_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BuildObjectResponse'
-type MockGitHTTPComponent_BuildObjectResponse_Call struct {
-	*mock.Call
-}
-
-// BuildObjectResponse is a helper method to define mock.On call
-//   - ctx context.Context
-//   - req types.BatchRequest
-//   - isUpload bool
-func (_e *MockGitHTTPComponent_Expecter) BuildObjectResponse(ctx interface{}, req interface{}, isUpload interface{}) *MockGitHTTPComponent_BuildObjectResponse_Call {
-	return &MockGitHTTPComponent_BuildObjectResponse_Call{Call: _e.mock.On("BuildObjectResponse", ctx, req, isUpload)}
-}
-
-func (_c *MockGitHTTPComponent_BuildObjectResponse_Call) Run(run func(ctx context.Context, req types.BatchRequest, isUpload bool)) *MockGitHTTPComponent_BuildObjectResponse_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(types.BatchRequest), args[2].(bool))
-	})
-	return _c
-}
-
-func (_c *MockGitHTTPComponent_BuildObjectResponse_Call) Return(_a0 *types.BatchResponse, _a1 error) *MockGitHTTPComponent_BuildObjectResponse_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockGitHTTPComponent_BuildObjectResponse_Call) RunAndReturn(run func(context.Context, types.BatchRequest, bool) (*types.BatchResponse, error)) *MockGitHTTPComponent_BuildObjectResponse_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // CreateLock provides a mock function with given fields: ctx, req
 func (_m *MockGitHTTPComponent) CreateLock(ctx context.Context, req types.LfsLockReq) (*database.LfsLock, error) {
 	ret := _m.Called(ctx, req)
@@ -296,6 +236,65 @@ func (_c *MockGitHTTPComponent_InfoRefs_Call) Return(_a0 io.Reader, _a1 error) *
 }
 
 func (_c *MockGitHTTPComponent_InfoRefs_Call) RunAndReturn(run func(context.Context, types.InfoRefsReq) (io.Reader, error)) *MockGitHTTPComponent_InfoRefs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// LFSBatch provides a mock function with given fields: ctx, req
+func (_m *MockGitHTTPComponent) LFSBatch(ctx context.Context, req types.BatchRequest) (*types.BatchResponse, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LFSBatch")
+	}
+
+	var r0 *types.BatchResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.BatchRequest) (*types.BatchResponse, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, types.BatchRequest) *types.BatchResponse); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.BatchResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, types.BatchRequest) error); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockGitHTTPComponent_LFSBatch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LFSBatch'
+type MockGitHTTPComponent_LFSBatch_Call struct {
+	*mock.Call
+}
+
+// LFSBatch is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req types.BatchRequest
+func (_e *MockGitHTTPComponent_Expecter) LFSBatch(ctx interface{}, req interface{}) *MockGitHTTPComponent_LFSBatch_Call {
+	return &MockGitHTTPComponent_LFSBatch_Call{Call: _e.mock.On("LFSBatch", ctx, req)}
+}
+
+func (_c *MockGitHTTPComponent_LFSBatch_Call) Run(run func(ctx context.Context, req types.BatchRequest)) *MockGitHTTPComponent_LFSBatch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.BatchRequest))
+	})
+	return _c
+}
+
+func (_c *MockGitHTTPComponent_LFSBatch_Call) Return(_a0 *types.BatchResponse, _a1 error) *MockGitHTTPComponent_LFSBatch_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockGitHTTPComponent_LFSBatch_Call) RunAndReturn(run func(context.Context, types.BatchRequest) (*types.BatchResponse, error)) *MockGitHTTPComponent_LFSBatch_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/builder/store/database/lfs_meta_object_test.go
+++ b/builder/store/database/lfs_meta_object_test.go
@@ -35,6 +35,10 @@ func TestLfsMetaStore_CRUD(t *testing.T) {
 	require.Equal(t, 1, len(objs))
 	require.Equal(t, "foobar", objs[0].Oid)
 
+	objs, err = store.FindByRepoID(ctx, 987)
+	require.Nil(t, err)
+	require.Equal(t, 0, len(objs))
+
 	// update
 	_, err = store.UpdateOrCreate(ctx, database.LfsMetaObject{
 		RepositoryID: 123,

--- a/common/types/git_http.go
+++ b/common/types/git_http.go
@@ -18,6 +18,13 @@ var (
 	ErrSizeMismatch = errors.New("content size does not match")
 )
 
+type LFSBatchOperation string
+
+const (
+	LFSBatchUpload   LFSBatchOperation = "upload"
+	LFSBatchDownload LFSBatchOperation = "download"
+)
+
 type InfoRefsReq struct {
 	Namespace   string         `json:"namespace"`
 	Name        string         `json:"name"`
@@ -40,15 +47,15 @@ type GitUploadPackReq struct {
 type GitReceivePackReq = GitUploadPackReq
 
 type BatchRequest struct {
-	Operation     string         `json:"operation"`
-	Transfers     []string       `json:"transfers,omitempty"`
-	Ref           *Reference     `json:"ref,omitempty"`
-	Objects       []Pointer      `json:"objects"`
-	Authorization string         `json:"authorization"`
-	Namespace     string         `json:"namespace"`
-	Name          string         `json:"name"`
-	RepoType      RepositoryType `json:"repo_type"`
-	CurrentUser   string         `json:"current_user"`
+	Operation     LFSBatchOperation `json:"operation"`
+	Transfers     []string          `json:"transfers,omitempty"`
+	Ref           *Reference        `json:"ref,omitempty"`
+	Objects       []Pointer         `json:"objects"`
+	Authorization string            `json:"authorization"`
+	Namespace     string            `json:"namespace"`
+	Name          string            `json:"name"`
+	RepoType      RepositoryType    `json:"repo_type"`
+	CurrentUser   string            `json:"current_user"`
 }
 
 type UploadRequest struct {

--- a/component/errors.go
+++ b/component/errors.go
@@ -20,3 +20,12 @@ var (
 func ErrForbiddenMsg(msg string) error {
 	return fmt.Errorf("%s, %w", msg, ErrForbidden)
 }
+
+type HTTPError struct {
+	StatusCode int
+	Message    any
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("StatusCode: %d, Message: %v", e.StatusCode, e.Message)
+}

--- a/component/git_http_test.go
+++ b/component/git_http_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/minio/minio-go/v7"
@@ -120,82 +121,165 @@ func TestGitHTTPComponent_GitReceivePack(t *testing.T) {
 
 }
 
-func TestGitHTTPComponent_BuildObjectResponse(t *testing.T) {
-	ctx := context.TODO()
-	gc := initializeTestGitHTTPComponent(ctx, t)
-
-	oid1 := "a3f8e1b4f77bb24e508906c6972f81928f0d926e6daef1b29d12e348b8a3547e"
-	oid2 := "c39e7f5f1d61fa58ec6dbcd3b60a50870c577f0988d7c080fc88d1b460e7f5f1"
-	gc.mocks.stores.RepoMock().EXPECT().FindByPath(
-		ctx, types.ModelRepo, "ns", "n",
-	).Return(&database.Repository{
-		ID:      123,
-		Private: true,
-	}, nil)
-	gc.mocks.s3Client.EXPECT().StatObject(
-		ctx, "",
-		"lfs/a3/f8/e1b4f77bb24e508906c6972f81928f0d926e6daef1b29d12e348b8a3547e",
-		minio.StatObjectOptions{},
-	).Return(
-		minio.ObjectInfo{Size: 100}, nil,
-	)
-	gc.mocks.s3Client.EXPECT().StatObject(
-		ctx, "",
-		"lfs/c3/9e/7f5f1d61fa58ec6dbcd3b60a50870c577f0988d7c080fc88d1b460e7f5f1",
-		minio.StatObjectOptions{},
-	).Return(
-		minio.ObjectInfo{Size: 100}, nil,
-	)
-	gc.mocks.stores.LfsMetaObjectMock().EXPECT().FindByOID(ctx, int64(123), oid1).Return(
-		&database.LfsMetaObject{}, nil,
-	)
-	gc.mocks.stores.LfsMetaObjectMock().EXPECT().FindByOID(ctx, int64(123), oid2).Return(
-		nil, nil,
-	)
-	gc.mocks.components.repo.EXPECT().AllowWriteAccess(
-		ctx, types.ModelRepo, "ns", "n", "user",
-	).Return(true, nil)
-	gc.mocks.stores.LfsMetaObjectMock().EXPECT().Create(ctx, database.LfsMetaObject{
-		Oid:          oid2,
-		Size:         100,
-		RepositoryID: 123,
-		Existing:     true,
-	}).Return(nil, nil)
-
-	resp, err := gc.BuildObjectResponse(ctx, types.BatchRequest{
-		Namespace:   "ns",
-		Name:        "n",
-		RepoType:    types.ModelRepo,
-		CurrentUser: "user",
-		Objects: []types.Pointer{
-			{
-				Oid:  oid1,
-				Size: 5,
-			},
-			{
-				Oid:  oid2,
-				Size: 100,
-			},
-		},
-	}, true)
-	require.Nil(t, err)
-	require.Equal(t, &types.BatchResponse{
-		Objects: []*types.ObjectResponse{
-			{
-				Pointer: types.Pointer{Oid: oid1, Size: 5},
-				Error: &types.ObjectError{
-					Code:    422,
-					Message: "Object a3f8e1b4f77bb24e508906c6972f81928f0d926e6daef1b29d12e348b8a3547e is not 5 bytes",
+func TestGitHTTPComponent_Batch(t *testing.T) {
+	existOID := "a3f8e1b4f77bb24e508906c6972f81928f0d926e6daef1b29d12e348b8a3547e"
+	notExistOID := "c39e7f5f1d61fa58ec6dbcd3b60a50870c577f0988d7c080fc88d1b460e7f5f1"
+	cases := []struct {
+		name           string
+		hasReadAccess  bool
+		hasWriteAccess bool
+		operation      types.LFSBatchOperation
+		exist          bool
+		err            error
+		resp           *types.BatchResponse
+	}{
+		{
+			name:          "download success",
+			hasReadAccess: true,
+			operation:     types.LFSBatchDownload,
+			exist:         true,
+			resp: &types.BatchResponse{
+				Objects: []*types.ObjectResponse{
+					{
+						Pointer: types.Pointer{Oid: existOID, Size: 100},
+						Actions: map[string]*types.Link{
+							"download": {
+								Href:   "http://foo.com/bar",
+								Header: map[string]string{},
+							},
+						},
+					},
 				},
-				Actions: nil,
-			},
-			{
-				Pointer: types.Pointer{Oid: oid2, Size: 100},
-				Actions: map[string]*types.Link{},
 			},
 		},
-	}, resp)
+		{
+			name:      "download no read access, no write access",
+			operation: types.LFSBatchDownload,
+			exist:     true,
+			err:       ErrNotFound,
+		},
+		{
+			name:           "download no read access, has write access",
+			operation:      types.LFSBatchDownload,
+			exist:          true,
+			hasWriteAccess: true,
+			err:            ErrNotFound,
+		},
+		{
+			name:          "download file not exist",
+			operation:     types.LFSBatchDownload,
+			exist:         false,
+			hasReadAccess: true,
+			resp: &types.BatchResponse{
+				Objects: []*types.ObjectResponse{
+					{
+						Error: &types.ObjectError{
+							Code:    404,
+							Message: "Object does not exist",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "upload success",
+			operation:      types.LFSBatchUpload,
+			hasWriteAccess: true,
+			resp: &types.BatchResponse{
+				Objects: []*types.ObjectResponse{
+					{
+						Pointer: types.Pointer{Oid: notExistOID, Size: 100},
+						Actions: map[string]*types.Link{
+							"upload": {
+								Href:   "https://foo.com/models/ns/n.git/info/lfs/objects/" + notExistOID + "/100",
+								Header: map[string]string{},
+							},
+							"verify": {
+								Href: "https://foo.com/models/ns/n.git/info/lfs/verify",
+								Header: map[string]string{
+									"Accept": "application/vnd.git-lfs+json",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "upload no read access, no write access",
+			operation: types.LFSBatchUpload,
+			err:       ErrNotFound,
+		},
+		{
+			name:          "upload has read access, no write access",
+			operation:     types.LFSBatchUpload,
+			hasReadAccess: true,
+			err:           ErrForbidden,
+		},
+		{
+			name:           "upload file exist",
+			operation:      types.LFSBatchUpload,
+			hasWriteAccess: true,
+			exist:          true,
+			resp: &types.BatchResponse{
+				Objects: nil,
+			},
+		},
+	}
 
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.TODO()
+			gc := initializeTestGitHTTPComponent(ctx, t)
+			oid := existOID
+			if !c.exist {
+				oid = notExistOID
+			}
+			path := path.Join(oid[0:2], oid[2:4], oid[4:])
+
+			gc.mocks.stores.RepoMock().EXPECT().FindByPath(
+				ctx, types.ModelRepo, "ns", "n",
+			).Return(&database.Repository{
+				ID:      123,
+				Private: true,
+			}, nil).Maybe()
+
+			gc.mocks.components.repo.EXPECT().AllowReadAccess(
+				ctx, types.ModelRepo, "ns", "n", "user",
+			).Return(c.hasReadAccess, nil).Maybe()
+			gc.mocks.components.repo.EXPECT().AllowWriteAccess(
+				ctx, types.ModelRepo, "ns", "n", "user",
+			).Return(c.hasWriteAccess, nil).Maybe()
+			gc.mocks.stores.LfsMetaObjectMock().EXPECT().FindByRepoID(ctx, int64(123)).Return(
+				[]database.LfsMetaObject{{
+					Oid: existOID,
+				}}, nil,
+			).Maybe()
+			if c.operation == types.LFSBatchDownload {
+				reqParams := make(url.Values)
+				url := &url.URL{Scheme: "http", Host: "foo.com", Path: "bar"}
+				gc.mocks.s3Client.EXPECT().PresignedGetObject(
+					ctx, "", "lfs/"+path, types.OssFileExpire, reqParams,
+				).Return(url, nil).Maybe()
+			}
+
+			resp, err := gc.LFSBatch(ctx, types.BatchRequest{
+				Operation:   c.operation,
+				Namespace:   "ns",
+				Name:        "n",
+				RepoType:    types.ModelRepo,
+				CurrentUser: "user",
+				Objects: []types.Pointer{
+					{Oid: oid, Size: 100},
+				},
+			})
+			if err != nil {
+				require.ErrorIs(t, err, c.err)
+			} else {
+				require.Equal(t, c.resp, resp)
+			}
+		})
+	}
 }
 
 func TestGitHTTPComponent_LfsUpload(t *testing.T) {
@@ -207,6 +291,11 @@ func TestGitHTTPComponent_LfsUpload(t *testing.T) {
 
 			rc := io.NopCloser(&io.LimitedReader{})
 			oid := "a3f8e1b4f77bb24e508906c6972f81928f0d926e6daef1b29d12e348b8a3547e"
+			var size int64 = 100
+			if exist {
+				oid = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+				size = 0
+			}
 			gc.mocks.stores.RepoMock().EXPECT().FindByPath(
 				ctx, types.ModelRepo, "ns", "n",
 			).Return(&database.Repository{
@@ -216,10 +305,10 @@ func TestGitHTTPComponent_LfsUpload(t *testing.T) {
 			if exist {
 				gc.mocks.s3Client.EXPECT().StatObject(
 					ctx, "",
-					"lfs/a3/f8/e1b4f77bb24e508906c6972f81928f0d926e6daef1b29d12e348b8a3547e",
+					"lfs/e3/b0/c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					minio.StatObjectOptions{},
 				).Return(
-					minio.ObjectInfo{Size: 100}, nil,
+					minio.ObjectInfo{Size: size}, nil,
 				)
 			} else {
 				gc.mocks.s3Client.EXPECT().StatObject(
@@ -242,7 +331,7 @@ func TestGitHTTPComponent_LfsUpload(t *testing.T) {
 
 				gc.mocks.stores.LfsMetaObjectMock().EXPECT().Create(ctx, database.LfsMetaObject{
 					Oid:          oid,
-					Size:         100,
+					Size:         size,
 					RepositoryID: 123,
 					Existing:     true,
 				}).Return(nil, nil)
@@ -250,7 +339,7 @@ func TestGitHTTPComponent_LfsUpload(t *testing.T) {
 
 			err := gc.LfsUpload(ctx, rc, types.UploadRequest{
 				Oid:         oid,
-				Size:        100,
+				Size:        size,
 				CurrentUser: "user",
 				Namespace:   "ns",
 				Name:        "n",
@@ -260,29 +349,51 @@ func TestGitHTTPComponent_LfsUpload(t *testing.T) {
 		})
 	}
 
+	t.Run("exist but sha256 not match", func(t *testing.T) {
+		ctx := context.TODO()
+		gc := initializeTestGitHTTPComponent(ctx, t)
+
+		rc := io.NopCloser(&io.LimitedReader{})
+		oid := "a3f8e1b4f77bb24e508906c6972f81928f0d926e6daef1b29d12e348b8a3547e"
+		var size int64
+
+		gc.mocks.stores.RepoMock().EXPECT().FindByPath(
+			ctx, types.ModelRepo, "ns", "n",
+		).Return(&database.Repository{
+			ID:      123,
+			Private: true,
+		}, nil)
+		gc.mocks.s3Client.EXPECT().StatObject(
+			ctx, "",
+			"lfs/a3/f8/e1b4f77bb24e508906c6972f81928f0d926e6daef1b29d12e348b8a3547e",
+			minio.StatObjectOptions{},
+		).Return(
+			minio.ObjectInfo{Size: size}, nil,
+		)
+		gc.mocks.components.repo.EXPECT().AllowWriteAccess(
+			ctx, types.ModelRepo, "ns", "n", "user",
+		).Return(true, nil)
+
+		err := gc.LfsUpload(ctx, rc, types.UploadRequest{
+			Oid:         oid,
+			Size:        size,
+			CurrentUser: "user",
+			Namespace:   "ns",
+			Name:        "n",
+			RepoType:    types.ModelRepo,
+		})
+		require.Equal(t, "invalid lfs size or oid", err.Error())
+	})
+
 }
 
 func TestGitHTTPComponent_LfsVerify(t *testing.T) {
 	ctx := context.TODO()
 	gc := initializeTestGitHTTPComponent(ctx, t)
 
-	gc.mocks.stores.RepoMock().EXPECT().FindByPath(
-		ctx, types.ModelRepo, "ns", "n",
-	).Return(&database.Repository{
-		ID:      123,
-		Private: true,
-	}, nil)
-
 	gc.mocks.s3Client.EXPECT().StatObject(ctx, "", "lfs/oid", minio.StatObjectOptions{}).Return(
 		minio.ObjectInfo{Size: 100}, nil,
 	)
-	gc.mocks.stores.LfsMetaObjectMock().EXPECT().FindByOID(ctx, int64(123), "oid").Return(nil, sql.ErrNoRows)
-	gc.mocks.stores.LfsMetaObjectMock().EXPECT().Create(ctx, database.LfsMetaObject{
-		Oid:          "oid",
-		Size:         100,
-		RepositoryID: 123,
-		Existing:     true,
-	}).Return(nil, nil)
 
 	err := gc.LfsVerify(ctx, types.VerifyRequest{
 		CurrentUser: "user",


### PR DESCRIPTION
### **LFS API Security Issues**  
- **LFS Batch - Download Info**: Previously, the repository permissions were not checked before providing download links.  
- **LFS Batch - Upload Info**: If the file already existed in MinIO, it skipped the SHA-256 checksum validation and directly created an `lfsMetaObject`.  
- **LFS Verify**: If the file existed in MinIO, it directly created an `lfsMetaObject` based on the user's request.  

### **Refactor Details**  

The refactor follows GitLab's implementation, making the logic almost identical.  

#### **GitLab LFS Batch API Logic**  
- **Repository Permission Check:**  
  - **Download:** Allowed if the user has `read` permission.  
  - **Upload:** Allowed if the user has `write` permission.  
  - If neither condition is met:  
    - If the user has `read` access, return **403 Forbidden**.  
    - If the user has no access, return **404 Not Found** to prevent information leakage about file existence.  
  - [GitLab LFS Batch Permission Check Code](https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/app/controllers/concerns/lfs_request.rb#L40)

- **Batch API Response:**  
  - **Download:**  
    - Retrieve all LFS OIDs for the repository.  
    - Iterate over the requested objects:  
      - If the object exists in the repository, return the download link.  
      - If not, return **404 Not Found**.  
    - [GitLab LFS Batch Download Code](https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/app/controllers/repositories/lfs_api_controller.rb#L58)

  - **Upload:**  
    - Retrieve all LFS OIDs for the repository.  
    - Iterate over the requested objects:  
      - If the object exists in the repository, skip it.  
      - If it does not exist, return an upload link.  
    - No Verify logic exists in GitLab.
    - [GitLab LFS Batch Upload Code](https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/app/controllers/repositories/lfs_api_controller.rb#L81)

### **PR Changes**  
- Refactored the **LFS Batch** logic in the `GitHTTP` component to match GitLab's behavior.  
  - Removed the automatic creation of `lfsMetaObject` when the file exists in MinIO.  
  - Improved test coverage.  
- **LFS Upload:**  
  - Even if the file exists in MinIO, it must still be uploaded to perform SHA-256 checksum validation.  
- **LFS Verify:**  
  - Removed `lfsMetaObject` creation logic.  
  - Now, only performs file size verification (since `lfsMetaObject` creation is handled during upload).  
  - This logic does not exist in GitLab. Reference from Gitea:  [VerifyHandler](https://github.com/go-gitea/gitea/blob/main/services/lfs/server.go#L358) - [Verify](https://github.com/go-gitea/gitea/blob/063c23e1bcf52fde5bda82d0c1dbe7dd04e2771f/modules/lfs/content_store.go#L93)