### PR TITLE
Fix runner

### DIFF
--- a/runner/component/service.go
+++ b/runner/component/service.go
@@ -554,6 +554,12 @@ func (s *serviceComponentImpl) GetServiceStatus(ctx context.Context, ks v1.Servi
 		}
 	case serviceCondition.Status == corev1.ConditionFalse:
 		resp.Code = common.DeployFailed
+		for _, instance := range instList {
+			if instance.Status == string(corev1.PodRunning) || instance.Status == string(corev1.PodPending) {
+				resp.Code = common.Deploying
+				break
+			}
+		}
 	}
 	resp.Instances = instList
 	return resp, err

--- a/runner/handler/service.go
+++ b/runner/handler/service.go
@@ -121,8 +121,16 @@ func (s *K8sHandler) ServiceStatus(c *gin.Context) {
 	srvName := s.getServiceNameFromRequest(c)
 	resp, err := s.serviceCompoent.GetServiceByName(c.Request.Context(), srvName, request.ClusterID)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			resp = &types.StatusResponse{}
+			resp.Code = common.Stopped
+			resp.Message = "service was deleted"
+			c.JSON(http.StatusOK, resp)
+			return
+		}
 		slog.Error("failed to get service", slog.Any("error", err), slog.String("srv_name", srvName))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get service"})
+		return
 	}
 	c.JSON(http.StatusOK, resp)
 }


### PR DESCRIPTION
**What is this feature?**

fix deploy status issue: pending deployment will be treat as failed service

**Why do we need this feature?**

model as service

**Who is this feature for?**

csghub user

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

This Merge Request addresses a bug in the deployment status handling by treating pending deployments as failed services. It modifies the service component to update the deployment status based on pod status, ensuring that running or pending instances are correctly marked as deploying. Additionally, it updates the service handler to handle cases where a service has been deleted, providing a more accurate status response.

Key updates:
1. Fixed deployment status issue by adjusting the condition to mark services as deploying if any instances are running or pending.
2. Enhanced service status handling in the handler to return a specific response when a service has been deleted, improving the accuracy of service status reports.

<!-- @codegpt description end -->