### PR TITLE
AllTags api support filter

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_TagStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_TagStore.go
@@ -25,7 +25,7 @@ func (_m *MockTagStore) EXPECT() *MockTagStore_Expecter {
 }
 
 // AllCategories provides a mock function with given fields: ctx, scope
-func (_m *MockTagStore) AllCategories(ctx context.Context, scope database.TagScope) ([]database.TagCategory, error) {
+func (_m *MockTagStore) AllCategories(ctx context.Context, scope types.TagScope) ([]database.TagCategory, error) {
 	ret := _m.Called(ctx, scope)
 
 	if len(ret) == 0 {
@@ -34,10 +34,10 @@ func (_m *MockTagStore) AllCategories(ctx context.Context, scope database.TagSco
 
 	var r0 []database.TagCategory
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope) ([]database.TagCategory, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.TagScope) ([]database.TagCategory, error)); ok {
 		return rf(ctx, scope)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope) []database.TagCategory); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.TagScope) []database.TagCategory); ok {
 		r0 = rf(ctx, scope)
 	} else {
 		if ret.Get(0) != nil {
@@ -45,7 +45,7 @@ func (_m *MockTagStore) AllCategories(ctx context.Context, scope database.TagSco
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, database.TagScope) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, types.TagScope) error); ok {
 		r1 = rf(ctx, scope)
 	} else {
 		r1 = ret.Error(1)
@@ -61,14 +61,14 @@ type MockTagStore_AllCategories_Call struct {
 
 // AllCategories is a helper method to define mock.On call
 //   - ctx context.Context
-//   - scope database.TagScope
+//   - scope types.TagScope
 func (_e *MockTagStore_Expecter) AllCategories(ctx interface{}, scope interface{}) *MockTagStore_AllCategories_Call {
 	return &MockTagStore_AllCategories_Call{Call: _e.mock.On("AllCategories", ctx, scope)}
 }
 
-func (_c *MockTagStore_AllCategories_Call) Run(run func(ctx context.Context, scope database.TagScope)) *MockTagStore_AllCategories_Call {
+func (_c *MockTagStore_AllCategories_Call) Run(run func(ctx context.Context, scope types.TagScope)) *MockTagStore_AllCategories_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(database.TagScope))
+		run(args[0].(context.Context), args[1].(types.TagScope))
 	})
 	return _c
 }
@@ -78,7 +78,7 @@ func (_c *MockTagStore_AllCategories_Call) Return(_a0 []database.TagCategory, _a
 	return _c
 }
 
-func (_c *MockTagStore_AllCategories_Call) RunAndReturn(run func(context.Context, database.TagScope) ([]database.TagCategory, error)) *MockTagStore_AllCategories_Call {
+func (_c *MockTagStore_AllCategories_Call) RunAndReturn(run func(context.Context, types.TagScope) ([]database.TagCategory, error)) *MockTagStore_AllCategories_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -663,29 +663,29 @@ func (_c *MockTagStore_AllSpaceTags_Call) RunAndReturn(run func(context.Context)
 	return _c
 }
 
-// AllTags provides a mock function with given fields: ctx
-func (_m *MockTagStore) AllTags(ctx context.Context) ([]database.Tag, error) {
-	ret := _m.Called(ctx)
+// AllTags provides a mock function with given fields: ctx, filter
+func (_m *MockTagStore) AllTags(ctx context.Context, filter *types.TagFilter) ([]*database.Tag, error) {
+	ret := _m.Called(ctx, filter)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AllTags")
 	}
 
-	var r0 []database.Tag
+	var r0 []*database.Tag
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) ([]database.Tag, error)); ok {
-		return rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, *types.TagFilter) ([]*database.Tag, error)); ok {
+		return rf(ctx, filter)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context) []database.Tag); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, *types.TagFilter) []*database.Tag); ok {
+		r0 = rf(ctx, filter)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Tag)
+			r0 = ret.Get(0).([]*database.Tag)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func(context.Context, *types.TagFilter) error); ok {
+		r1 = rf(ctx, filter)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -700,142 +700,24 @@ type MockTagStore_AllTags_Call struct {
 
 // AllTags is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockTagStore_Expecter) AllTags(ctx interface{}) *MockTagStore_AllTags_Call {
-	return &MockTagStore_AllTags_Call{Call: _e.mock.On("AllTags", ctx)}
+//   - filter *types.TagFilter
+func (_e *MockTagStore_Expecter) AllTags(ctx interface{}, filter interface{}) *MockTagStore_AllTags_Call {
+	return &MockTagStore_AllTags_Call{Call: _e.mock.On("AllTags", ctx, filter)}
 }
 
-func (_c *MockTagStore_AllTags_Call) Run(run func(ctx context.Context)) *MockTagStore_AllTags_Call {
+func (_c *MockTagStore_AllTags_Call) Run(run func(ctx context.Context, filter *types.TagFilter)) *MockTagStore_AllTags_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		run(args[0].(context.Context), args[1].(*types.TagFilter))
 	})
 	return _c
 }
 
-func (_c *MockTagStore_AllTags_Call) Return(_a0 []database.Tag, _a1 error) *MockTagStore_AllTags_Call {
+func (_c *MockTagStore_AllTags_Call) Return(_a0 []*database.Tag, _a1 error) *MockTagStore_AllTags_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockTagStore_AllTags_Call) RunAndReturn(run func(context.Context) ([]database.Tag, error)) *MockTagStore_AllTags_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// AllTagsByScope provides a mock function with given fields: ctx, scope
-func (_m *MockTagStore) AllTagsByScope(ctx context.Context, scope database.TagScope) ([]*database.Tag, error) {
-	ret := _m.Called(ctx, scope)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AllTagsByScope")
-	}
-
-	var r0 []*database.Tag
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope) ([]*database.Tag, error)); ok {
-		return rf(ctx, scope)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope) []*database.Tag); ok {
-		r0 = rf(ctx, scope)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*database.Tag)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, database.TagScope) error); ok {
-		r1 = rf(ctx, scope)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockTagStore_AllTagsByScope_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllTagsByScope'
-type MockTagStore_AllTagsByScope_Call struct {
-	*mock.Call
-}
-
-// AllTagsByScope is a helper method to define mock.On call
-//   - ctx context.Context
-//   - scope database.TagScope
-func (_e *MockTagStore_Expecter) AllTagsByScope(ctx interface{}, scope interface{}) *MockTagStore_AllTagsByScope_Call {
-	return &MockTagStore_AllTagsByScope_Call{Call: _e.mock.On("AllTagsByScope", ctx, scope)}
-}
-
-func (_c *MockTagStore_AllTagsByScope_Call) Run(run func(ctx context.Context, scope database.TagScope)) *MockTagStore_AllTagsByScope_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(database.TagScope))
-	})
-	return _c
-}
-
-func (_c *MockTagStore_AllTagsByScope_Call) Return(_a0 []*database.Tag, _a1 error) *MockTagStore_AllTagsByScope_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockTagStore_AllTagsByScope_Call) RunAndReturn(run func(context.Context, database.TagScope) ([]*database.Tag, error)) *MockTagStore_AllTagsByScope_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// AllTagsByScopeAndCategory provides a mock function with given fields: ctx, scope, category
-func (_m *MockTagStore) AllTagsByScopeAndCategory(ctx context.Context, scope database.TagScope, category string) ([]*database.Tag, error) {
-	ret := _m.Called(ctx, scope, category)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AllTagsByScopeAndCategory")
-	}
-
-	var r0 []*database.Tag
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope, string) ([]*database.Tag, error)); ok {
-		return rf(ctx, scope, category)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope, string) []*database.Tag); ok {
-		r0 = rf(ctx, scope, category)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*database.Tag)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, database.TagScope, string) error); ok {
-		r1 = rf(ctx, scope, category)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockTagStore_AllTagsByScopeAndCategory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllTagsByScopeAndCategory'
-type MockTagStore_AllTagsByScopeAndCategory_Call struct {
-	*mock.Call
-}
-
-// AllTagsByScopeAndCategory is a helper method to define mock.On call
-//   - ctx context.Context
-//   - scope database.TagScope
-//   - category string
-func (_e *MockTagStore_Expecter) AllTagsByScopeAndCategory(ctx interface{}, scope interface{}, category interface{}) *MockTagStore_AllTagsByScopeAndCategory_Call {
-	return &MockTagStore_AllTagsByScopeAndCategory_Call{Call: _e.mock.On("AllTagsByScopeAndCategory", ctx, scope, category)}
-}
-
-func (_c *MockTagStore_AllTagsByScopeAndCategory_Call) Run(run func(ctx context.Context, scope database.TagScope, category string)) *MockTagStore_AllTagsByScopeAndCategory_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(database.TagScope), args[2].(string))
-	})
-	return _c
-}
-
-func (_c *MockTagStore_AllTagsByScopeAndCategory_Call) Return(_a0 []*database.Tag, _a1 error) *MockTagStore_AllTagsByScopeAndCategory_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockTagStore_AllTagsByScopeAndCategory_Call) RunAndReturn(run func(context.Context, database.TagScope, string) ([]*database.Tag, error)) *MockTagStore_AllTagsByScopeAndCategory_Call {
+func (_c *MockTagStore_AllTags_Call) RunAndReturn(run func(context.Context, *types.TagFilter) ([]*database.Tag, error)) *MockTagStore_AllTags_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -900,7 +782,7 @@ func (_c *MockTagStore_CreateCategory_Call) RunAndReturn(run func(context.Contex
 }
 
 // CreateTag provides a mock function with given fields: ctx, category, name, group, scope
-func (_m *MockTagStore) CreateTag(ctx context.Context, category string, name string, group string, scope database.TagScope) (database.Tag, error) {
+func (_m *MockTagStore) CreateTag(ctx context.Context, category string, name string, group string, scope types.TagScope) (database.Tag, error) {
 	ret := _m.Called(ctx, category, name, group, scope)
 
 	if len(ret) == 0 {
@@ -909,16 +791,16 @@ func (_m *MockTagStore) CreateTag(ctx context.Context, category string, name str
 
 	var r0 database.Tag
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, database.TagScope) (database.Tag, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, types.TagScope) (database.Tag, error)); ok {
 		return rf(ctx, category, name, group, scope)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, database.TagScope) database.Tag); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, types.TagScope) database.Tag); ok {
 		r0 = rf(ctx, category, name, group, scope)
 	} else {
 		r0 = ret.Get(0).(database.Tag)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, database.TagScope) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, types.TagScope) error); ok {
 		r1 = rf(ctx, category, name, group, scope)
 	} else {
 		r1 = ret.Error(1)
@@ -937,14 +819,14 @@ type MockTagStore_CreateTag_Call struct {
 //   - category string
 //   - name string
 //   - group string
-//   - scope database.TagScope
+//   - scope types.TagScope
 func (_e *MockTagStore_Expecter) CreateTag(ctx interface{}, category interface{}, name interface{}, group interface{}, scope interface{}) *MockTagStore_CreateTag_Call {
 	return &MockTagStore_CreateTag_Call{Call: _e.mock.On("CreateTag", ctx, category, name, group, scope)}
 }
 
-func (_c *MockTagStore_CreateTag_Call) Run(run func(ctx context.Context, category string, name string, group string, scope database.TagScope)) *MockTagStore_CreateTag_Call {
+func (_c *MockTagStore_CreateTag_Call) Run(run func(ctx context.Context, category string, name string, group string, scope types.TagScope)) *MockTagStore_CreateTag_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(database.TagScope))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(types.TagScope))
 	})
 	return _c
 }
@@ -954,7 +836,7 @@ func (_c *MockTagStore_CreateTag_Call) Return(_a0 database.Tag, _a1 error) *Mock
 	return _c
 }
 
-func (_c *MockTagStore_CreateTag_Call) RunAndReturn(run func(context.Context, string, string, string, database.TagScope) (database.Tag, error)) *MockTagStore_CreateTag_Call {
+func (_c *MockTagStore_CreateTag_Call) RunAndReturn(run func(context.Context, string, string, string, types.TagScope) (database.Tag, error)) *MockTagStore_CreateTag_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1228,66 +1110,6 @@ func (_c *MockTagStore_FindTagByID_Call) Return(_a0 *database.Tag, _a1 error) *M
 }
 
 func (_c *MockTagStore_FindTagByID_Call) RunAndReturn(run func(context.Context, int64) (*database.Tag, error)) *MockTagStore_FindTagByID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetTagsByScopeAndCategories provides a mock function with given fields: ctx, scope, categories
-func (_m *MockTagStore) GetTagsByScopeAndCategories(ctx context.Context, scope database.TagScope, categories []string) ([]*database.Tag, error) {
-	ret := _m.Called(ctx, scope, categories)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetTagsByScopeAndCategories")
-	}
-
-	var r0 []*database.Tag
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope, []string) ([]*database.Tag, error)); ok {
-		return rf(ctx, scope, categories)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope, []string) []*database.Tag); ok {
-		r0 = rf(ctx, scope, categories)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*database.Tag)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, database.TagScope, []string) error); ok {
-		r1 = rf(ctx, scope, categories)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockTagStore_GetTagsByScopeAndCategories_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTagsByScopeAndCategories'
-type MockTagStore_GetTagsByScopeAndCategories_Call struct {
-	*mock.Call
-}
-
-// GetTagsByScopeAndCategories is a helper method to define mock.On call
-//   - ctx context.Context
-//   - scope database.TagScope
-//   - categories []string
-func (_e *MockTagStore_Expecter) GetTagsByScopeAndCategories(ctx interface{}, scope interface{}, categories interface{}) *MockTagStore_GetTagsByScopeAndCategories_Call {
-	return &MockTagStore_GetTagsByScopeAndCategories_Call{Call: _e.mock.On("GetTagsByScopeAndCategories", ctx, scope, categories)}
-}
-
-func (_c *MockTagStore_GetTagsByScopeAndCategories_Call) Run(run func(ctx context.Context, scope database.TagScope, categories []string)) *MockTagStore_GetTagsByScopeAndCategories_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(database.TagScope), args[2].([]string))
-	})
-	return _c
-}
-
-func (_c *MockTagStore_GetTagsByScopeAndCategories_Call) Return(_a0 []*database.Tag, _a1 error) *MockTagStore_GetTagsByScopeAndCategories_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockTagStore_GetTagsByScopeAndCategories_Call) RunAndReturn(run func(context.Context, database.TagScope, []string) ([]*database.Tag, error)) *MockTagStore_GetTagsByScopeAndCategories_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/_mocks/opencsg.com/csghub-server/component/mock_TagComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_TagComponent.go
@@ -82,29 +82,29 @@ func (_c *MockTagComponent_AllCategories_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
-// AllTagsByScopeAndCategory provides a mock function with given fields: ctx, scope, category
-func (_m *MockTagComponent) AllTagsByScopeAndCategory(ctx context.Context, scope string, category string) ([]*database.Tag, error) {
-	ret := _m.Called(ctx, scope, category)
+// AllTags provides a mock function with given fields: ctx, filter
+func (_m *MockTagComponent) AllTags(ctx context.Context, filter *types.TagFilter) ([]*database.Tag, error) {
+	ret := _m.Called(ctx, filter)
 
 	if len(ret) == 0 {
-		panic("no return value specified for AllTagsByScopeAndCategory")
+		panic("no return value specified for AllTags")
 	}
 
 	var r0 []*database.Tag
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) ([]*database.Tag, error)); ok {
-		return rf(ctx, scope, category)
+	if rf, ok := ret.Get(0).(func(context.Context, *types.TagFilter) ([]*database.Tag, error)); ok {
+		return rf(ctx, filter)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) []*database.Tag); ok {
-		r0 = rf(ctx, scope, category)
+	if rf, ok := ret.Get(0).(func(context.Context, *types.TagFilter) []*database.Tag); ok {
+		r0 = rf(ctx, filter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*database.Tag)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, scope, category)
+	if rf, ok := ret.Get(1).(func(context.Context, *types.TagFilter) error); ok {
+		r1 = rf(ctx, filter)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -112,32 +112,31 @@ func (_m *MockTagComponent) AllTagsByScopeAndCategory(ctx context.Context, scope
 	return r0, r1
 }
 
-// MockTagComponent_AllTagsByScopeAndCategory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllTagsByScopeAndCategory'
-type MockTagComponent_AllTagsByScopeAndCategory_Call struct {
+// MockTagComponent_AllTags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllTags'
+type MockTagComponent_AllTags_Call struct {
 	*mock.Call
 }
 
-// AllTagsByScopeAndCategory is a helper method to define mock.On call
+// AllTags is a helper method to define mock.On call
 //   - ctx context.Context
-//   - scope string
-//   - category string
-func (_e *MockTagComponent_Expecter) AllTagsByScopeAndCategory(ctx interface{}, scope interface{}, category interface{}) *MockTagComponent_AllTagsByScopeAndCategory_Call {
-	return &MockTagComponent_AllTagsByScopeAndCategory_Call{Call: _e.mock.On("AllTagsByScopeAndCategory", ctx, scope, category)}
+//   - filter *types.TagFilter
+func (_e *MockTagComponent_Expecter) AllTags(ctx interface{}, filter interface{}) *MockTagComponent_AllTags_Call {
+	return &MockTagComponent_AllTags_Call{Call: _e.mock.On("AllTags", ctx, filter)}
 }
 
-func (_c *MockTagComponent_AllTagsByScopeAndCategory_Call) Run(run func(ctx context.Context, scope string, category string)) *MockTagComponent_AllTagsByScopeAndCategory_Call {
+func (_c *MockTagComponent_AllTags_Call) Run(run func(ctx context.Context, filter *types.TagFilter)) *MockTagComponent_AllTags_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(*types.TagFilter))
 	})
 	return _c
 }
 
-func (_c *MockTagComponent_AllTagsByScopeAndCategory_Call) Return(_a0 []*database.Tag, _a1 error) *MockTagComponent_AllTagsByScopeAndCategory_Call {
+func (_c *MockTagComponent_AllTags_Call) Return(_a0 []*database.Tag, _a1 error) *MockTagComponent_AllTags_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockTagComponent_AllTagsByScopeAndCategory_Call) RunAndReturn(run func(context.Context, string, string) ([]*database.Tag, error)) *MockTagComponent_AllTagsByScopeAndCategory_Call {
+func (_c *MockTagComponent_AllTags_Call) RunAndReturn(run func(context.Context, *types.TagFilter) ([]*database.Tag, error)) *MockTagComponent_AllTags_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -529,7 +528,7 @@ func (_c *MockTagComponent_UpdateCategory_Call) RunAndReturn(run func(context.Co
 }
 
 // UpdateLibraryTags provides a mock function with given fields: ctx, tagScope, namespace, name, oldFilePath, newFilePath
-func (_m *MockTagComponent) UpdateLibraryTags(ctx context.Context, tagScope database.TagScope, namespace string, name string, oldFilePath string, newFilePath string) error {
+func (_m *MockTagComponent) UpdateLibraryTags(ctx context.Context, tagScope types.TagScope, namespace string, name string, oldFilePath string, newFilePath string) error {
 	ret := _m.Called(ctx, tagScope, namespace, name, oldFilePath, newFilePath)
 
 	if len(ret) == 0 {
@@ -537,7 +536,7 @@ func (_m *MockTagComponent) UpdateLibraryTags(ctx context.Context, tagScope data
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope, string, string, string, string) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.TagScope, string, string, string, string) error); ok {
 		r0 = rf(ctx, tagScope, namespace, name, oldFilePath, newFilePath)
 	} else {
 		r0 = ret.Error(0)
@@ -553,7 +552,7 @@ type MockTagComponent_UpdateLibraryTags_Call struct {
 
 // UpdateLibraryTags is a helper method to define mock.On call
 //   - ctx context.Context
-//   - tagScope database.TagScope
+//   - tagScope types.TagScope
 //   - namespace string
 //   - name string
 //   - oldFilePath string
@@ -562,9 +561,9 @@ func (_e *MockTagComponent_Expecter) UpdateLibraryTags(ctx interface{}, tagScope
 	return &MockTagComponent_UpdateLibraryTags_Call{Call: _e.mock.On("UpdateLibraryTags", ctx, tagScope, namespace, name, oldFilePath, newFilePath)}
 }
 
-func (_c *MockTagComponent_UpdateLibraryTags_Call) Run(run func(ctx context.Context, tagScope database.TagScope, namespace string, name string, oldFilePath string, newFilePath string)) *MockTagComponent_UpdateLibraryTags_Call {
+func (_c *MockTagComponent_UpdateLibraryTags_Call) Run(run func(ctx context.Context, tagScope types.TagScope, namespace string, name string, oldFilePath string, newFilePath string)) *MockTagComponent_UpdateLibraryTags_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(database.TagScope), args[2].(string), args[3].(string), args[4].(string), args[5].(string))
+		run(args[0].(context.Context), args[1].(types.TagScope), args[2].(string), args[3].(string), args[4].(string), args[5].(string))
 	})
 	return _c
 }
@@ -574,13 +573,13 @@ func (_c *MockTagComponent_UpdateLibraryTags_Call) Return(_a0 error) *MockTagCom
 	return _c
 }
 
-func (_c *MockTagComponent_UpdateLibraryTags_Call) RunAndReturn(run func(context.Context, database.TagScope, string, string, string, string) error) *MockTagComponent_UpdateLibraryTags_Call {
+func (_c *MockTagComponent_UpdateLibraryTags_Call) RunAndReturn(run func(context.Context, types.TagScope, string, string, string, string) error) *MockTagComponent_UpdateLibraryTags_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateMetaTags provides a mock function with given fields: ctx, tagScope, namespace, name, content
-func (_m *MockTagComponent) UpdateMetaTags(ctx context.Context, tagScope database.TagScope, namespace string, name string, content string) ([]*database.RepositoryTag, error) {
+func (_m *MockTagComponent) UpdateMetaTags(ctx context.Context, tagScope types.TagScope, namespace string, name string, content string) ([]*database.RepositoryTag, error) {
 	ret := _m.Called(ctx, tagScope, namespace, name, content)
 
 	if len(ret) == 0 {
@@ -589,10 +588,10 @@ func (_m *MockTagComponent) UpdateMetaTags(ctx context.Context, tagScope databas
 
 	var r0 []*database.RepositoryTag
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope, string, string, string) ([]*database.RepositoryTag, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.TagScope, string, string, string) ([]*database.RepositoryTag, error)); ok {
 		return rf(ctx, tagScope, namespace, name, content)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope, string, string, string) []*database.RepositoryTag); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.TagScope, string, string, string) []*database.RepositoryTag); ok {
 		r0 = rf(ctx, tagScope, namespace, name, content)
 	} else {
 		if ret.Get(0) != nil {
@@ -600,7 +599,7 @@ func (_m *MockTagComponent) UpdateMetaTags(ctx context.Context, tagScope databas
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, database.TagScope, string, string, string) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, types.TagScope, string, string, string) error); ok {
 		r1 = rf(ctx, tagScope, namespace, name, content)
 	} else {
 		r1 = ret.Error(1)
@@ -616,7 +615,7 @@ type MockTagComponent_UpdateMetaTags_Call struct {
 
 // UpdateMetaTags is a helper method to define mock.On call
 //   - ctx context.Context
-//   - tagScope database.TagScope
+//   - tagScope types.TagScope
 //   - namespace string
 //   - name string
 //   - content string
@@ -624,9 +623,9 @@ func (_e *MockTagComponent_Expecter) UpdateMetaTags(ctx interface{}, tagScope in
 	return &MockTagComponent_UpdateMetaTags_Call{Call: _e.mock.On("UpdateMetaTags", ctx, tagScope, namespace, name, content)}
 }
 
-func (_c *MockTagComponent_UpdateMetaTags_Call) Run(run func(ctx context.Context, tagScope database.TagScope, namespace string, name string, content string)) *MockTagComponent_UpdateMetaTags_Call {
+func (_c *MockTagComponent_UpdateMetaTags_Call) Run(run func(ctx context.Context, tagScope types.TagScope, namespace string, name string, content string)) *MockTagComponent_UpdateMetaTags_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(database.TagScope), args[2].(string), args[3].(string), args[4].(string))
+		run(args[0].(context.Context), args[1].(types.TagScope), args[2].(string), args[3].(string), args[4].(string))
 	})
 	return _c
 }
@@ -636,13 +635,13 @@ func (_c *MockTagComponent_UpdateMetaTags_Call) Return(_a0 []*database.Repositor
 	return _c
 }
 
-func (_c *MockTagComponent_UpdateMetaTags_Call) RunAndReturn(run func(context.Context, database.TagScope, string, string, string) ([]*database.RepositoryTag, error)) *MockTagComponent_UpdateMetaTags_Call {
+func (_c *MockTagComponent_UpdateMetaTags_Call) RunAndReturn(run func(context.Context, types.TagScope, string, string, string) ([]*database.RepositoryTag, error)) *MockTagComponent_UpdateMetaTags_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateRepoTagsByCategory provides a mock function with given fields: ctx, tagScope, repoID, category, tagNames
-func (_m *MockTagComponent) UpdateRepoTagsByCategory(ctx context.Context, tagScope database.TagScope, repoID int64, category string, tagNames []string) error {
+func (_m *MockTagComponent) UpdateRepoTagsByCategory(ctx context.Context, tagScope types.TagScope, repoID int64, category string, tagNames []string) error {
 	ret := _m.Called(ctx, tagScope, repoID, category, tagNames)
 
 	if len(ret) == 0 {
@@ -650,7 +649,7 @@ func (_m *MockTagComponent) UpdateRepoTagsByCategory(ctx context.Context, tagSco
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, database.TagScope, int64, string, []string) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.TagScope, int64, string, []string) error); ok {
 		r0 = rf(ctx, tagScope, repoID, category, tagNames)
 	} else {
 		r0 = ret.Error(0)
@@ -666,7 +665,7 @@ type MockTagComponent_UpdateRepoTagsByCategory_Call struct {
 
 // UpdateRepoTagsByCategory is a helper method to define mock.On call
 //   - ctx context.Context
-//   - tagScope database.TagScope
+//   - tagScope types.TagScope
 //   - repoID int64
 //   - category string
 //   - tagNames []string
@@ -674,9 +673,9 @@ func (_e *MockTagComponent_Expecter) UpdateRepoTagsByCategory(ctx interface{}, t
 	return &MockTagComponent_UpdateRepoTagsByCategory_Call{Call: _e.mock.On("UpdateRepoTagsByCategory", ctx, tagScope, repoID, category, tagNames)}
 }
 
-func (_c *MockTagComponent_UpdateRepoTagsByCategory_Call) Run(run func(ctx context.Context, tagScope database.TagScope, repoID int64, category string, tagNames []string)) *MockTagComponent_UpdateRepoTagsByCategory_Call {
+func (_c *MockTagComponent_UpdateRepoTagsByCategory_Call) Run(run func(ctx context.Context, tagScope types.TagScope, repoID int64, category string, tagNames []string)) *MockTagComponent_UpdateRepoTagsByCategory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(database.TagScope), args[2].(int64), args[3].(string), args[4].([]string))
+		run(args[0].(context.Context), args[1].(types.TagScope), args[2].(int64), args[3].(string), args[4].([]string))
 	})
 	return _c
 }
@@ -686,7 +685,7 @@ func (_c *MockTagComponent_UpdateRepoTagsByCategory_Call) Return(_a0 error) *Moc
 	return _c
 }
 
-func (_c *MockTagComponent_UpdateRepoTagsByCategory_Call) RunAndReturn(run func(context.Context, database.TagScope, int64, string, []string) error) *MockTagComponent_UpdateRepoTagsByCategory_Call {
+func (_c *MockTagComponent_UpdateRepoTagsByCategory_Call) RunAndReturn(run func(context.Context, types.TagScope, int64, string, []string) error) *MockTagComponent_UpdateRepoTagsByCategory_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/api/handler/tag.go
+++ b/api/handler/tag.go
@@ -35,18 +35,22 @@ type TagsHandler struct {
 // @Accept       json
 // @Produce      json
 // @Param		 category query string false "category name"
-// @Param		 scope query string false "scope name" Enums(model, dataset)
+// @Param		 scope query string false "scope name" Enums(model, dataset, code, space, prompt)
+// @Param		 built_in query bool false "built_in"
 // @Success      200  {object}  types.ResponseWithTotal{data=[]database.Tag} "tags"
 // @Failure      400  {object}  types.APIBadRequest "Bad request"
 // @Failure      500  {object}  types.APIInternalServerError "Internal server error"
 // @Router       /tags [get]
 func (t *TagsHandler) AllTags(ctx *gin.Context) {
-	//TODO:validate inputs
-	category := ctx.Query("category")
-	scope := ctx.Query("scope")
-	tags, err := t.tag.AllTagsByScopeAndCategory(ctx.Request.Context(), scope, category)
+	filter := new(types.TagFilter)
+	err := ctx.ShouldBindQuery(filter)
 	if err != nil {
-		slog.Error("Failed to load tags", slog.Any("category", category), slog.Any("scope", scope), slog.Any("error", err))
+		httpbase.BadRequest(ctx, err.Error())
+		return
+	}
+	tags, err := t.tag.AllTags(ctx.Request.Context(), filter)
+	if err != nil {
+		slog.Error("Failed to load tags", slog.Any("filter", filter), slog.Any("error", err))
 		httpbase.ServerError(ctx, err)
 		return
 	}

--- a/api/handler/tag_test.go
+++ b/api/handler/tag_test.go
@@ -27,36 +27,81 @@ func NewTestTagHandler(
 }
 
 func TestTagHandler_AllTags(t *testing.T) {
-	var tags []*database.Tag
-	tags = append(tags, &database.Tag{ID: 1, Name: "test1"})
+	t.Run("no builtin", func(t *testing.T) {
+		var tags []*database.Tag
+		tags = append(tags, &database.Tag{ID: 1, Name: "test1"})
 
-	values := url.Values{}
-	values.Add("category", "testcate")
-	values.Add("scope", "testscope")
-	req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
+		values := url.Values{}
+		values.Add("category", "task")
+		values.Add("scope", "model")
+		req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
 
-	hr := httptest.NewRecorder()
-	ginContext, _ := gin.CreateTestContext(hr)
-	ginContext.Request = req
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
 
-	tagComp := mockcom.NewMockTagComponent(t)
-	tagComp.EXPECT().AllTagsByScopeAndCategory(ginContext.Request.Context(), "testscope", "testcate").Return(tags, nil)
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagComp.EXPECT().AllTags(ginContext.Request.Context(), &types.TagFilter{
+			Scopes:     []types.TagScope{types.TagScope("model")},
+			Categories: []string{"task"},
+			BuiltIn:    nil,
+		}).Return(tags, nil)
 
-	tagHandler, err := NewTestTagHandler(tagComp)
-	require.Nil(t, err)
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
 
-	tagHandler.AllTags(ginContext)
+		tagHandler.AllTags(ginContext)
 
-	require.Equal(t, http.StatusOK, hr.Code)
+		require.Equal(t, http.StatusOK, hr.Code, hr.Body.String())
 
-	var resp httpbase.R
+		var resp httpbase.R
 
-	err = json.Unmarshal(hr.Body.Bytes(), &resp)
-	require.Nil(t, err)
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
 
-	require.Equal(t, 0, resp.Code)
-	require.Equal(t, "", resp.Msg)
-	require.NotNil(t, resp.Data)
+		require.Equal(t, 0, resp.Code)
+		require.Equal(t, "", resp.Msg)
+		require.NotNil(t, resp.Data)
+	})
+
+	t.Run("with builtin", func(t *testing.T) {
+		var tags []*database.Tag
+		tags = append(tags, &database.Tag{ID: 1, Name: "test1"})
+
+		values := url.Values{}
+		values.Add("category", "task")
+		values.Add("scope", "model")
+		values.Add("built_in", "true")
+		req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		builtin := true
+		tagComp.EXPECT().AllTags(ginContext.Request.Context(), &types.TagFilter{
+			Scopes:     []types.TagScope{types.TagScope("model")},
+			Categories: []string{"task"},
+			BuiltIn:    &builtin,
+		}).Return(tags, nil)
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+
+		require.Equal(t, http.StatusOK, hr.Code, hr.Body.String())
+
+		var resp httpbase.R
+
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
+
+		require.Equal(t, 0, resp.Code)
+		require.Equal(t, "", resp.Msg)
+		require.NotNil(t, resp.Data)
+	})
 }
 
 func TestTagHandler_CreateTag(t *testing.T) {
@@ -198,7 +243,7 @@ func TestTagHandler_DeleteTag(t *testing.T) {
 
 func TestTagHandler_AllCategories(t *testing.T) {
 	var categories []database.TagCategory
-	categories = append(categories, database.TagCategory{ID: 1, Name: "test1", Scope: database.TagScope("scope")})
+	categories = append(categories, database.TagCategory{ID: 1, Name: "test1", Scope: types.TagScope("scope")})
 
 	req := httptest.NewRequest("get", "/tags/categories", nil)
 
@@ -244,7 +289,7 @@ func TestTagHandler_CreateCategory(t *testing.T) {
 
 	tagComp := mockcom.NewMockTagComponent(t)
 	tagComp.EXPECT().CreateCategory(ginContext.Request.Context(), username, data).Return(
-		&database.TagCategory{ID: 1, Name: "testcate", Scope: database.TagScope("testscope")},
+		&database.TagCategory{ID: 1, Name: "testcate", Scope: types.TagScope("testscope")},
 		nil,
 	)
 
@@ -284,7 +329,7 @@ func TestTagHandler_UpdateCategory(t *testing.T) {
 
 	tagComp := mockcom.NewMockTagComponent(t)
 	tagComp.EXPECT().UpdateCategory(ginContext.Request.Context(), username, data, int64(1)).Return(
-		&database.TagCategory{ID: 1, Name: "testcate", Scope: database.TagScope("testscope")},
+		&database.TagCategory{ID: 1, Name: "testcate", Scope: types.TagScope("testscope")},
 		nil,
 	)
 

--- a/builder/store/database/prompt_test.go
+++ b/builder/store/database/prompt_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/tests"
+	"opencsg.com/csghub-server/common/types"
 )
 
 func TestPromptStore_Create(t *testing.T) {
@@ -153,7 +154,7 @@ func TestPromptStore_FindByPath(t *testing.T) {
 		if n == "b" {
 			c = 1
 		}
-		tag, err := ts.CreateTag(ctx, "foo", n, n, database.DatasetTagScope)
+		tag, err := ts.CreateTag(ctx, "foo", n, n, types.DatasetTagScope)
 		require.Nil(t, err)
 		tags = append(tags, database.RepositoryTag{
 			RepositoryID: repo.ID,

--- a/builder/store/database/repository_test.go
+++ b/builder/store/database/repository_test.go
@@ -297,7 +297,7 @@ func TestRepoStore_PublicToUserSimple(t *testing.T) {
 		Name:     "tag_" + uuid.NewString(),
 		Category: "evaluation",
 		Group:    "",
-		Scope:    database.DatasetTagScope,
+		Scope:    types.DatasetTagScope,
 		BuiltIn:  true,
 		ShowName: "",
 	})
@@ -305,7 +305,7 @@ func TestRepoStore_PublicToUserSimple(t *testing.T) {
 		Name:     "tag_" + uuid.NewString(),
 		Category: "runtime_framework",
 		Group:    "",
-		Scope:    database.DatasetTagScope,
+		Scope:    types.DatasetTagScope,
 		BuiltIn:  true,
 		ShowName: "",
 	})

--- a/common/types/tag.go
+++ b/common/types/tag.go
@@ -44,3 +44,19 @@ type CreateCategory struct {
 }
 
 type UpdateCategory CreateCategory
+
+type TagScope string
+
+const (
+	ModelTagScope   TagScope = "model"
+	DatasetTagScope TagScope = "dataset"
+	CodeTagScope    TagScope = "code"
+	SpaceTagScope   TagScope = "space"
+	PromptTagScope  TagScope = "prompt"
+)
+
+type TagFilter struct {
+	Scopes     []TagScope `form:"scope" binding:"omitempty,dive,eq=model|eq=dataset|eq=code|eq=space|eq=prompt"`
+	Categories []string   `form:"category" binding:"omitempty,dive"`
+	BuiltIn    *bool      `form:"built_in" binding:"omitnil"`
+}

--- a/component/callback/git_callback.go
+++ b/component/callback/git_callback.go
@@ -255,20 +255,20 @@ func (c *gitCallbackComponentImpl) removeFiles(ctx context.Context, repoType, na
 				return fmt.Errorf("failed to clear met tags,cause: %w", err)
 			}
 		} else {
-			var tagScope database.TagScope
+			var tagScope types.TagScope
 			switch repoType {
 			case fmt.Sprintf("%ss", types.DatasetRepo):
-				tagScope = database.DatasetTagScope
+				tagScope = types.DatasetTagScope
 			case fmt.Sprintf("%ss", types.ModelRepo):
-				tagScope = database.ModelTagScope
+				tagScope = types.ModelTagScope
 			case fmt.Sprintf("%ss", types.PromptRepo):
-				tagScope = database.PromptTagScope
+				tagScope = types.PromptTagScope
 			default:
 				return nil
 				// case CodeRepoType:
-				// 	tagScope = database.CodeTagScope
+				// 	tagScope = types.CodeTagScope
 				// case SpaceRepoType:
-				// 	tagScope = database.SpaceTagScope
+				// 	tagScope = types.SpaceTagScope
 			}
 			err := c.tagComponent.UpdateLibraryTags(ctx, tagScope, namespace, repoName, fileName, "")
 			if err != nil {
@@ -298,20 +298,20 @@ func (c *gitCallbackComponentImpl) addFiles(ctx context.Context, repoType, names
 				return err
 			}
 		} else {
-			var tagScope database.TagScope
+			var tagScope types.TagScope
 			switch repoType {
 			case fmt.Sprintf("%ss", types.DatasetRepo):
-				tagScope = database.DatasetTagScope
+				tagScope = types.DatasetTagScope
 			case fmt.Sprintf("%ss", types.ModelRepo):
-				tagScope = database.ModelTagScope
+				tagScope = types.ModelTagScope
 			case fmt.Sprintf("%ss", types.PromptRepo):
-				tagScope = database.PromptTagScope
+				tagScope = types.PromptTagScope
 			default:
 				return nil
 				// case CodeRepoType:
-				// 	tagScope = database.CodeTagScope
+				// 	tagScope = types.CodeTagScope
 				// case SpaceRepoType:
-				// 	tagScope = database.SpaceTagScope
+				// 	tagScope = types.SpaceTagScope
 			}
 			err := c.tagComponent.UpdateLibraryTags(ctx, tagScope, namespace, repoName, "", fileName)
 			if err != nil {
@@ -328,22 +328,22 @@ func (c *gitCallbackComponentImpl) addFiles(ctx context.Context, repoType, names
 func (c *gitCallbackComponentImpl) updateMetaTags(ctx context.Context, repoType, namespace, repoName, ref, content string) error {
 	var (
 		err      error
-		tagScope database.TagScope
+		tagScope types.TagScope
 	)
 	switch repoType {
 	case fmt.Sprintf("%ss", types.DatasetRepo):
-		tagScope = database.DatasetTagScope
+		tagScope = types.DatasetTagScope
 	case fmt.Sprintf("%ss", types.ModelRepo):
-		tagScope = database.ModelTagScope
+		tagScope = types.ModelTagScope
 	case fmt.Sprintf("%ss", types.PromptRepo):
-		tagScope = database.PromptTagScope
+		tagScope = types.PromptTagScope
 	default:
 		return nil
 		// TODO: support code and space
 		// case CodeRepoType:
-		// 	tagScope = database.CodeTagScope
+		// 	tagScope = types.CodeTagScope
 		// case SpaceRepoType:
-		// 	tagScope = database.SpaceTagScope
+		// 	tagScope = types.SpaceTagScope
 	}
 	_, err = c.tagComponent.UpdateMetaTags(ctx, tagScope, namespace, repoName, content)
 	if err != nil {
@@ -472,7 +472,11 @@ func (c *gitCallbackComponentImpl) updateModelRuntimeFrameworks(ctx context.Cont
 	}
 	slog.Debug("get arch for git callback", slog.Any("namespace", namespace), slog.Any("repoName", repoName), slog.Any("arch", arch))
 	//add resource tag, like ascend
-	runtime_framework_tags, _ := c.tagStore.GetTagsByScopeAndCategories(ctx, "model", []string{"runtime_framework", "resource"})
+	filter := &types.TagFilter{
+		Scopes:     []types.TagScope{types.ModelTagScope},
+		Categories: []string{"runtime_framework", "resource"},
+	}
+	runtime_framework_tags, _ := c.tagStore.AllTags(ctx, filter)
 	fields := strings.Split(repo.Path, "/")
 	err = c.runtimeArchComponent.AddResourceTag(ctx, runtime_framework_tags, fields[1], repo.ID)
 	if err != nil {

--- a/component/callback/git_callback_test.go
+++ b/component/callback/git_callback_test.go
@@ -127,8 +127,12 @@ func TestGitCallbackComponent_UpdateRepoInfos(t *testing.T) {
 		&database.Repository{ID: 1, Path: "foo/bar"}, nil,
 	)
 	gc.mocks.runtimeArchComponent.EXPECT().GetArchitecture(ctx, types.TaskAutoDetection, &database.Repository{ID: 1, Path: "foo/bar"}).Return("foo", nil)
-	gc.mocks.stores.TagMock().EXPECT().GetTagsByScopeAndCategories(
-		ctx, database.ModelTagScope, []string{"runtime_framework", "resource"},
+	filter := &types.TagFilter{
+		Categories: []string{"runtime_framework", "resource"},
+		Scopes:     []types.TagScope{types.ModelTagScope},
+	}
+	gc.mocks.stores.TagMock().EXPECT().AllTags(
+		ctx, filter,
 	).Return([]*database.Tag{{Name: "t1"}}, nil)
 	gc.mocks.runtimeArchComponent.EXPECT().AddResourceTag(
 		ctx, []*database.Tag{{Name: "t1"}}, "bar", int64(1),
@@ -152,12 +156,12 @@ func TestGitCallbackComponent_UpdateRepoInfos(t *testing.T) {
 	).Return(nil)
 	// removed mock
 	gc.mocks.tagComponent.EXPECT().UpdateLibraryTags(
-		ctx, database.ModelTagScope, "ns", "n", "bar.go", "",
+		ctx, types.ModelTagScope, "ns", "n", "bar.go", "",
 	).Return(nil)
 	gc.mocks.tagComponent.EXPECT().ClearMetaTags(ctx, types.ModelRepo, "ns", "n").Return(nil)
 	// added mock
 	gc.mocks.tagComponent.EXPECT().UpdateLibraryTags(
-		ctx, database.ModelTagScope, "ns", "n", "", "foo.go",
+		ctx, types.ModelTagScope, "ns", "n", "", "foo.go",
 	).Return(nil)
 	gc.mocks.gitServer.EXPECT().GetRepoFileRaw(mock.Anything, gitserver.GetRepoInfoByPathReq{
 		Namespace: "ns",
@@ -167,7 +171,7 @@ func TestGitCallbackComponent_UpdateRepoInfos(t *testing.T) {
 		RepoType:  types.ModelRepo,
 	}).Return("", nil)
 	gc.mocks.tagComponent.EXPECT().UpdateMetaTags(
-		ctx, database.ModelTagScope, "ns", "n", "",
+		ctx, types.ModelTagScope, "ns", "n", "",
 	).Return(nil, nil)
 
 	err := gc.UpdateRepoInfos(ctx, &types.GiteaCallbackPushReq{

--- a/component/model.go
+++ b/component/model.go
@@ -1055,7 +1055,12 @@ func (c *modelComponentImpl) SetRuntimeFrameworkModes(ctx context.Context, curre
 		return nil, err
 	}
 
-	runtime_framework_tags, _ := c.tagStore.GetTagsByScopeAndCategories(ctx, "model", []string{"runtime_framework", "resource"})
+	//add resource tag, like ascend
+	filter := &types.TagFilter{
+		Scopes:     []types.TagScope{types.ModelTagScope},
+		Categories: []string{"runtime_framework", "resource"},
+	}
+	runtime_framework_tags, _ := c.tagStore.AllTags(ctx, filter)
 
 	var failedModels []string
 	for _, model := range models {

--- a/component/model_test.go
+++ b/component/model_test.go
@@ -495,8 +495,12 @@ func TestModelComponent_SetRuntimeFrameworkModes(t *testing.T) {
 		}, nil,
 	)
 	rftags := []*database.Tag{{Name: "t1"}, {Name: "t2"}}
-	mc.mocks.stores.TagMock().EXPECT().GetTagsByScopeAndCategories(
-		ctx, database.TagScope("model"), []string{"runtime_framework", "resource"},
+	filter := &types.TagFilter{
+		Categories: []string{"runtime_framework", "resource"},
+		Scopes:     []types.TagScope{types.ModelTagScope},
+	}
+	mc.mocks.stores.TagMock().EXPECT().AllTags(
+		ctx, filter,
 	).Return(rftags, nil)
 
 	mc.mocks.stores.RepoRuntimeFrameworkMock().EXPECT().GetByIDsAndType(

--- a/component/multi_sync.go
+++ b/component/multi_sync.go
@@ -228,7 +228,7 @@ func (c *multiSyncComponentImpl) createLocalDataset(ctx context.Context, m *type
 				Group:    tag.Group,
 				BuiltIn:  tag.BuiltIn,
 				ShowName: tag.ShowName,
-				Scope:    database.DatasetTagScope,
+				Scope:    types.DatasetTagScope,
 			}
 			t, err := c.tagStore.FindOrCreate(ctx, dbTag)
 			if err != nil {
@@ -354,7 +354,7 @@ func (c *multiSyncComponentImpl) createLocalModel(ctx context.Context, m *types.
 				Group:    tag.Group,
 				BuiltIn:  tag.BuiltIn,
 				ShowName: tag.ShowName,
-				Scope:    database.ModelTagScope,
+				Scope:    types.ModelTagScope,
 			}
 			t, err := c.tagStore.FindOrCreate(ctx, dbTag)
 			if err != nil {

--- a/component/multi_sync_test.go
+++ b/component/multi_sync_test.go
@@ -109,7 +109,7 @@ func TestMultiSyncComponent_SyncAsClient(t *testing.T) {
 	mc.mocks.stores.RepoMock().EXPECT().UpdateOrCreateRepo(ctx, *dbrepo).Return(dbrepo, nil)
 	dbrepo.ID = 1
 	mc.mocks.stores.TagMock().EXPECT().FindOrCreate(ctx, database.Tag{
-		Name: "t1", Scope: database.ModelTagScope,
+		Name: "t1", Scope: types.ModelTagScope,
 	}).Return(
 		&database.Tag{Name: "t1", ID: 11}, nil,
 	)
@@ -148,7 +148,7 @@ func TestMultiSyncComponent_SyncAsClient(t *testing.T) {
 	mc.mocks.stores.RepoMock().EXPECT().UpdateOrCreateRepo(ctx, *dbrepo).Return(dbrepo, nil)
 	dbrepo.ID = 2
 	mc.mocks.stores.TagMock().EXPECT().FindOrCreate(ctx, database.Tag{
-		Name: "t2", Scope: database.DatasetTagScope,
+		Name: "t2", Scope: types.DatasetTagScope,
 	}).Return(
 		&database.Tag{Name: "t2", ID: 12}, nil,
 	)

--- a/component/repo.go
+++ b/component/repo.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net/http"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -1556,26 +1555,6 @@ func (c *repoComponentImpl) FileInfo(ctx context.Context, req *types.GetFileReq)
 		return nil, fmt.Errorf("failed to get git model repository file info, error: %w", err)
 	}
 	return file, nil
-}
-
-func (c *repoComponentImpl) getFilePreviewCode(fileContent []byte) types.FilePreviewCode {
-	// detect the file content type like text/plain, image/jpeg, etc
-	detectedType := http.DetectContentType(fileContent)
-	switch {
-	case strings.HasPrefix(detectedType, "text"):
-		return types.FilePreviewCodeNormal
-	default:
-		return types.FilePreviewCodeNotText
-	}
-}
-
-func (c *repoComponentImpl) adjustMaxFileSize(maxFileSize int64) int64 {
-	// same with aliyun green check large content size
-	const maxModerationContentSize = 100 * 9000
-	if maxFileSize == 0 || maxFileSize > maxModerationContentSize {
-		maxFileSize = maxModerationContentSize
-	}
-	return maxFileSize
 }
 
 func getTagScopeByRepoType(repoType types.RepositoryType) types.TagScope {

--- a/component/repo_test.go
+++ b/component/repo_test.go
@@ -1395,7 +1395,7 @@ func TestRepoComponent_UpdateTags(t *testing.T) {
 		mockedRepo, nil,
 	).Once()
 	repo.mocks.components.tag.EXPECT().UpdateRepoTagsByCategory(
-		ctx, database.ModelTagScope, int64(123), "cat", []string{"foo", "bar"},
+		ctx, types.ModelTagScope, int64(123), "cat", []string{"foo", "bar"},
 	).Return(nil)
 	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "user").Return(database.User{
 		RoleMask: "admin",

--- a/component/runtime_architecture.go
+++ b/component/runtime_architecture.go
@@ -204,7 +204,12 @@ func (c *runtimeArchitectureComponentImpl) scanNewModels(ctx context.Context, re
 		if err != nil {
 			return fmt.Errorf("failed to get runtime framework by ID, %w", err)
 		}
-		runtime_framework_tags, _ := c.tagStore.GetTagsByScopeAndCategories(ctx, "model", []string{"runtime_framework", "resource"})
+		//add resource tag, like ascend
+		filter := &types.TagFilter{
+			Scopes:     []types.TagScope{types.ModelTagScope},
+			Categories: []string{"runtime_framework", "resource"},
+		}
+		runtime_framework_tags, _ := c.tagStore.AllTags(ctx, filter)
 		for _, repo := range repos {
 			arch, err := c.GetArchitecture(ctx, req.Task, &repo)
 			if err != nil {

--- a/component/runtime_architecture_test.go
+++ b/component/runtime_architecture_test.go
@@ -89,9 +89,11 @@ func TestRuntimeArchComponent_ScanArchitectures(t *testing.T) {
 	}, nil)
 	//page 2
 	rc.mocks.stores.RepoMock().EXPECT().GetRepoWithoutRuntimeByID(ctx, int64(1), []string{"foo"}, 1000, 1).Return(nil, nil)
-	rc.mocks.stores.TagMock().EXPECT().GetTagsByScopeAndCategories(ctx, database.ModelTagScope, []string{
-		"runtime_framework", "resource",
-	}).Return([]*database.Tag{}, nil)
+	filter := &types.TagFilter{
+		Categories: []string{"runtime_framework", "resource"},
+		Scopes:     []types.TagScope{types.ModelTagScope},
+	}
+	rc.mocks.stores.TagMock().EXPECT().AllTags(ctx, filter).Return([]*database.Tag{}, nil)
 	rc.mocks.stores.RepoRuntimeFrameworkMock().EXPECT().Add(ctx, int64(1), int64(0), 0).Return(nil)
 	rc.mocks.stores.ResourceModelMock().EXPECT().CheckModelNameNotInRFRepo(ctx, "bar", int64(0)).Return(
 		&database.ResourceModel{}, nil,

--- a/component/tagparser/tag_processor.go
+++ b/component/tagparser/tag_processor.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/types"
 )
 
 type DatasetTagStore interface {
@@ -30,27 +31,27 @@ var _ TagProcessor = (*tagProcessor)(nil)
 
 type tagProcessor struct {
 	existingTags func(ctx context.Context) ([]*database.Tag, error)
-	tagScope     database.TagScope
+	tagScope     types.TagScope
 }
 
 func NewDatasetTagProcessor(ts DatasetTagStore) TagProcessor {
 	p := new(tagProcessor)
 	p.existingTags = ts.AllDatasetTags
-	p.tagScope = database.DatasetTagScope
+	p.tagScope = types.DatasetTagScope
 	return p
 }
 
 func NewModelTagProcessor(ts ModelTagStore) TagProcessor {
 	p := new(tagProcessor)
 	p.existingTags = ts.AllModelTags
-	p.tagScope = database.ModelTagScope
+	p.tagScope = types.ModelTagScope
 	return p
 }
 
 func NewPromptTagProcessor(ts PromptTagStore) TagProcessor {
 	p := new(tagProcessor)
 	p.existingTags = ts.AllPromptTags
-	p.tagScope = database.PromptTagScope
+	p.tagScope = types.PromptTagScope
 	return p
 }
 

--- a/component/tagparser/tag_processor_test.go
+++ b/component/tagparser/tag_processor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/types"
 )
 
 type mockTagStore struct {
@@ -61,7 +62,7 @@ func Test_ProcessReadme(t *testing.T) {
 }
 func Test_processTags(t *testing.T) {
 	p := new(tagProcessor)
-	p.tagScope = database.DatasetTagScope
+	p.tagScope = types.DatasetTagScope
 
 	existingCategoryTagMap := make(map[string]map[string]*database.Tag)
 
@@ -80,7 +81,7 @@ func Test_processTags(t *testing.T) {
 	categoryTagMap := make(map[string][]string)
 	categoryTagMap[categoryNameTask] = append(categoryTagMap[categoryNameTask], "finance", "code", "mit") //should create an "task" tag "mit"
 	categoryTagMap[categoryNameLicense] = append(categoryTagMap[categoryNameLicense], "mit")              //should match this one
-	categoryTagMap["Unknown"] = append(categoryTagMap["Unknown"], "mit")                                   //should igore this one
+	categoryTagMap["Unknown"] = append(categoryTagMap["Unknown"], "mit")                                  //should igore this one
 
 	tagsMatched, tagsToCreate := p.processTags(existingCategoryTagMap, categoryTagMap)
 	if len(tagsMatched) != 3 {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15702,7 +15702,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/database.TagScope"
+                    "$ref": "#/definitions/types.TagScope"
                 },
                 "show_name": {
                     "type": "string"
@@ -15725,14 +15725,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/database.TagScope"
+                    "$ref": "#/definitions/types.TagScope"
                 },
                 "show_name": {
                     "type": "string"
                 }
             }
         },
-        "database.TagScope": {
+        "types.TagScope": {
             "type": "string",
             "enum": [
                 "model",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -15691,7 +15691,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/database.TagScope"
+                    "$ref": "#/definitions/types.TagScope"
                 },
                 "show_name": {
                     "type": "string"
@@ -15714,14 +15714,14 @@
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/database.TagScope"
+                    "$ref": "#/definitions/types.TagScope"
                 },
                 "show_name": {
                     "type": "string"
                 }
             }
         },
-        "database.TagScope": {
+        "types.TagScope": {
             "type": "string",
             "enum": [
                 "model",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -354,7 +354,7 @@ definitions:
       name:
         type: string
       scope:
-        $ref: '#/definitions/database.TagScope'
+        $ref: '#/definitions/types.TagScope'
       show_name:
         type: string
       updated_at:
@@ -369,11 +369,11 @@ definitions:
       name:
         type: string
       scope:
-        $ref: '#/definitions/database.TagScope'
+        $ref: '#/definitions/types.TagScope'
       show_name:
         type: string
     type: object
-  database.TagScope:
+  types.TagScope:
     enum:
     - model
     - dataset


### PR DESCRIPTION
**What is this feature?**

refactor AllTags api to support tag filtering by multiple properties, like scope, category and built_in

**Why do we need this feature?**

get tag data by different requirements

**Who is this feature for?**

all

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request introduces support for filtering tags by multiple properties such as scope, category, and built-in status in the AllTags API. This enhancement allows for more granular retrieval of tag data based on different requirements. The changes involve modifications to the tag storage and retrieval logic, including updates to mock data and tests to ensure the new filtering capabilities are correctly implemented and functioning as expected.

Key updates include:
1. Refactoring to support tag filtering by scope, category, and built-in status.
2. Adjustments to tag-related components and services to accommodate the new filtering feature.
3. Updates to unit tests to cover the new functionality and ensure existing features remain unaffected.

<!-- @codegpt description end -->