### PR TITLE
Add more repo sources support

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoStore.go
@@ -195,6 +195,53 @@ func (_c *MockRepoStore_BatchGet_Call) RunAndReturn(run func(context.Context, ty
 	return _c
 }
 
+// BulkUpdateSourcePath provides a mock function with given fields: ctx, repos
+func (_m *MockRepoStore) BulkUpdateSourcePath(ctx context.Context, repos []*database.Repository) error {
+	ret := _m.Called(ctx, repos)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BulkUpdateSourcePath")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, []*database.Repository) error); ok {
+		r0 = rf(ctx, repos)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockRepoStore_BulkUpdateSourcePath_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BulkUpdateSourcePath'
+type MockRepoStore_BulkUpdateSourcePath_Call struct {
+	*mock.Call
+}
+
+// BulkUpdateSourcePath is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repos []*database.Repository
+func (_e *MockRepoStore_Expecter) BulkUpdateSourcePath(ctx interface{}, repos interface{}) *MockRepoStore_BulkUpdateSourcePath_Call {
+	return &MockRepoStore_BulkUpdateSourcePath_Call{Call: _e.mock.On("BulkUpdateSourcePath", ctx, repos)}
+}
+
+func (_c *MockRepoStore_BulkUpdateSourcePath_Call) Run(run func(ctx context.Context, repos []*database.Repository)) *MockRepoStore_BulkUpdateSourcePath_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]*database.Repository))
+	})
+	return _c
+}
+
+func (_c *MockRepoStore_BulkUpdateSourcePath_Call) Return(_a0 error) *MockRepoStore_BulkUpdateSourcePath_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockRepoStore_BulkUpdateSourcePath_Call) RunAndReturn(run func(context.Context, []*database.Repository) error) *MockRepoStore_BulkUpdateSourcePath_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ByUser provides a mock function with given fields: ctx, userID
 func (_m *MockRepoStore) ByUser(ctx context.Context, userID int64) ([]database.Repository, error) {
 	ret := _m.Called(ctx, userID)
@@ -1122,6 +1169,66 @@ func (_c *MockRepoStore_FindByRepoSourceWithBatch_Call) Return(_a0 []database.Re
 }
 
 func (_c *MockRepoStore_FindByRepoSourceWithBatch_Call) RunAndReturn(run func(context.Context, types.RepositorySource, int, int) ([]database.Repository, error)) *MockRepoStore_FindByRepoSourceWithBatch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FindMirrorReposWithBatch provides a mock function with given fields: ctx, batchSize, batch
+func (_m *MockRepoStore) FindMirrorReposWithBatch(ctx context.Context, batchSize int, batch int) ([]database.Repository, error) {
+	ret := _m.Called(ctx, batchSize, batch)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindMirrorReposWithBatch")
+	}
+
+	var r0 []database.Repository
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int, int) ([]database.Repository, error)); ok {
+		return rf(ctx, batchSize, batch)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int, int) []database.Repository); ok {
+		r0 = rf(ctx, batchSize, batch)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Repository)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = rf(ctx, batchSize, batch)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockRepoStore_FindMirrorReposWithBatch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindMirrorReposWithBatch'
+type MockRepoStore_FindMirrorReposWithBatch_Call struct {
+	*mock.Call
+}
+
+// FindMirrorReposWithBatch is a helper method to define mock.On call
+//   - ctx context.Context
+//   - batchSize int
+//   - batch int
+func (_e *MockRepoStore_Expecter) FindMirrorReposWithBatch(ctx interface{}, batchSize interface{}, batch interface{}) *MockRepoStore_FindMirrorReposWithBatch_Call {
+	return &MockRepoStore_FindMirrorReposWithBatch_Call{Call: _e.mock.On("FindMirrorReposWithBatch", ctx, batchSize, batch)}
+}
+
+func (_c *MockRepoStore_FindMirrorReposWithBatch_Call) Run(run func(ctx context.Context, batchSize int, batch int)) *MockRepoStore_FindMirrorReposWithBatch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int), args[2].(int))
+	})
+	return _c
+}
+
+func (_c *MockRepoStore_FindMirrorReposWithBatch_Call) Return(_a0 []database.Repository, _a1 error) *MockRepoStore_FindMirrorReposWithBatch_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockRepoStore_FindMirrorReposWithBatch_Call) RunAndReturn(run func(context.Context, int, int) ([]database.Repository, error)) *MockRepoStore_FindMirrorReposWithBatch_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2060,6 +2167,55 @@ func (_c *MockRepoStore_UpdateRepoFileDownloads_Call) Return(err error) *MockRep
 }
 
 func (_c *MockRepoStore_UpdateRepoFileDownloads_Call) RunAndReturn(run func(context.Context, *database.Repository, time.Time, int64) error) *MockRepoStore_UpdateRepoFileDownloads_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateSourcePath provides a mock function with given fields: ctx, repoID, sourcePath, sourceType
+func (_m *MockRepoStore) UpdateSourcePath(ctx context.Context, repoID int64, sourcePath string, sourceType string) error {
+	ret := _m.Called(ctx, repoID, sourcePath, sourceType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateSourcePath")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string, string) error); ok {
+		r0 = rf(ctx, repoID, sourcePath, sourceType)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockRepoStore_UpdateSourcePath_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateSourcePath'
+type MockRepoStore_UpdateSourcePath_Call struct {
+	*mock.Call
+}
+
+// UpdateSourcePath is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repoID int64
+//   - sourcePath string
+//   - sourceType string
+func (_e *MockRepoStore_Expecter) UpdateSourcePath(ctx interface{}, repoID interface{}, sourcePath interface{}, sourceType interface{}) *MockRepoStore_UpdateSourcePath_Call {
+	return &MockRepoStore_UpdateSourcePath_Call{Call: _e.mock.On("UpdateSourcePath", ctx, repoID, sourcePath, sourceType)}
+}
+
+func (_c *MockRepoStore_UpdateSourcePath_Call) Run(run func(ctx context.Context, repoID int64, sourcePath string, sourceType string)) *MockRepoStore_UpdateSourcePath_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *MockRepoStore_UpdateSourcePath_Call) Return(_a0 error) *MockRepoStore_UpdateSourcePath_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockRepoStore_UpdateSourcePath_Call) RunAndReturn(run func(context.Context, int64, string, string) error) *MockRepoStore_UpdateSourcePath_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/builder/store/database/migrations/20250121092707_add_source_info_to_repositories.down.sql
+++ b/builder/store/database/migrations/20250121092707_add_source_info_to_repositories.down.sql
@@ -1,0 +1,13 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE repositories DROP COLUMN IF EXISTS csg_path;
+
+--bun:split
+
+ALTER TABLE repositories DROP COLUMN IF EXISTS hf_path;
+
+--bun:split
+
+ALTER TABLE repositories DROP COLUMN IF EXISTS ms_path;

--- a/builder/store/database/migrations/20250121092707_add_source_info_to_repositories.up.sql
+++ b/builder/store/database/migrations/20250121092707_add_source_info_to_repositories.up.sql
@@ -1,0 +1,13 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS csg_path VARCHAR;
+
+--bun:split
+
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS hf_path VARCHAR;
+
+--bun:split
+
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS ms_path VARCHAR;

--- a/common/types/common.go
+++ b/common/types/common.go
@@ -1,0 +1,7 @@
+package types
+
+type MultiSource struct {
+	HFPath  string `json:"hf_path"`
+	MSPath  string `json:"ms_path"`
+	CSGPath string `json:"csg_path"`
+}

--- a/common/types/dataset.go
+++ b/common/types/dataset.go
@@ -45,6 +45,7 @@ type Dataset struct {
 	Namespace            *Namespace           `json:"namespace"`
 	SensitiveCheckStatus string               `json:"sensitive_check_status"`
 	MirrorLastUpdatedAt  time.Time            `json:"mirror_last_updated_at"`
+	MultiSource
 }
 
 type DataViewerReq struct {

--- a/common/types/model.go
+++ b/common/types/model.go
@@ -169,6 +169,7 @@ type Model struct {
 	RecomOpWeight        int                  `json:"recom_op_weight,omitempty"`
 	SensitiveCheckStatus string               `json:"sensitive_check_status"`
 	MirrorLastUpdatedAt  time.Time            `json:"mirror_last_updated_at"`
+	MultiSource
 }
 
 type SDKModelInfo struct {

--- a/common/utils/common/repo.go
+++ b/common/utils/common/repo.go
@@ -20,6 +20,12 @@ const (
 	CodeOrgPrefix    = "codes_"
 )
 
+const (
+	CSGSourceType = "csghub"
+	HFSourceType  = "huggingface"
+	MSSourceType  = "modelscope"
+)
+
 func WithPrefix(name string, prefix string) string {
 	return prefix + name
 }

--- a/common/utils/common/repo_test.go
+++ b/common/utils/common/repo_test.go
@@ -258,3 +258,36 @@ func TestIsValidName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSourceTypeAndPathFromURL(t *testing.T) {
+	type args struct {
+		url string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		want1   string
+		wantErr bool
+	}{
+		{name: "Test GetSourceTypeAndPathFromURL when url is opencsg", args: args{url: "https://opencsg.com/models/abc/def.git"}, want: "opencsg", want1: "abc/def", wantErr: false},
+		{name: "Test GetSourceTypeAndPathFromURL when url is huggingface", args: args{url: "https://huggingface.co/aaa/bbb.git"}, want: "huggingface", want1: "aaa/bbb", wantErr: false},
+		{name: "Test GetSourceTypeAndPathFromURL when url is modelscope", args: args{url: "https://www.modelscope.cn/models/ccc/ddd.git"}, want: "modelscope", want1: "ccc/ddd", wantErr: false},
+		{name: "Test GetSourceTypeAndPathFromURL when url is unknown", args: args{url: "https://aaa.cn/models/ccc/ddd.git"}, want: "", want1: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := GetSourceTypeAndPathFromURL(tt.args.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetSourceTypeAndPathFromURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetSourceTypeAndPathFromURL() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetSourceTypeAndPathFromURL() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/component/dataset.go
+++ b/component/dataset.go
@@ -413,6 +413,11 @@ func (c *datasetComponentImpl) Show(ctx context.Context, namespace, name, curren
 		CanWrite:            permission.CanWrite,
 		CanManage:           permission.CanAdmin,
 		Namespace:           ns,
+		MultiSource: types.MultiSource{
+			HFPath:  dataset.Repository.HFPath,
+			MSPath:  dataset.Repository.MSPath,
+			CSGPath: dataset.Repository.CSGPath,
+		},
 	}
 	if permission.CanAdmin {
 		resDataset.SensitiveCheckStatus = dataset.Repository.SensitiveCheckStatus.String()

--- a/component/mirror.go
+++ b/component/mirror.go
@@ -249,6 +249,14 @@ func (c *mirrorComponentImpl) CreateMirrorRepo(ctx context.Context, req types.Cr
 	mirror.SourceRepoPath = fmt.Sprintf("%s/%s", req.SourceNamespace, req.SourceName)
 	mirror.Priority = types.HighMirrorPriority
 
+	sourceType, sourcePath, err := common.GetSourceTypeAndPathFromURL(req.SourceGitCloneUrl)
+	if err == nil {
+		err = c.repoStore.UpdateSourcePath(ctx, repo.ID, sourcePath, sourceType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update source path in repo: %v", err)
+		}
+	}
+
 	var taskId int64
 	if c.config.GitServer.Type == types.GitServerTypeGitea {
 		taskId, err = c.mirrorServer.CreateMirrorRepo(ctx, mirrorserver.CreateMirrorRepoReq{

--- a/component/model.go
+++ b/component/model.go
@@ -465,6 +465,11 @@ func (c *modelComponentImpl) Show(ctx context.Context, namespace, name, currentU
 		CanWrite:            permission.CanWrite,
 		CanManage:           permission.CanAdmin,
 		Namespace:           ns,
+		MultiSource: types.MultiSource{
+			HFPath:  model.Repository.HFPath,
+			MSPath:  model.Repository.MSPath,
+			CSGPath: model.Repository.CSGPath,
+		},
 	}
 	// admin user or owner can see the sensitive check status
 	if permission.CanAdmin {

--- a/component/multi_sync.go
+++ b/component/multi_sync.go
@@ -213,6 +213,9 @@ func (c *multiSyncComponentImpl) createLocalDataset(ctx context.Context, m *type
 		SyncStatus:     types.SyncStatusPending,
 		// HTTPCloneURL:   gitRepo.HttpCloneURL,
 		// SSHCloneURL:    gitRepo.SshCloneURL,
+		MSPath:  m.MultiSource.MSPath,
+		HFPath:  m.MultiSource.HFPath,
+		CSGPath: m.MultiSource.CSGPath,
 	}
 	newDBRepo, err := c.repoStore.UpdateOrCreateRepo(ctx, dbRepo)
 	if err != nil {
@@ -339,6 +342,9 @@ func (c *multiSyncComponentImpl) createLocalModel(ctx context.Context, m *types.
 		SyncStatus:     types.SyncStatusPending,
 		// HTTPCloneURL:   gitRepo.HttpCloneURL,
 		// SSHCloneURL:    gitRepo.SshCloneURL,
+		MSPath:  m.MultiSource.MSPath,
+		HFPath:  m.MultiSource.HFPath,
+		CSGPath: m.MultiSource.CSGPath,
 	}
 	newDBRepo, err := c.repoStore.UpdateOrCreateRepo(ctx, dbRepo)
 	if err != nil {

--- a/component/repo.go
+++ b/component/repo.go
@@ -1777,6 +1777,14 @@ func (c *repoComponentImpl) CreateMirror(ctx context.Context, req types.CreateMi
 	mirror.LocalRepoPath = fmt.Sprintf("%s_%s_%s_%s", mirrorSource.SourceName, req.RepoType, req.Namespace, req.Name)
 	mirror.RepositoryID = repo.ID
 
+	sourceType, sourcePath, err := common.GetSourceTypeAndPathFromURL(req.SourceUrl)
+	if err == nil {
+		err = c.repoStore.UpdateSourcePath(ctx, repo.ID, sourceType, sourcePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update source path in repo: %v", err)
+		}
+	}
+
 	if c.config.Saas {
 		if c.config.GitServer.Type == types.GitServerTypeGitea {
 			mirror.PushUsername = req.CurrentUser


### PR DESCRIPTION
**What is this feature?**

## Add more repo sources support

Add CSGPath, MSPath, HFPath to store the source of the repository. 
- CSGPath is the source path of the repository in OpenCSG.
- MSPath is the source path of the repository in ModelScope.
- HFPath is the source path of the repository in Huggingface.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**
