### PR TITLE
Fix LFS batch API auth incorrect status code 

### DIFF
--- a/builder/git/gitserver/gitaly/file.go
+++ b/builder/git/gitserver/gitaly/file.go
@@ -644,9 +644,10 @@ func (c *Client) GetTree(ctx context.Context, req types.GetTreeRequest) (*types.
 			if err == io.EOF {
 				break
 			}
+			return nil, err
 		}
 		if treeEntries == nil {
-			return nil, errors.New("bad request")
+			return nil, errors.New("GetTreeEntries API invalid response")
 		}
 		cursor = treeEntries.PaginationCursor.GetNextCursor()
 		entries := treeEntries.Entries

--- a/component/git_http.go
+++ b/component/git_http.go
@@ -266,6 +266,9 @@ func (c *gitHTTPComponentImpl) lfsBatchUploadInfo(ctx context.Context, req types
 func (c *gitHTTPComponentImpl) lfsCheckAccess(ctx context.Context, req types.BatchRequest) error {
 	switch req.Operation {
 	case types.LFSBatchUpload:
+		if req.CurrentUser == "" {
+			return ErrUnauthorized
+		}
 		allowWrite, err := c.repoComponent.AllowWriteAccess(
 			ctx, req.RepoType, req.Namespace, req.Name, req.CurrentUser,
 		)

--- a/component/git_http.go
+++ b/component/git_http.go
@@ -290,6 +290,9 @@ func (c *gitHTTPComponentImpl) lfsCheckAccess(ctx context.Context, req types.Bat
 			ctx, req.RepoType, req.Namespace, req.Name, req.CurrentUser,
 		)
 		if err != nil {
+			if errors.Is(err, ErrUserNotFound) && req.CurrentUser == "" {
+				err = ErrUnauthorized
+			}
 			return err
 		}
 		if !allowRead {


### PR DESCRIPTION
When the repository is cloned using HTTP/HTTPS and no token is provided, the LFS batch API will initially make a request without including authentication information. If the server responds with a 401 status code, Git LFS will automatically fetch the auth information and update the repository's `.git/config` file as follows:
```
[lfs "https://xxx.com/repos/xxx/xxx.git/info/lfs"]
	access = basic
```
After that, subsequent batch API requests will automatically include the auth information.

Therefore, if a batch request does not include authentication but requires it (e.g., for uploading or accessing a private repository), the server must return a 401 status code.