### PR TITLE
Add minio BucketLookup config

### DIFF
--- a/builder/store/s3/minio_ce.go
+++ b/builder/store/s3/minio_ce.go
@@ -20,11 +20,23 @@ type minioClient struct {
 	internalClient *minio.Client
 }
 
+var bucketLookupMapping = map[string]minio.BucketLookupType{
+	"auto": minio.BucketLookupAuto,
+	"dns":  minio.BucketLookupDNS,
+	"path": minio.BucketLookupPath,
+}
+
 func NewMinio(cfg *config.Config) (Client, error) {
+	var bucketLookupType minio.BucketLookupType
+	if val, ok := bucketLookupMapping[cfg.S3.BucketLookup]; ok {
+		bucketLookupType = val
+	} else {
+		bucketLookupType = minio.BucketLookupAuto
+	}
 	mClient, err := minio.New(cfg.S3.Endpoint, &minio.Options{
 		Creds:        credentials.NewStaticV4(cfg.S3.AccessKeyID, cfg.S3.AccessKeySecret, ""),
 		Secure:       cfg.S3.EnableSSL,
-		BucketLookup: minio.BucketLookupAuto,
+		BucketLookup: bucketLookupType,
 		Region:       cfg.S3.Region,
 	})
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**

Add minio BucketLookup config

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request introduces a new feature to configure Minio bucket lookup types dynamically in the application. It adds a mapping for bucket lookup types (`auto`, `dns`, `path`) and updates the `NewMinio` function to use this mapping based on the configuration provided. This allows for more flexible Minio client behavior, accommodating different deployment environments or requirements.

Key updates:
1. Added a `bucketLookupMapping` to map string identifiers to Minio's `BucketLookupType`.
2. Modified the `NewMinio` function to dynamically set the `BucketLookup` option based on the application's configuration.

<!-- @codegpt description end -->