### PR TITLE
Support inference and finetue with deepseek R1 models

### DIFF
--- a/builder/store/database/migrations/20250207090542_upgrade_ms_swift.down.sql
+++ b/builder/store/database/migrations/20250207090542_upgrade_ms_swift.down.sql
@@ -1,0 +1,32 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'SmallThinker-3B-Preview';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'internlm3-8b-instruct';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'DeepSeek-R1';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'DeepSeek-R1-Zero';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'DeepSeek-R1-Distill-Qwen-1.5B';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'DeepSeek-R1-Distill-Qwen-7B';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'DeepSeek-R1-Distill-Qwen-14B';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'DeepSeek-R1-Distill-Qwen-32B';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'DeepSeek-R1-Distill-Llama-8B';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'DeepSeek-R1-Distill-Llama-70B';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'phi-4';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'MiniMax-Text-01';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'MiniCPM-V-2_6';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'MiniCPM-o-2_6';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'MiniMax-VL-01';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'Qwen2.5-7B-Instruct-1M';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'Qwen2.5-14B-Instruct-1M';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'UI-TARS-2B-SFT';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'UI-TARS-7B-SFT';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'UI-TARS-7B-DPO';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'UI-TARS-72B-SFT';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'UI-TARS-72B-DPO';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'Qwen2.5-VL-3B-Instruct';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'Qwen2.5-VL-7B-Instruct';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'Qwen2.5-VL-72B-Instruct';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'Janus-Pro-1B';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'Janus-Pro-7B';
+DELETE FROM resource_models WHERE engine_name = 'ms-swift' AND model_name = 'Qwen2.5-Math-7B-PRM800K';

--- a/builder/store/database/migrations/20250207090542_upgrade_ms_swift.up.sql
+++ b/builder/store/database/migrations/20250207090542_upgrade_ms_swift.up.sql
@@ -1,0 +1,32 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'SmallThinker-3B-Preview', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'internlm3-8b-instruct', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'DeepSeek-R1', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'DeepSeek-R1-Zero', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'DeepSeek-R1-Distill-Qwen-1.5B', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'DeepSeek-R1-Distill-Qwen-7B', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'DeepSeek-R1-Distill-Qwen-14B', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'DeepSeek-R1-Distill-Qwen-32B', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'DeepSeek-R1-Distill-Llama-8B', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'DeepSeek-R1-Distill-Llama-70B', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'phi-4', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'MiniMax-Text-01', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'MiniCPM-V-2_6', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'MiniCPM-o-2_6', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'MiniMax-VL-01', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'Qwen2.5-7B-Instruct-1M', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'Qwen2.5-14B-Instruct-1M', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'UI-TARS-2B-SFT', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'UI-TARS-7B-SFT', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'UI-TARS-7B-DPO', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'UI-TARS-72B-SFT', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'UI-TARS-72B-DPO', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'Qwen2.5-VL-3B-Instruct', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'Qwen2.5-VL-7B-Instruct', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'Qwen2.5-VL-72B-Instruct', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'Janus-Pro-1B', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'Janus-Pro-7B', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;
+INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', 'Qwen2.5-Math-7B-PRM800K', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;

--- a/common/utils/common/repo.go
+++ b/common/utils/common/repo.go
@@ -173,9 +173,12 @@ func GetSourceTypeAndPathFromURL(url string) (string, string, error) {
 // get built-int task from tags
 func GetBuiltInTaskFromTags(tags []database.Tag) string {
 	for _, tag := range tags {
-		if tag.BuiltIn && tag.Category == "task" {
+		if tag.Name == string(types.TextGeneration) {
+			return tag.Name
+		}
+		if tag.Name == string(types.Text2Image) {
 			return tag.Name
 		}
 	}
-	return ""
+	return string(types.TextGeneration)
 }

--- a/component/model_ce_test.go
+++ b/component/model_ce_test.go
@@ -53,6 +53,7 @@ func TestModelComponent_Deploy(t *testing.T) {
 		RepoID:     1,
 		SKU:        "123",
 		Type:       types.ServerlessType,
+		Task:       "text-generation",
 	}).Return(111, nil)
 
 	id, err := mc.Deploy(ctx, types.DeployActReq{

--- a/docker/finetune/Dockerfile.ms-swift
+++ b/docker/finetune/Dockerfile.ms-swift
@@ -35,12 +35,12 @@ RUN pip install --no-cache-dir jupyterlab numpy==1.26.4 \
     gradio-client==1.4.0
 # Create a working directory
 WORKDIR /etc/csghub
-RUN git clone https://github.com/modelscope/ms-swift.git --branch v3.0.1 --single-branch
+RUN git clone https://github.com/modelscope/ms-swift.git --branch v3.1.0 --single-branch
 RUN cd ms-swift && pip install --no-cache-dir -e "."
-#because this library is update frequently, we use new line
+#Due to the frequent updates of this library, we use a new line
 RUN pip install --no-cache-dir vllm==v0.6.3.post1 transformers==4.47.1 timm==1.0.11 evalscope==0.5.5
 #install flash-attn
-RUN pip install --no-build-isolation --no-cache-dir ninja flash-attn
+RUN pip install https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/flash_attn-2.7.4.post1+cu12torch2.4cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
 # setup supervisord
 RUN mkdir -p /var/log/supervisord
 COPY swift/supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/docker/finetune/README.md
+++ b/docker/finetune/README.md
@@ -24,9 +24,9 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 ```
 ## Build Multi-Platform Images for swift
 ```bash
-#opencsg-registry.cn-beijing.cr.aliyuncs.com/public/ms-swift:v3.0.1
+#opencsg-registry.cn-beijing.cr.aliyuncs.com/public/ms-swift:v3.1.0
 export BUILDX_NO_DEFAULT_ATTESTATIONS=1
-export IMAGE_TAG=v3.0.1
+export IMAGE_TAG=v3.1.0
 docker buildx build --platform linux/amd64,linux/arm64 \
   -t ${OPENCSG_ACR}/public/ms-swift:${IMAGE_TAG} \
   -t ${OPENCSG_ACR}/public/ms-swift:latest \
@@ -49,7 +49,7 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 | Image Name | Version | CUDA Version | Fix
 | --- | --- | --- |--- |
 | llama-factory | 1.21-cuda12.1-devel-ubuntu22.04-py310-torch2.1.2 | 12.1 |- |
-| ms-swift | v3.0.1 | 12.4 |- |
+| ms-swift | v3.1.0 | 12.4 |- |
 
 
 ## Run Finetune Image Locally

--- a/docker/finetune/swift/generate_resource_model.py
+++ b/docker/finetune/swift/generate_resource_model.py
@@ -1,0 +1,32 @@
+from typing import Any, List
+import argparse
+from swift.llm import MODEL_MAPPING, TEMPLATE_MAPPING, ModelType, TemplateType
+
+
+def get_url_suffix(model_id):
+    if ':' in model_id:
+        return model_id.split(':')[0]
+    return model_id
+
+
+def generate_model_sql():
+    for template in TemplateType.get_template_name_list():
+        assert template in TEMPLATE_MAPPING
+
+    for model_type in ModelType.get_model_name_list():
+        model_meta = MODEL_MAPPING[model_type]
+        template = model_meta.template
+        for group in model_meta.model_groups:
+            for model in group.models:
+                hf_model_id = model.hf_model_id
+                if hf_model_id is None:
+                    continue
+                namespace_and_name = hf_model_id.split('/')
+                # generate sql and save to file
+                sql = f"INSERT INTO resource_models (resource_name, engine_name, model_name, type) VALUES ('nvidia', 'ms-swift', '{namespace_and_name[1]}', 'gpu') ON CONFLICT (engine_name, model_name) DO NOTHING;"
+                with open("resource_model.sql", 'a') as file:
+                    file.write(sql + '\n')
+
+
+if __name__ == '__main__':
+    generate_model_sql()

--- a/docker/inference/Dockerfile.sglang
+++ b/docker/inference/Dockerfile.sglang
@@ -1,4 +1,4 @@
-FROM lmsysorg/sglang:v0.4.1.post3-cu124-srt
+FROM lmsysorg/sglang:v0.4.2.post2-cu124-srt
 RUN pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
 RUN apt-get update && apt-get install -y dumb-init && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir csghub-sdk==0.4.6

--- a/docker/inference/Dockerfile.vllm
+++ b/docker/inference/Dockerfile.vllm
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:v0.6.3.post1
+FROM vllm/vllm-openai:v0.7.2
 RUN pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
 RUN pip install --no-cache-dir csghub-sdk==0.4.3 ray supervisor huggingface-hub==0.27.0
 RUN apt-get update && apt-get install -y supervisor

--- a/docker/inference/README.md
+++ b/docker/inference/README.md
@@ -12,8 +12,8 @@ echo "$OPENCSG_ACR_PASSWORD" | docker login $OPENCSG_ACR -u $OPENCSG_ACR_USERNAM
 ```bash
 export BUILDX_NO_DEFAULT_ATTESTATIONS=1
 
-# For vllm: opencsg-registry.cn-beijing.cr.aliyuncs.com/public/vllm-local:3.2
-export IMAGE_TAG=3.2
+# For vllm: opencsg-registry.cn-beijing.cr.aliyuncs.com/public/vllm-local:v0.7.2
+export IMAGE_TAG=v0.7.2
 docker buildx build --platform linux/amd64,linux/arm64 \
   -t ${OPENCSG_ACR}/public/vllm-local:${IMAGE_TAG} \
   -t ${OPENCSG_ACR}/public/vllm-local:latest \
@@ -36,8 +36,8 @@ docker buildx build --platform linux/amd64 \
   -f Dockerfile.tgi \
   --push .
 
-# For sglang: opencsg-registry.cn-beijing.cr.aliyuncs.com/public/sglang:v0.4.1.post3-cu124-srt
-export IMAGE_TAG=v0.4.1.post3-cu124-srt
+# For sglang: opencsg-registry.cn-beijing.cr.aliyuncs.com/public/sglang:v0.4.2.post2-cu124-srt
+export IMAGE_TAG=v0.4.2.post2-cu124-srt
 docker buildx build --platform linux/amd64 \
   -t ${OPENCSG_ACR}/public/sglang:${IMAGE_TAG} \
   -t ${OPENCSG_ACR}/public/sglang:latest \
@@ -88,11 +88,11 @@ docker run -d \
 | Task| Image Name | Version | CUDA Version | Fix
 | --- | --- | --- | --- |--- |
 |text generation| vllm | 2.8 | 12.1 | - |
-|text generation| vllm | 3.2 | 12.4 |fix hf hub timestamp|
+|text generation| vllm | v0.7.1 | 12.4 |fix hf hub timestamp|
 |text generation| vllm-cpu | 2.4 | -|fix hf hub timestamp |
 |text generation| tgi | 2.2 | 12.1 |- |
 |text generation| tgi | 3.2 | 12.4 |fix hf hub timestamp|
-|image generation| hf-inference-toolkit | 0.3.5 | 12.1 |-|
+|image generation| hf-inference-toolkit | 0.5.3 | 12.1 |-|
 |text generation| sglang | v0.4.1.post3-cu124-srt | 12.4 |- |
 
 

--- a/docker/inference/sglang/serve.sh
+++ b/docker/inference/sglang/serve.sh
@@ -7,7 +7,7 @@ python3 /etc/csghub/entry.py
 if [ -z "$GPU_NUM" ]; then
     GPU_NUM=1
 fi
-LimitedMaxToken=$(($GPU_NUM * 4096))
+LimitedMaxToken=$(($GPU_NUM * 5120))
 args="--tp $GPU_NUM --enable-mixed-chunk --disable-radix-cache --trust-remote-code --enable-p2p-check --model-path $REPO_ID --port 8000 --host 0.0.0.0 --mem-fraction-static 0.8 --enable-torch-compile"
 configfile="/workspace/$REPO_ID/config.json"
 if [ -f "$configfile" ]; then

--- a/docker/inference/vllm/serve.sh
+++ b/docker/inference/vllm/serve.sh
@@ -7,7 +7,7 @@ if [ -z "$GPU_NUM" ]; then
     GPU_NUM=1
 fi
 #LimitedMaxToken is gpu_num multiplied by 4096
-LimitedMaxToken=$(($GPU_NUM * 4096))
+LimitedMaxToken=$(($GPU_NUM * 5120))
 GPU_MEMORY_UTILIZATION=0.9
 args="--trust-remote-code --model $REPO_ID --tensor-parallel-size $GPU_NUM --gpu-memory-utilization $GPU_MEMORY_UTILIZATION"
 configfile="/workspace/$REPO_ID/config.json"


### PR DESCRIPTION
**What is this feature?**

vLLM offers support for reasoning models like [DeepSeek R1](https://huggingface.co/deepseek-ai/DeepSeek-R1), which are designed to generate outputs containing both reasoning steps and final conclusions.
Reasoning models return a additional reasoning_content field in their outputs, which contains the reasoning steps that led to the final conclusion. This field is not present in the outputs of other models.

ms-swfit also support fintune with R1 models.
For this enhancement, should upgrade vllm and ms-swift to latest version

**Why do we need this feature?**

Use latest think output from deepseek R1 model

**Who is this feature for?**

csghub users

**Which issue(s) does this PR fix?**:

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request introduces support for reasoning models like DeepSeek R1 in the vLLM framework, enabling outputs to include reasoning steps alongside final conclusions. It also adds functionality for fine-tuning with R1 models, requiring an upgrade to the latest versions of vllm and ms-swift. Key updates include:
1. Modification in `repo.go` to adjust the retrieval of built-in tasks from tags, specifically adding support for `TextGeneration` and `Text2Image` tasks.
2. Enhancement in `model_ce_test.go` to include a `Task` field in the deployment test, specifically setting it to "text-generation" to align with the new feature's requirements.

<!-- @codegpt description end -->