### PR TITLE
support download model with different mirrors

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_MirrorStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_MirrorStore.go
@@ -310,23 +310,23 @@ func (_c *MockMirrorStore_FindByRepoPath_Call) RunAndReturn(run func(context.Con
 }
 
 // FindWithMapping provides a mock function with given fields: ctx, repoType, namespace, name, mapping
-func (_m *MockMirrorStore) FindWithMapping(ctx context.Context, repoType types.RepositoryType, namespace string, name string, mapping types.Mapping) (*database.Mirror, error) {
+func (_m *MockMirrorStore) FindWithMapping(ctx context.Context, repoType types.RepositoryType, namespace string, name string, mapping types.Mapping) (*database.Repository, error) {
 	ret := _m.Called(ctx, repoType, namespace, name, mapping)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FindWithMapping")
 	}
 
-	var r0 *database.Mirror
+	var r0 *database.Repository
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, string, string, types.Mapping) (*database.Mirror, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, string, string, types.Mapping) (*database.Repository, error)); ok {
 		return rf(ctx, repoType, namespace, name, mapping)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, string, string, types.Mapping) *database.Mirror); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, string, string, types.Mapping) *database.Repository); ok {
 		r0 = rf(ctx, repoType, namespace, name, mapping)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*database.Mirror)
+			r0 = ret.Get(0).(*database.Repository)
 		}
 	}
 
@@ -361,12 +361,12 @@ func (_c *MockMirrorStore_FindWithMapping_Call) Run(run func(ctx context.Context
 	return _c
 }
 
-func (_c *MockMirrorStore_FindWithMapping_Call) Return(_a0 *database.Mirror, _a1 error) *MockMirrorStore_FindWithMapping_Call {
+func (_c *MockMirrorStore_FindWithMapping_Call) Return(_a0 *database.Repository, _a1 error) *MockMirrorStore_FindWithMapping_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockMirrorStore_FindWithMapping_Call) RunAndReturn(run func(context.Context, types.RepositoryType, string, string, types.Mapping) (*database.Mirror, error)) *MockMirrorStore_FindWithMapping_Call {
+func (_c *MockMirrorStore_FindWithMapping_Call) RunAndReturn(run func(context.Context, types.RepositoryType, string, string, types.Mapping) (*database.Repository, error)) *MockMirrorStore_FindWithMapping_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/api/router/api.go
+++ b/api/router/api.go
@@ -147,8 +147,12 @@ func NewRouter(config *config.Config, enableSwagger bool) (*gin.Engine, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating HF dataset handler: %w", err)
 	}
-
-	createHFRoutes(r, hfdsHandler, repoCommonHandler, modelHandler, userHandler)
+	//create routes for hf
+	createMappingRoutes(r, "/hf", hfdsHandler, repoCommonHandler, modelHandler, userHandler)
+	//create routes for ms
+	createMappingRoutes(r, "/ms", hfdsHandler, repoCommonHandler, modelHandler, userHandler)
+	//create routes for csg
+	createMappingRoutes(r, "/csg", hfdsHandler, repoCommonHandler, modelHandler, userHandler)
 
 	apiGroup := r.Group("/api/v1")
 	// TODO:use middleware to handle common response
@@ -758,9 +762,9 @@ func createAccountRoutes(apiGroup *gin.RouterGroup, needAPIKey gin.HandlerFunc, 
 	}
 }
 
-func createHFRoutes(r *gin.Engine, hfdsHandler *handler.HFDatasetHandler, repoCommonHandler *handler.RepoHandler, modelHandler *handler.ModelHandler, userHandler *handler.UserHandler) {
+func createMappingRoutes(r *gin.Engine, group string, hfdsHandler *handler.HFDatasetHandler, repoCommonHandler *handler.RepoHandler, modelHandler *handler.ModelHandler, userHandler *handler.UserHandler) {
 	// Huggingface SDK routes
-	hfGroup := r.Group("/hf")
+	hfGroup := r.Group(group)
 	{
 		hfGroup.GET("/:namespace/:name/resolve/:branch/*file_path", middleware.RepoMapping(types.ModelRepo), repoCommonHandler.SDKDownload)
 		hfGroup.HEAD("/:namespace/:name/resolve/:branch/*file_path", middleware.RepoMapping(types.ModelRepo), repoCommonHandler.HeadSDKDownload)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -9774,11 +9774,20 @@ const docTemplate = `{
                     {
                         "enum": [
                             "model",
-                            "dataset"
+                            "dataset",
+                            "code",
+                            "space",
+                            "prompt"
                         ],
                         "type": "string",
                         "description": "scope name",
                         "name": "scope",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "built_in",
+                        "name": "built_in",
                         "in": "query"
                     }
                 ],
@@ -15508,6 +15517,9 @@ const docTemplate = `{
                 "created_at": {
                     "type": "string"
                 },
+                "csg_path": {
+                    "type": "string"
+                },
                 "default_branch": {
                     "type": "string"
                 },
@@ -15524,6 +15536,9 @@ const docTemplate = `{
                     }
                 },
                 "git_path": {
+                    "type": "string"
+                },
+                "hf_path": {
                     "type": "string"
                 },
                 "http_clone_url": {
@@ -15544,6 +15559,9 @@ const docTemplate = `{
                 },
                 "mirror": {
                     "$ref": "#/definitions/database.Mirror"
+                },
+                "ms_path": {
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"
@@ -15731,23 +15749,6 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
-        },
-        "types.TagScope": {
-            "type": "string",
-            "enum": [
-                "model",
-                "dataset",
-                "code",
-                "space",
-                "prompt"
-            ],
-            "x-enum-varnames": [
-                "ModelTagScope",
-                "DatasetTagScope",
-                "CodeTagScope",
-                "SpaceTagScope",
-                "PromptTagScope"
-            ]
         },
         "database.User": {
             "type": "object",
@@ -17029,6 +17030,9 @@ const docTemplate = `{
                 "created_at": {
                     "type": "string"
                 },
+                "csg_path": {
+                    "type": "string"
+                },
                 "default_branch": {
                     "type": "string"
                 },
@@ -17037,6 +17041,9 @@ const docTemplate = `{
                 },
                 "downloads": {
                     "type": "integer"
+                },
+                "hf_path": {
+                    "type": "string"
                 },
                 "id": {
                     "type": "integer"
@@ -17048,6 +17055,9 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "mirror_last_updated_at": {
+                    "type": "string"
+                },
+                "ms_path": {
                     "type": "string"
                 },
                 "name": {
@@ -17638,6 +17648,9 @@ const docTemplate = `{
                 "created_at": {
                     "type": "string"
                 },
+                "csg_path": {
+                    "type": "string"
+                },
                 "default_branch": {
                     "type": "string"
                 },
@@ -17656,6 +17669,9 @@ const docTemplate = `{
                 "enable_inference": {
                     "type": "boolean"
                 },
+                "hf_path": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "integer"
                 },
@@ -17666,6 +17682,9 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "mirror_last_updated_at": {
+                    "type": "string"
+                },
+                "ms_path": {
                     "type": "string"
                 },
                 "name": {
@@ -17799,9 +17818,6 @@ const docTemplate = `{
                 },
                 "secure_level": {
                     "type": "integer"
-                },
-                "task": {
-                    "type": "string"
                 }
             }
         },
@@ -18507,6 +18523,23 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "types.TagScope": {
+            "type": "string",
+            "enum": [
+                "model",
+                "dataset",
+                "code",
+                "space",
+                "prompt"
+            ],
+            "x-enum-varnames": [
+                "ModelTagScope",
+                "DatasetTagScope",
+                "CodeTagScope",
+                "SpaceTagScope",
+                "PromptTagScope"
+            ]
         },
         "types.TaskType": {
             "type": "string",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -9763,11 +9763,20 @@
                     {
                         "enum": [
                             "model",
-                            "dataset"
+                            "dataset",
+                            "code",
+                            "space",
+                            "prompt"
                         ],
                         "type": "string",
                         "description": "scope name",
                         "name": "scope",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "built_in",
+                        "name": "built_in",
                         "in": "query"
                     }
                 ],
@@ -15497,6 +15506,9 @@
                 "created_at": {
                     "type": "string"
                 },
+                "csg_path": {
+                    "type": "string"
+                },
                 "default_branch": {
                     "type": "string"
                 },
@@ -15513,6 +15525,9 @@
                     }
                 },
                 "git_path": {
+                    "type": "string"
+                },
+                "hf_path": {
                     "type": "string"
                 },
                 "http_clone_url": {
@@ -15533,6 +15548,9 @@
                 },
                 "mirror": {
                     "$ref": "#/definitions/database.Mirror"
+                },
+                "ms_path": {
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"
@@ -15720,23 +15738,6 @@
                     "type": "string"
                 }
             }
-        },
-        "types.TagScope": {
-            "type": "string",
-            "enum": [
-                "model",
-                "dataset",
-                "code",
-                "space",
-                "prompt"
-            ],
-            "x-enum-varnames": [
-                "ModelTagScope",
-                "DatasetTagScope",
-                "CodeTagScope",
-                "SpaceTagScope",
-                "PromptTagScope"
-            ]
         },
         "database.User": {
             "type": "object",
@@ -17018,6 +17019,9 @@
                 "created_at": {
                     "type": "string"
                 },
+                "csg_path": {
+                    "type": "string"
+                },
                 "default_branch": {
                     "type": "string"
                 },
@@ -17026,6 +17030,9 @@
                 },
                 "downloads": {
                     "type": "integer"
+                },
+                "hf_path": {
+                    "type": "string"
                 },
                 "id": {
                     "type": "integer"
@@ -17037,6 +17044,9 @@
                     "type": "integer"
                 },
                 "mirror_last_updated_at": {
+                    "type": "string"
+                },
+                "ms_path": {
                     "type": "string"
                 },
                 "name": {
@@ -17627,6 +17637,9 @@
                 "created_at": {
                     "type": "string"
                 },
+                "csg_path": {
+                    "type": "string"
+                },
                 "default_branch": {
                     "type": "string"
                 },
@@ -17645,6 +17658,9 @@
                 "enable_inference": {
                     "type": "boolean"
                 },
+                "hf_path": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "integer"
                 },
@@ -17655,6 +17671,9 @@
                     "type": "integer"
                 },
                 "mirror_last_updated_at": {
+                    "type": "string"
+                },
+                "ms_path": {
                     "type": "string"
                 },
                 "name": {
@@ -17788,9 +17807,6 @@
                 },
                 "secure_level": {
                     "type": "integer"
-                },
-                "task": {
-                    "type": "string"
                 }
             }
         },
@@ -18496,6 +18512,23 @@
                     "type": "string"
                 }
             }
+        },
+        "types.TagScope": {
+            "type": "string",
+            "enum": [
+                "model",
+                "dataset",
+                "code",
+                "space",
+                "prompt"
+            ],
+            "x-enum-varnames": [
+                "ModelTagScope",
+                "DatasetTagScope",
+                "CodeTagScope",
+                "SpaceTagScope",
+                "PromptTagScope"
+            ]
         },
         "types.TaskType": {
             "type": "string",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -225,6 +225,8 @@ definitions:
     properties:
       created_at:
         type: string
+      csg_path:
+        type: string
       default_branch:
         type: string
       description:
@@ -236,6 +238,8 @@ definitions:
           $ref: '#/definitions/database.RepositoryDownload'
         type: array
       git_path:
+        type: string
+      hf_path:
         type: string
       http_clone_url:
         type: string
@@ -250,6 +254,8 @@ definitions:
         type: integer
       mirror:
         $ref: '#/definitions/database.Mirror'
+      ms_path:
+        type: string
       name:
         type: string
       nickname:
@@ -373,20 +379,6 @@ definitions:
       show_name:
         type: string
     type: object
-  types.TagScope:
-    enum:
-    - model
-    - dataset
-    - code
-    - space
-    - prompt
-    type: string
-    x-enum-varnames:
-    - ModelTagScope
-    - DatasetTagScope
-    - CodeTagScope
-    - SpaceTagScope
-    - PromptTagScope
   database.User:
     properties:
       accessTokens:
@@ -1255,12 +1247,16 @@ definitions:
         type: boolean
       created_at:
         type: string
+      csg_path:
+        type: string
       default_branch:
         type: string
       description:
         type: string
       downloads:
         type: integer
+      hf_path:
+        type: string
       id:
         type: integer
       license:
@@ -1268,6 +1264,8 @@ definitions:
       likes:
         type: integer
       mirror_last_updated_at:
+        type: string
+      ms_path:
         type: string
       name:
         type: string
@@ -1665,6 +1663,8 @@ definitions:
         type: boolean
       created_at:
         type: string
+      csg_path:
+        type: string
       default_branch:
         type: string
       description:
@@ -1677,6 +1677,8 @@ definitions:
         type: boolean
       enable_inference:
         type: boolean
+      hf_path:
+        type: string
       id:
         type: integer
       license:
@@ -1684,6 +1686,8 @@ definitions:
       likes:
         type: integer
       mirror_last_updated_at:
+        type: string
+      ms_path:
         type: string
       name:
         type: string
@@ -1772,8 +1776,6 @@ definitions:
         type: integer
       secure_level:
         type: integer
-      task:
-        type: string
     type: object
   types.ModelWidgetType:
     enum:
@@ -2255,6 +2257,20 @@ definitions:
       msg:
         type: string
     type: object
+  types.TagScope:
+    enum:
+    - model
+    - dataset
+    - code
+    - space
+    - prompt
+    type: string
+    x-enum-varnames:
+    - ModelTagScope
+    - DatasetTagScope
+    - CodeTagScope
+    - SpaceTagScope
+    - PromptTagScope
   types.TaskType:
     enum:
     - evaluation
@@ -10406,9 +10422,16 @@ paths:
         enum:
         - model
         - dataset
+        - code
+        - space
+        - prompt
         in: query
         name: scope
         type: string
+      - description: built_in
+        in: query
+        name: built_in
+        type: boolean
       produces:
       - application/json
       responses:


### PR DESCRIPTION
**What is this feature?**

user can download model with different source repo id.
https://hub.opencsg.com/hf for hugging model id
https://hub.opencsg.com/ms for modelscope model id

**Why do we need this feature?**
some open source tool like opencompass can support donwload with modelscope repo id, so using this way, csghub user can specify the id to download from csghub

**Who is this feature for?**
csghub sdk

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request introduces support for downloading models from different mirrors based on the source repository ID. It allows users to specify a repository ID from either Hugging Face or ModelScope to download models directly from CSGHub. This feature is aimed at enhancing the flexibility and usability of the CSGHub SDK by accommodating different repository sources.

Key updates include:
1. Added functionality to handle different mirror sources for model downloads.
2. Updated middleware and API routing to support new download paths based on the source repository ID.
3. Modified the `MirrorStore` interface and its implementation to support repository lookups by mapping types.
4. Enhanced Swagger documentation to reflect new query parameters and repository path options.
5. Updated unit tests to cover new functionality and ensure compatibility with existing features.

<!-- @codegpt description end -->