### PR TITLE
[dataviewer] Support preview json/csv large file and optimize thread num

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -241,10 +241,10 @@ type Config struct {
 		ActivityMaximumAttempts                 int32  `env:"OPENCSG_DATAVIEWER_ACTIVITY_MAXIMUM_ATTEMPTS, default=2"`
 		CacheDir                                string `env:"OPENCSG_DATAVIEWER_CACHE_DIR, default=/tmp/opencsg"`
 		DownloadLfsFile                         bool   `env:"OPENCSG_DATAVIEWER_DOWNLOAD_LFS_FILE, default=true"`
-		ThreadNumOfExport                       int    `env:"OPENCSG_DATAVIEWER_THREAD_NUM_OF_EXPORT, default=4"`
-		MaxFileSize                             int64  `env:"OPENCSG_DATAVIEWER_MAX_FILE_SIZE, default=104857600"` // 100 MB
+		MaxThreadNumOfExport                    int    `env:"OPENCSG_DATAVIEWER_MAX_THREAD_NUM_OF_EXPORT, default=8"`
 		MaxConcurrentSessionExecutionSize       int    `env:"OPENCSG_DATAVIEWER_MAX_CONCURRENT_SESSION_EXECUTION_SIZE, default=1"`
-		SessionExecutionTimeout                 int    `env:"OPENCSG_DATAVIEWER_SESSION_EXECUTION_TIMEOUT, default=240"` // 240 minutes
+		SessionExecutionTimeout                 int    `env:"OPENCSG_DATAVIEWER_SESSION_EXECUTION_TIMEOUT, default=240"` // 240 mins
+		ConvertLimitSize                        int64  `env:"OPENCSG_DATAVIEWER_CONVERT_LIMIT_SIZE, default=5368709120"` // 5G
 	}
 
 	Proxy struct {

--- a/component/model.go
+++ b/component/model.go
@@ -1073,7 +1073,7 @@ func (c *modelComponentImpl) SetRuntimeFrameworkModes(ctx context.Context, curre
 		if err != nil {
 			return nil, err
 		}
-		if relations == nil || len(relations) < 1 {
+		if len(relations) < 1 {
 			err = c.repoRuntimeFrameworkStore.Add(ctx, id, model.Repository.ID, deployType)
 			if err != nil {
 				failedModels = append(failedModels, model.Repository.Path)
@@ -1135,7 +1135,7 @@ func (c *modelComponentImpl) ListModelsOfRuntimeFrameworks(ctx context.Context, 
 		return nil, 0, fmt.Errorf("failed to get repo by deploy type, error:%w", err)
 	}
 
-	if runtimeRepos == nil || len(runtimeRepos) < 1 {
+	if len(runtimeRepos) < 1 {
 		return nil, 0, nil
 	}
 

--- a/dataviewer/common/types.go
+++ b/dataviewer/common/types.go
@@ -67,19 +67,27 @@ type Split struct {
 }
 
 type RepoFilesReq struct {
-	Namespace string
-	RepoName  string
-	RepoType  types.RepositoryType
-	Ref       string
-	Folder    string
-	GSTree    func(ctx context.Context, req gitserver.GetRepoInfoByPathReq) ([]*types.File, error)
+	Namespace      string
+	RepoName       string
+	RepoType       types.RepositoryType
+	Ref            string
+	Folder         string
+	GSTree         func(ctx context.Context, req gitserver.GetRepoInfoByPathReq) ([]*types.File, error)
+	TotalLimitSize int64
+}
+
+type RepoFile struct {
+	*types.File
+	DownloadSize int64
 }
 
 type RepoFilesClass struct {
-	AllFiles     map[string]*types.File
-	ParquetFiles map[string]*types.File
-	JsonlFiles   map[string]*types.File
-	CsvFiles     map[string]*types.File
+	AllFiles      map[string]*RepoFile
+	ParquetFiles  map[string]*RepoFile
+	JsonlFiles    map[string]*RepoFile
+	CsvFiles      map[string]*RepoFile
+	TotalJsonSize int64
+	TotalCsvSize  int64
 }
 
 type DownloadCard struct {
@@ -111,6 +119,7 @@ type FileObject struct {
 	ObjectKey       string `yaml:"object_key" json:"object_key"`
 	LocalRepoPath   string `yaml:"local_repo_path" json:"local_repo_path"`
 	LocalFileName   string `yaml:"local_file_name" json:"local_file_name"`
+	DownloadSize    int64  `yaml:"download_size" json:"download_size"`
 }
 
 type CataLogRespone struct {
@@ -126,8 +135,8 @@ type WorkflowUpdateParams struct {
 }
 
 type ScanRepoFileReq struct {
-	Req         types.UpdateViewerReq
-	MaxFileSize int64
+	Req              types.UpdateViewerReq
+	ConvertLimitSize int64
 }
 
 type DetermineCardReq struct {
@@ -171,4 +180,18 @@ type UpdateWorkflowStatusReq struct {
 	Req                types.UpdateViewerReq
 	WorkflowErrMsg     string
 	ShouldUpdateViewer bool
+}
+
+type FileExtName struct {
+	Parquet string
+	Jsonl   string
+	Json    string
+	Csv     string
+}
+
+type SplitName struct {
+	Train string
+	Test  string
+	Val   string
+	Other string
 }

--- a/dataviewer/component/dataset_viewer.go
+++ b/dataviewer/component/dataset_viewer.go
@@ -602,11 +602,11 @@ func (c *datasetViewerComponentImpl) getParquetFilesBySplit(ctx context.Context,
 
 			var validator func(string) bool
 			switch split {
-			case workflows.TrainSplitName:
+			case workflows.SplitName.Train:
 				validator = workflows.IsTrainFile
-			case workflows.TestSplitName:
+			case workflows.SplitName.Test:
 				validator = workflows.IsTestFile
-			case workflows.ValSplitName:
+			case workflows.SplitName.Val:
 				validator = workflows.IsValidationFile
 			default:
 				return nil, fmt.Errorf("unknown split type: %s", split)
@@ -661,24 +661,24 @@ func (c *datasetViewerComponentImpl) genDefaultCatalog(ctx context.Context, req 
 		if calcTotal {
 			total = c.getFilesRowCount(ctx, req, trainFiles)
 		}
-		configData.DataFiles = append(configData.DataFiles, dvCom.DataFiles{Split: workflows.TrainSplitName, Path: trainFiles})
-		datasetInfo.Splits = append(datasetInfo.Splits, dvCom.Split{Name: workflows.TrainSplitName, NumExamples: total})
+		configData.DataFiles = append(configData.DataFiles, dvCom.DataFiles{Split: workflows.SplitName.Train, Path: trainFiles})
+		datasetInfo.Splits = append(datasetInfo.Splits, dvCom.Split{Name: workflows.SplitName.Train, NumExamples: total})
 	}
 	if len(testFiles) > 0 {
 		total := 0
 		if calcTotal {
 			total = c.getFilesRowCount(ctx, req, testFiles)
 		}
-		configData.DataFiles = append(configData.DataFiles, dvCom.DataFiles{Split: workflows.TestSplitName, Path: testFiles})
-		datasetInfo.Splits = append(datasetInfo.Splits, dvCom.Split{Name: workflows.TestSplitName, NumExamples: total})
+		configData.DataFiles = append(configData.DataFiles, dvCom.DataFiles{Split: workflows.SplitName.Test, Path: testFiles})
+		datasetInfo.Splits = append(datasetInfo.Splits, dvCom.Split{Name: workflows.SplitName.Test, NumExamples: total})
 	}
 	if len(valFiles) > 0 {
 		total := 0
 		if calcTotal {
 			total = c.getFilesRowCount(ctx, req, valFiles)
 		}
-		configData.DataFiles = append(configData.DataFiles, dvCom.DataFiles{Split: workflows.ValSplitName, Path: valFiles})
-		datasetInfo.Splits = append(datasetInfo.Splits, dvCom.Split{Name: workflows.ValSplitName, NumExamples: total})
+		configData.DataFiles = append(configData.DataFiles, dvCom.DataFiles{Split: workflows.SplitName.Val, Path: valFiles})
+		datasetInfo.Splits = append(datasetInfo.Splits, dvCom.Split{Name: workflows.SplitName.Val, NumExamples: total})
 	}
 	configData.ConfigName = workflows.DefaultSubsetName
 	datasetInfo.ConfigName = workflows.DefaultSubsetName

--- a/dataviewer/workflows/activity.go
+++ b/dataviewer/workflows/activity.go
@@ -258,7 +258,7 @@ func (dva *dataViewerActivityImpl) DetermineCardData(ctx context.Context, determ
 	} else if determineParam.RepoDataType == RepoCsvData {
 		scopeFiles = determineParam.Class.CsvFiles
 	}
-	if scopeFiles == nil || len(scopeFiles) < 1 {
+	if len(scopeFiles) < 1 {
 		slog.Warn("no valid target files found", slog.Any("card", determineParam.Card))
 		return nil, nil
 	}

--- a/dataviewer/workflows/activity.go
+++ b/dataviewer/workflows/activity.go
@@ -47,10 +47,11 @@ type DataViewerActivity interface {
 }
 
 type dataViewerActivityImpl struct {
-	gitServer   gitserver.GitServer
-	s3Client    s3.Client
-	cfg         *config.Config
-	viewerStore database.DataviewerStore
+	gitServer    gitserver.GitServer
+	s3Client     s3.Client
+	cfg          *config.Config
+	viewerStore  database.DataviewerStore
+	lfsMetaStore database.LfsMetaObjectStore
 }
 
 func NewDataViewerActivity(cfg *config.Config, gs gitserver.GitServer) (DataViewerActivity, error) {
@@ -59,10 +60,11 @@ func NewDataViewerActivity(cfg *config.Config, gs gitserver.GitServer) (DataView
 		return nil, fmt.Errorf("fail to init s3 client for data viewer, error: %w", err)
 	}
 	return &dataViewerActivityImpl{
-		gitServer:   gs,
-		s3Client:    s3Client,
-		cfg:         cfg,
-		viewerStore: database.NewDataviewerStore(),
+		gitServer:    gs,
+		s3Client:     s3Client,
+		cfg:          cfg,
+		viewerStore:  database.NewDataviewerStore(),
+		lfsMetaStore: database.NewLfsMetaObjectStore(),
 	}, nil
 }
 
@@ -126,27 +128,30 @@ func (dva *dataViewerActivityImpl) GetCardFromReadme(ctx context.Context, req ty
 
 func (dva *dataViewerActivityImpl) ScanRepoFiles(ctx context.Context, scanParam dvCom.ScanRepoFileReq) (*dvCom.RepoFilesClass, error) {
 	repoReq := dvCom.RepoFilesReq{
-		Namespace: scanParam.Req.Namespace,
-		RepoName:  scanParam.Req.Name,
-		RepoType:  scanParam.Req.RepoType,
-		Ref:       scanParam.Req.Branch,
-		Folder:    "",
-		GSTree:    dva.gitServer.GetRepoFileTree,
+		Namespace:      scanParam.Req.Namespace,
+		RepoName:       scanParam.Req.Name,
+		RepoType:       scanParam.Req.RepoType,
+		Ref:            scanParam.Req.Branch,
+		Folder:         "",
+		GSTree:         dva.gitServer.GetRepoFileTree,
+		TotalLimitSize: scanParam.ConvertLimitSize,
 	}
 	fileClass := dvCom.RepoFilesClass{
-		AllFiles:     make(map[string]*types.File),
-		ParquetFiles: make(map[string]*types.File),
-		JsonlFiles:   make(map[string]*types.File),
-		CsvFiles:     make(map[string]*types.File),
+		AllFiles:      make(map[string]*dvCom.RepoFile),
+		ParquetFiles:  make(map[string]*dvCom.RepoFile),
+		JsonlFiles:    make(map[string]*dvCom.RepoFile),
+		CsvFiles:      make(map[string]*dvCom.RepoFile),
+		TotalJsonSize: 0,
+		TotalCsvSize:  0,
 	}
-	err := GetFilePaths(repoReq, &fileClass, scanParam.MaxFileSize)
+	err := GetFilePaths(repoReq, &fileClass)
 	if err != nil {
 		return nil, fmt.Errorf("scan repo file error: %w", err)
 	}
 	return &fileClass, nil
 }
 
-func (dva *dataViewerActivityImpl) autoBuildCardData(card *dvCom.CardData, sortKeys []string, targetFiles map[string]*types.File) {
+func (dva *dataViewerActivityImpl) autoBuildCardData(card *dvCom.CardData, sortKeys []string, targetFiles map[string]*dvCom.RepoFile) {
 	var (
 		trainFiles []string
 		testFiles  []string
@@ -165,50 +170,50 @@ func (dva *dataViewerActivityImpl) autoBuildCardData(card *dvCom.CardData, sortK
 		}
 		if IsTrainFile(path) {
 			trainFiles = append(trainFiles, path)
-			trainFileObjects = append(trainFileObjects, TransferFileObject(file, DefaultSubsetName, TrainSplitName))
+			trainFileObjects = append(trainFileObjects, TransferFileObject(file, DefaultSubsetName, SplitName.Train))
 		} else if IsTestFile(path) {
 			testFiles = append(testFiles, path)
-			testFileObjects = append(testFileObjects, TransferFileObject(file, DefaultSubsetName, TestSplitName))
+			testFileObjects = append(testFileObjects, TransferFileObject(file, DefaultSubsetName, SplitName.Test))
 		} else if IsValidationFile(path) {
 			valFiles = append(valFiles, path)
-			valFileObjects = append(valFileObjects, TransferFileObject(file, DefaultSubsetName, ValSplitName))
+			valFileObjects = append(valFileObjects, TransferFileObject(file, DefaultSubsetName, SplitName.Val))
 		} else {
 			otherFiles = append(otherFiles, path)
-			otherFileObjects = append(otherFileObjects, TransferFileObject(file, DefaultSubsetName, OtherSplitName))
+			otherFileObjects = append(otherFileObjects, TransferFileObject(file, DefaultSubsetName, SplitName.Other))
 		}
 	}
 	var configData dvCom.ConfigData
 	var datasetInfo dvCom.DatasetInfo
 	if len(trainFiles) > 0 {
 		configData.DataFiles = append(configData.DataFiles,
-			dvCom.DataFiles{Split: TrainSplitName, Path: trainFiles},
+			dvCom.DataFiles{Split: SplitName.Train, Path: trainFiles},
 		)
 		datasetInfo.Splits = append(datasetInfo.Splits,
-			dvCom.Split{Name: TrainSplitName, NumExamples: 0, Origins: trainFileObjects},
+			dvCom.Split{Name: SplitName.Train, NumExamples: 0, Origins: trainFileObjects},
 		)
 	}
 	if len(testFiles) > 0 {
 		configData.DataFiles = append(configData.DataFiles,
-			dvCom.DataFiles{Split: TestSplitName, Path: testFiles},
+			dvCom.DataFiles{Split: SplitName.Test, Path: testFiles},
 		)
 		datasetInfo.Splits = append(datasetInfo.Splits,
-			dvCom.Split{Name: TestSplitName, NumExamples: 0, Origins: testFileObjects},
+			dvCom.Split{Name: SplitName.Test, NumExamples: 0, Origins: testFileObjects},
 		)
 	}
 	if len(valFiles) > 0 {
 		configData.DataFiles = append(configData.DataFiles,
-			dvCom.DataFiles{Split: ValSplitName, Path: valFiles},
+			dvCom.DataFiles{Split: SplitName.Val, Path: valFiles},
 		)
 		datasetInfo.Splits = append(datasetInfo.Splits,
-			dvCom.Split{Name: ValSplitName, NumExamples: 0, Origins: valFileObjects},
+			dvCom.Split{Name: SplitName.Val, NumExamples: 0, Origins: valFileObjects},
 		)
 	}
 	if len(otherFiles) > 0 {
 		configData.DataFiles = append(configData.DataFiles,
-			dvCom.DataFiles{Split: OtherSplitName, Path: otherFiles},
+			dvCom.DataFiles{Split: SplitName.Other, Path: otherFiles},
 		)
 		datasetInfo.Splits = append(datasetInfo.Splits,
-			dvCom.Split{Name: OtherSplitName, NumExamples: 0, Origins: otherFileObjects},
+			dvCom.Split{Name: SplitName.Other, NumExamples: 0, Origins: otherFileObjects},
 		)
 	}
 	if len(configData.DataFiles) > 0 {
@@ -219,7 +224,7 @@ func (dva *dataViewerActivityImpl) autoBuildCardData(card *dvCom.CardData, sortK
 	}
 }
 
-func (dva *dataViewerActivityImpl) fillUpCardData(card *dvCom.CardData, sortKeys []string, targetFiles map[string]*types.File) *dvCom.CardData {
+func (dva *dataViewerActivityImpl) fillUpCardData(card *dvCom.CardData, sortKeys []string, targetFiles map[string]*dvCom.RepoFile) *dvCom.CardData {
 	var configs []dvCom.ConfigData
 	var infos []dvCom.DatasetInfo
 	for _, conf := range card.Configs {
@@ -245,7 +250,7 @@ func (dva *dataViewerActivityImpl) fillUpCardData(card *dvCom.CardData, sortKeys
 }
 
 func (dva *dataViewerActivityImpl) DetermineCardData(ctx context.Context, determineParam dvCom.DetermineCardReq) (*dvCom.CardData, error) {
-	var scopeFiles map[string]*types.File
+	var scopeFiles map[string]*dvCom.RepoFile
 	if determineParam.RepoDataType == RepoParquetData {
 		scopeFiles = determineParam.Class.ParquetFiles
 	} else if determineParam.RepoDataType == RepoJsonData {
@@ -254,7 +259,7 @@ func (dva *dataViewerActivityImpl) DetermineCardData(ctx context.Context, determ
 		scopeFiles = determineParam.Class.CsvFiles
 	}
 	if scopeFiles == nil || len(scopeFiles) < 1 {
-		slog.Warn("no target valid files found", slog.Any("card", determineParam.Card))
+		slog.Warn("no valid target files found", slog.Any("card", determineParam.Card))
 		return nil, nil
 	}
 
@@ -468,14 +473,13 @@ func (dva *dataViewerActivityImpl) DownloadSplitFiles(ctx context.Context, downl
 					Size:          file.Size,
 					SubsetName:    info.ConfigName,
 					SplitName:     split.Name,
-				})
+				}, extName)
 				if err != nil {
 					slog.Error("failed to download file", slog.Any("req", downloadReq.Req),
 						slog.Any("file", file), slog.Any("error", err))
 					return nil, fmt.Errorf("failed to download file %s in branch %s, cause: %w",
 						file.RepoFile, downloadReq.Req.Branch, err)
 				}
-				// slog.Info("downloaded file successfully", slog.Any("req", req), slog.Any("file", file), slog.Any("downloadObj", downloadObj))
 				newFiles = append(newFiles, *downloadObj)
 			}
 			splitPath := fmt.Sprintf("%s/%s/%s", cacheRepoPath, info.ConfigName, split.Name)
@@ -489,7 +493,7 @@ func (dva *dataViewerActivityImpl) DownloadSplitFiles(ctx context.Context, downl
 	return &dvCom.DownloadCard{Configs: downloadReq.Card.Configs, Subsets: subsets}, nil
 }
 
-func (dva *dataViewerActivityImpl) downloadFile(ctx context.Context, req types.UpdateViewerReq, orginFile dvCom.FileObject, loadFile *dvCom.FileObject) (*dvCom.FileObject, error) {
+func (dva *dataViewerActivityImpl) downloadFile(ctx context.Context, req types.UpdateViewerReq, orginFile dvCom.FileObject, loadFile *dvCom.FileObject, fileExtName string) (*dvCom.FileObject, error) {
 	cacheFilePath := fmt.Sprintf("%s/%s/%s", loadFile.LocalRepoPath, loadFile.SubsetName, loadFile.SplitName)
 	_, err := os.Stat(cacheFilePath)
 	if err != nil && !os.IsNotExist(err) {
@@ -504,12 +508,12 @@ func (dva *dataViewerActivityImpl) downloadFile(ctx context.Context, req types.U
 	}
 	localFileFullPath := fmt.Sprintf("%s/%s", cacheFilePath, loadFile.LocalFileName)
 	if orginFile.Lfs {
-		err := dva.downloadLfsFile(ctx, localFileFullPath, orginFile, loadFile)
+		err := dva.downloadLfsFile(ctx, localFileFullPath, orginFile, loadFile, fileExtName)
 		if err != nil {
 			return nil, fmt.Errorf("fail to download repo %s/%s lfs file %s, error: %w", req.Namespace, req.Name, orginFile.RepoFile, err)
 		}
 	} else {
-		err := dva.downloadNormalFile(ctx, localFileFullPath, req, orginFile, loadFile)
+		err := dva.downloadNormalFile(ctx, localFileFullPath, req, orginFile, loadFile, fileExtName)
 		if err != nil {
 			return nil, fmt.Errorf("fail to download repo %s/%s normal file %s, error: %w", req.Namespace, req.Name, orginFile.RepoFile, err)
 		}
@@ -518,7 +522,7 @@ func (dva *dataViewerActivityImpl) downloadFile(ctx context.Context, req types.U
 	return loadFile, nil
 }
 
-func (dva *dataViewerActivityImpl) downloadLfsFile(ctx context.Context, localFileFullPath string, orginFile dvCom.FileObject, loadFile *dvCom.FileObject) error {
+func (dva *dataViewerActivityImpl) downloadLfsFile(ctx context.Context, localFileFullPath string, orginFile dvCom.FileObject, loadFile *dvCom.FileObject, fileExtName string) error {
 	objectKey := orginFile.LfsRelativePath
 	objectKey = path.Join("lfs", objectKey)
 	loadFile.ObjectKey = objectKey
@@ -545,14 +549,15 @@ func (dva *dataViewerActivityImpl) downloadLfsFile(ctx context.Context, localFil
 	}
 	defer writeFile.Close()
 
-	_, err = io.Copy(writeFile, resp.Body)
+	err = dva.CopyFileContent(writeFile, resp.Body, orginFile, loadFile, fileExtName)
 	if err != nil {
-		return fmt.Errorf("failed to save local file %s, error: %w", localFileFullPath, err)
+		return fmt.Errorf("failed to save local file %s for repo file %s from url: %s, error: %w", localFileFullPath, orginFile.RepoFile, signedUrl.String(), err)
 	}
+
 	return nil
 }
 
-func (dva *dataViewerActivityImpl) downloadNormalFile(ctx context.Context, localFileFullPath string, req types.UpdateViewerReq, orginFile dvCom.FileObject, loadFile *dvCom.FileObject) error {
+func (dva *dataViewerActivityImpl) downloadNormalFile(ctx context.Context, localFileFullPath string, req types.UpdateViewerReq, orginFile dvCom.FileObject, loadFile *dvCom.FileObject, fileExtName string) error {
 	getFileReaderReq := gitserver.GetRepoInfoByPathReq{
 		Namespace: req.Namespace,
 		Name:      req.Name,
@@ -561,20 +566,51 @@ func (dva *dataViewerActivityImpl) downloadNormalFile(ctx context.Context, local
 		RepoType:  req.RepoType,
 	}
 	reader, size, err := dva.gitServer.GetRepoFileReader(ctx, getFileReaderReq)
-	loadFile.Size = size
 	if err != nil {
 		return fmt.Errorf("failed to get repo %s/%s file %s for reader, error: %w", req.Namespace, req.Name, orginFile.RepoFile, err)
 	}
+	loadFile.Size = size
+	defer reader.Close()
+
 	writeFile, err := os.Create(localFileFullPath)
 	if err != nil {
 		return fmt.Errorf("failed to create local file %s for repo %s/%s file %s, error: %w", localFileFullPath, req.Namespace, req.Name, orginFile.RepoFile, err)
 	}
 	defer writeFile.Close()
 
-	_, err = io.Copy(writeFile, reader)
+	err = dva.CopyFileContent(writeFile, reader, orginFile, loadFile, fileExtName)
+
 	if err != nil {
 		return fmt.Errorf("failed to save local file %s for repo %s/%s file %s, error: %w", localFileFullPath, req.Namespace, req.Name, orginFile.RepoFile, err)
 	}
+
+	return nil
+}
+
+func (dva *dataViewerActivityImpl) CopyFileContent(writeFile *os.File, reader io.ReadCloser, orginFile dvCom.FileObject, loadFile *dvCom.FileObject, fileExtName string) error {
+	if (orginFile.Size - orginFile.DownloadSize) <= MinFileSizeGap {
+		_, err := io.Copy(writeFile, reader)
+		if err != nil {
+			return fmt.Errorf("failed to copy the whole file content error: %w", err)
+		}
+		loadFile.DownloadSize = loadFile.Size
+		return nil
+	}
+
+	if fileExtName == FileExtName.Json {
+		copyedSize, err := CopyJsonArray(writeFile, reader, orginFile.DownloadSize)
+		if err != nil {
+			return fmt.Errorf("failed to copy json array partly, error: %w", err)
+		}
+		loadFile.DownloadSize = copyedSize
+	} else {
+		copyedSize, err := CopyFileContext(writeFile, reader, orginFile.DownloadSize)
+		if err != nil {
+			return fmt.Errorf("failed to copy content partly, error: %w", err)
+		}
+		loadFile.DownloadSize = copyedSize
+	}
+
 	return nil
 }
 
@@ -590,12 +626,14 @@ func (dva *dataViewerActivityImpl) ConvertToParquetFiles(ctx context.Context, co
 				continue
 			}
 			objectNames := []string{}
+			totalDataSize := int64(0)
 			for _, file := range split.Files {
 				if file.Lfs && !dva.cfg.DataViewer.DownloadLfsFile {
 					objectNames = append(objectNames, fmt.Sprintf("'s3://%s/%s'", dva.cfg.S3.Bucket, file.ObjectKey))
 				} else {
 					objectNames = append(objectNames, fmt.Sprintf("'%s/%s/%s/%s'", file.LocalRepoPath, file.SubsetName, file.SplitName, file.LocalFileName))
 				}
+				totalDataSize += file.DownloadSize
 			}
 			slog.Debug("ConvertToParquetFiles", slog.Any("objectNames", objectNames))
 			_, err = os.Stat(split.ExportPath)
@@ -615,7 +653,8 @@ func (dva *dataViewerActivityImpl) ConvertToParquetFiles(ctx context.Context, co
 				method = "read_csv_auto"
 			}
 			splitExportPath := fmt.Sprintf("%s/", strings.TrimSuffix(split.ExportPath, "/"))
-			err = writer.ConvertToParquet(ctx, method, objectNames, dva.cfg.DataViewer.ThreadNumOfExport, splitExportPath)
+			threadNum := GetThreadNum(totalDataSize, dva.cfg.DataViewer.MaxThreadNumOfExport)
+			err = writer.ConvertToParquet(ctx, method, objectNames, threadNum, splitExportPath)
 			if err != nil {
 				slog.Error("failed to convert data", slog.Any("objectNames", objectNames),
 					slog.Any("req", convertReq.Req), slog.Any("configname", subset.ConfigName),
@@ -744,6 +783,17 @@ func (dva *dataViewerActivityImpl) uploadToRepo(ctx context.Context, req types.U
 
 	if uploadInfo.Size != pointer.Size {
 		return fmt.Errorf("uploaded S3 file %s size does not match expected size: %d != %d", uploadFile.ConvertPath, uploadInfo.Size, pointer.Size)
+	}
+
+	metaReq := database.LfsMetaObject{
+		Oid:          pointer.Oid,
+		Size:         pointer.Size,
+		RepositoryID: req.RepoID,
+		Existing:     true,
+	}
+	_, err = dva.lfsMetaStore.UpdateOrCreate(ctx, metaReq)
+	if err != nil {
+		return fmt.Errorf("failed to create meta record for lfs file %s in repo %s/%s branch %s, cause: %w", uploadFile.RepoFile, req.Namespace, req.Name, newBranch, err)
 	}
 
 	createReq := &types.CreateFileReq{

--- a/dataviewer/workflows/activity_test.go
+++ b/dataviewer/workflows/activity_test.go
@@ -106,8 +106,8 @@ func TestActivity_ScanRepoFiles(t *testing.T) {
 	require.Nil(t, err)
 
 	cls, err := dvActivity.ScanRepoFiles(ctx, dvCom.ScanRepoFileReq{
-		Req:         req,
-		MaxFileSize: config.DataViewer.MaxFileSize,
+		Req:              req,
+		ConvertLimitSize: config.DataViewer.ConvertLimitSize,
 	})
 	require.Nil(t, err)
 	require.NotNil(t, cls)
@@ -128,14 +128,24 @@ func TestActivity_DetermineCardData(t *testing.T) {
 	card := dvCom.CardData{}
 
 	repoFileClass := dvCom.RepoFilesClass{
-		AllFiles: map[string]*types.File{
-			"foo.parquet": {Name: "foo.parquet", Path: "train/foo.parquet"},
+		AllFiles: map[string]*dvCom.RepoFile{
+			"foo.parquet": {
+				File: &types.File{
+					Name: "foo.parquet",
+					Path: "train/foo.parquet",
+				},
+			},
 		},
-		ParquetFiles: map[string]*types.File{
-			"foo.parquet": {Name: "foo.parquet", Path: "train/foo.parquet"},
+		ParquetFiles: map[string]*dvCom.RepoFile{
+			"foo.parquet": {
+				File: &types.File{
+					Name: "foo.parquet",
+					Path: "train/foo.parquet",
+				},
+			},
 		},
-		JsonlFiles: map[string]*types.File{},
-		CsvFiles:   map[string]*types.File{},
+		JsonlFiles: map[string]*dvCom.RepoFile{},
+		CsvFiles:   map[string]*dvCom.RepoFile{},
 	}
 
 	dvActivity, err := NewTestDataViewerActivity(config, mockGitServer, s3Client, dvstore)

--- a/dataviewer/workflows/repo_files.go
+++ b/dataviewer/workflows/repo_files.go
@@ -11,31 +11,42 @@ import (
 )
 
 const (
-	RepoParquetData dvCom.RepoDataType = "parquet"
-	RepoJsonData    dvCom.RepoDataType = "json"
-	RepoCsvData     dvCom.RepoDataType = "csv"
+	RepoParquetData   dvCom.RepoDataType = "parquet"
+	RepoJsonData      dvCom.RepoDataType = "json"
+	RepoCsvData       dvCom.RepoDataType = "csv"
+	DataSizePerThread                    = 804857600
 )
 
 var (
 	GitDefaultUserName  = "admin"
 	GitDefaultUserEmail = "admin@csghub.com"
 	DefaultSubsetName   = "default"
-	TrainSplitName      = "train"
-	TestSplitName       = "test"
-	ValSplitName        = "validation"
-	OtherSplitName      = "others"
+	SplitName           = dvCom.SplitName{
+		Train: "train",
+		Test:  "test",
+		Val:   "validation",
+		Other: "others",
+	}
+	FileExtName = dvCom.FileExtName{
+		Parquet: ".parquet",
+		Jsonl:   ".jsonl",
+		Json:    ".json",
+		Csv:     ".csv",
+	}
+	MinFileSizeGap = int64(1048576)
 )
 
 func IsValidParquetFile(entryName string) bool {
-	return strings.HasSuffix(strings.ToLower(entryName), ".parquet")
+	return strings.HasSuffix(strings.ToLower(entryName), FileExtName.Parquet)
 }
 
 func IsValidJsonFile(entryName string) bool {
-	return strings.HasSuffix(strings.ToLower(entryName), ".jsonl") || strings.HasSuffix(strings.ToLower(entryName), ".json")
+	return strings.HasSuffix(strings.ToLower(entryName), FileExtName.Jsonl) ||
+		strings.HasSuffix(strings.ToLower(entryName), FileExtName.Json)
 }
 
 func IsValidCSVFile(entryName string) bool {
-	return strings.HasSuffix(strings.ToLower(entryName), ".csv")
+	return strings.HasSuffix(strings.ToLower(entryName), FileExtName.Csv)
 }
 
 func IsTrainFile(fileName string) bool {
@@ -68,15 +79,15 @@ func IsValidationFile(fileName string) bool {
 	return false
 }
 
-func GetFilePaths(req dvCom.RepoFilesReq, fileClass *dvCom.RepoFilesClass, maxFileSize int64) error {
-	err := getAllFiles(req, fileClass, maxFileSize)
+func GetFilePaths(req dvCom.RepoFilesReq, fileClass *dvCom.RepoFilesClass) error {
+	err := getAllFiles(req, fileClass)
 	if err != nil {
 		return fmt.Errorf("get repo all files error: %w", err)
 	}
 	return nil
 }
 
-func getAllFiles(req dvCom.RepoFilesReq, fileClass *dvCom.RepoFilesClass, maxFileSize int64) error {
+func getAllFiles(req dvCom.RepoFilesReq, fileClass *dvCom.RepoFilesClass) error {
 	getRepoFileTree := gitserver.GetRepoInfoByPathReq{
 		Namespace: req.Namespace,
 		Name:      req.RepoName,
@@ -91,34 +102,66 @@ func getAllFiles(req dvCom.RepoFilesReq, fileClass *dvCom.RepoFilesClass, maxFil
 	for _, file := range gitFiles {
 		if file.Type == "dir" {
 			err := getAllFiles(dvCom.RepoFilesReq{
-				Namespace: req.Namespace,
-				RepoName:  req.RepoName,
-				Folder:    file.Path,
-				RepoType:  req.RepoType,
-				Ref:       req.Ref,
-				GSTree:    req.GSTree,
-			}, fileClass, maxFileSize)
+				Namespace:      req.Namespace,
+				RepoName:       req.RepoName,
+				Folder:         file.Path,
+				RepoType:       req.RepoType,
+				Ref:            req.Ref,
+				GSTree:         req.GSTree,
+				TotalLimitSize: req.TotalLimitSize,
+			}, fileClass)
 			if err != nil {
 				return fmt.Errorf("list folder %s files error: %w", file.Path, err)
 			}
 		} else {
-			appendFile(file, fileClass, maxFileSize)
+			appendFile(file, fileClass, req.TotalLimitSize)
 		}
 	}
 	return nil
 }
 
-func appendFile(file *types.File, fileClass *dvCom.RepoFilesClass, maxFileSize int64) {
-	fileClass.AllFiles[file.Path] = file
-	if IsValidParquetFile(file.Name) {
-		fileClass.ParquetFiles[file.Path] = file
-	} else if IsValidJsonFile(file.Name) {
-		if file.Size <= maxFileSize {
-			fileClass.JsonlFiles[file.Path] = file
-		}
-	} else if IsValidCSVFile(file.Name) {
-		if file.Size <= maxFileSize {
-			fileClass.CsvFiles[file.Path] = file
-		}
+func appendFile(file *types.File, fileClass *dvCom.RepoFilesClass, limitSize int64) {
+	repoFile := &dvCom.RepoFile{
+		File:         file,
+		DownloadSize: file.Size,
 	}
+	fileClass.AllFiles[file.Path] = repoFile
+
+	if IsValidParquetFile(file.Name) {
+		fileClass.ParquetFiles[file.Path] = repoFile
+		return
+	}
+
+	if IsValidJsonFile(file.Name) {
+		if fileClass.TotalJsonSize >= limitSize {
+			return
+		}
+		if fileClass.TotalJsonSize+file.Size > limitSize {
+			fileClass.JsonlFiles[file.Path] = &dvCom.RepoFile{
+				File:         file,
+				DownloadSize: limitSize - fileClass.TotalJsonSize,
+			}
+		} else {
+			fileClass.JsonlFiles[file.Path] = repoFile
+		}
+		fileClass.TotalJsonSize += fileClass.JsonlFiles[file.Path].DownloadSize
+		return
+	}
+
+	if IsValidCSVFile(file.Name) {
+		if fileClass.TotalCsvSize >= limitSize {
+			return
+		}
+		if fileClass.TotalCsvSize+file.Size > limitSize {
+			fileClass.CsvFiles[file.Path] = &dvCom.RepoFile{
+				File:         file,
+				DownloadSize: limitSize - fileClass.TotalCsvSize,
+			}
+		} else {
+			fileClass.CsvFiles[file.Path] = repoFile
+		}
+		fileClass.TotalCsvSize += fileClass.CsvFiles[file.Path].DownloadSize
+		return
+	}
+
 }

--- a/dataviewer/workflows/repo_files_test.go
+++ b/dataviewer/workflows/repo_files_test.go
@@ -15,14 +15,14 @@ func TestRepoFiles_appendFile(t *testing.T) {
 	}
 
 	fileClass := dvCom.RepoFilesClass{
-		AllFiles:     make(map[string]*types.File),
-		ParquetFiles: make(map[string]*types.File),
-		JsonlFiles:   make(map[string]*types.File),
-		CsvFiles:     make(map[string]*types.File),
+		AllFiles:     make(map[string]*dvCom.RepoFile),
+		ParquetFiles: make(map[string]*dvCom.RepoFile),
+		JsonlFiles:   make(map[string]*dvCom.RepoFile),
+		CsvFiles:     make(map[string]*dvCom.RepoFile),
 	}
 
 	appendFile(file, &fileClass, 100)
 
 	require.Equal(t, 1, len(fileClass.AllFiles))
-	require.Equal(t, 0, len(fileClass.JsonlFiles))
+	require.Equal(t, 1, len(fileClass.JsonlFiles))
 }

--- a/dataviewer/workflows/utils.go
+++ b/dataviewer/workflows/utils.go
@@ -1,11 +1,15 @@
 package workflows
 
 import (
+	"bufio"
 	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -15,7 +19,7 @@ import (
 	dvCom "opencsg.com/csghub-server/dataviewer/common"
 )
 
-func TransferFileObject(file *types.File, subsetName, splitName string) dvCom.FileObject {
+func TransferFileObject(file *dvCom.RepoFile, subsetName, splitName string) dvCom.FileObject {
 	return dvCom.FileObject{
 		RepoFile:        file.Path,
 		Size:            file.Size,
@@ -24,6 +28,7 @@ func TransferFileObject(file *types.File, subsetName, splitName string) dvCom.Fi
 		LfsRelativePath: file.LfsRelativePath,
 		SubsetName:      subsetName,
 		SplitName:       splitName,
+		DownloadSize:    file.DownloadSize,
 	}
 }
 
@@ -46,7 +51,7 @@ func GetPatternFileList(path interface{}) []string {
 	return files
 }
 
-func ConvertRealFiles(splitFiles []string, sortKeys []string, targetFiles map[string]*types.File, subsetName, splitName string) []dvCom.FileObject {
+func ConvertRealFiles(splitFiles []string, sortKeys []string, targetFiles map[string]*dvCom.RepoFile, subsetName, splitName string) []dvCom.FileObject {
 	var phyFiles []dvCom.FileObject
 	for _, filePattern := range splitFiles {
 		if !strings.Contains(filePattern, dvCom.WILDCARD) {
@@ -103,4 +108,81 @@ func GetCacheRepoPath(ctx context.Context, cacheDir string, req types.UpdateView
 	segments := strings.Split(workflowID, "-")
 	timeSeq := segments[len(segments)-1]
 	return fmt.Sprintf("%s/%s/%s/%s/%s", strings.TrimSuffix(cacheDir, "/"), req.RepoType, req.Namespace, req.Name, timeSeq)
+}
+
+func CopyJsonArray(writeFile *os.File, reader io.ReadCloser, limitSize int64) (int64, error) {
+	decoder := json.NewDecoder(reader)
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('[') {
+		return 0, fmt.Errorf("invalid json array object error: %w", err)
+	}
+	writer := NewFileWriter(writeFile)
+	encoder := json.NewEncoder(writer)
+	_, err = writer.Write([]byte{'['})
+	if err != nil {
+		return 0, fmt.Errorf("write json begin delimiter error: %w", err)
+	}
+	count := 0
+	var copyedBytes int64
+	for decoder.More() {
+		if copyedBytes >= limitSize {
+			break
+		}
+		var obj map[string]interface{}
+		if err := decoder.Decode(&obj); err != nil {
+			return 0, fmt.Errorf("parse json object error: %w", err)
+		}
+		if count > 0 {
+			_, err = writer.Write([]byte{','})
+			if err != nil {
+				return 0, fmt.Errorf("write comma error: %w", err)
+			}
+		}
+
+		err = encoder.Encode(obj)
+		if err != nil {
+			return 0, fmt.Errorf("encode json object error: %w", err)
+		}
+		count++
+		copyedBytes += int64(writer.GetWriteBytes())
+	}
+	_, err = writer.Write([]byte{']'})
+	if err != nil {
+		return 0, fmt.Errorf("write json end delimiter error: %w", err)
+	}
+	return copyedBytes, nil
+}
+
+func CopyFileContext(writeFile *os.File, reader io.ReadCloser, limitSize int64) (int64, error) {
+	var copyedBytes int64
+	scanner := bufio.NewScanner(reader)
+	writer := bufio.NewWriter(writeFile)
+
+	for scanner.Scan() {
+		if copyedBytes >= limitSize {
+			break
+		}
+		line := scanner.Text()
+		n, err := writer.WriteString(fmt.Sprintln(line))
+		if err != nil {
+			return copyedBytes, fmt.Errorf("write content by line error: %w", err)
+		}
+		err = writer.Flush()
+		if err != nil {
+			return 0, fmt.Errorf("flush data error: %w", err)
+		}
+		copyedBytes += int64(n)
+	}
+
+	return copyedBytes, nil
+}
+
+func GetThreadNum(totalDataSize int64, maxThreadNum int) int {
+	threadNum := int(totalDataSize / DataSizePerThread)
+	if threadNum < 1 {
+		threadNum = 1
+	} else if threadNum > maxThreadNum {
+		threadNum = maxThreadNum
+	}
+	return threadNum
 }

--- a/dataviewer/workflows/utils_test.go
+++ b/dataviewer/workflows/utils_test.go
@@ -1,6 +1,9 @@
 package workflows
 
 import (
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,15 +29,21 @@ func TestUtils_ConvertRealFiles(t *testing.T) {
 	splitFiles := []string{"a/1.parquet", "b/2.parquet"}
 	sortKeys := []string{"a", "b"}
 
-	targetFiles := map[string]*types.File{
+	targetFiles := map[string]*dvCom.RepoFile{
 		"a/1.parquet": {
-			Path: "a/1.parquet",
+			File: &types.File{
+				Path: "a/1.parquet",
+			},
 		},
 		"b/2.parquet": {
-			Path: "b/2.parquet",
+			File: &types.File{
+				Path: "b/2.parquet",
+			},
 		},
 		"c/3.parquet": {
-			Path: "c/3.parquet",
+			File: &types.File{
+				Path: "c/3.parquet",
+			},
 		},
 	}
 
@@ -64,4 +73,102 @@ func TestUtils_GetCardDataMD5(t *testing.T) {
 	out := GetCardDataMD5(card)
 
 	require.Equal(t, "e096cecdbd943760b46ac073b6fd8d24", out)
+}
+
+func TestUtils_GetThreadNum(t *testing.T) {
+	t.Run("min thread num", func(t *testing.T) {
+		num := GetThreadNum(0, 2)
+		require.Equal(t, 1, num)
+	})
+
+	t.Run("normal thread num", func(t *testing.T) {
+		num := GetThreadNum(DataSizePerThread*4, 8)
+		require.Equal(t, 4, num)
+	})
+
+	t.Run("max thread num", func(t *testing.T) {
+		num := GetThreadNum(DataSizePerThread*10, 8)
+		require.Equal(t, 8, num)
+	})
+
+}
+
+func TestUtils_CopyFileContext(t *testing.T) {
+	tempFile := "/tmp/write_tmp_line_file"
+
+	t.Run("whole file", func(t *testing.T) {
+		writeFile, err := os.Create(tempFile)
+		require.Nil(t, err)
+
+		defer os.Remove(tempFile)
+
+		reader := io.NopCloser(strings.NewReader("it is not possible.\nIf it is odd."))
+
+		len, err := CopyFileContext(writeFile, reader, 100)
+		require.Nil(t, err)
+		require.Equal(t, int64(34), len)
+
+		data, err := os.ReadFile(tempFile)
+
+		require.Nil(t, err)
+		require.Equal(t, "it is not possible.\nIf it is odd.\n", string(data))
+	})
+
+	t.Run("partial file", func(t *testing.T) {
+		writeFile, err := os.Create(tempFile)
+		require.Nil(t, err)
+
+		defer os.Remove(tempFile)
+
+		reader := io.NopCloser(strings.NewReader("it is not possible.\nIf it is odd."))
+
+		len, err := CopyFileContext(writeFile, reader, 20)
+		require.Nil(t, err)
+		require.Equal(t, int64(20), len)
+
+		data, err := os.ReadFile(tempFile)
+
+		require.Nil(t, err)
+		require.Equal(t, "it is not possible.\n", string(data))
+	})
+
+}
+
+func TestUtils_CopyJsonArray(t *testing.T) {
+	tempFile := "/tmp/write_tmp_json_file"
+
+	t.Run("whole file", func(t *testing.T) {
+		writeFile, err := os.Create(tempFile)
+		require.Nil(t, err)
+
+		defer os.Remove(tempFile)
+
+		reader := io.NopCloser(strings.NewReader("[{\"a\": 1}, {\"b\": 2}]"))
+
+		len, err := CopyJsonArray(writeFile, reader, 100)
+		require.Nil(t, err)
+		require.Equal(t, int64(16), len)
+
+		data, err := os.ReadFile(tempFile)
+		require.Nil(t, err)
+		require.Equal(t, "[{\"a\":1}\n,{\"b\":2}\n]", string(data))
+	})
+
+	t.Run("partial file", func(t *testing.T) {
+		writeFile, err := os.Create(tempFile)
+		require.Nil(t, err)
+
+		defer os.Remove(tempFile)
+
+		reader := io.NopCloser(strings.NewReader("[{\"a\": 1}, {\"b\": 2}]"))
+
+		len, err := CopyJsonArray(writeFile, reader, 5)
+		require.Nil(t, err)
+		require.Equal(t, int64(8), len)
+
+		data, err := os.ReadFile(tempFile)
+		require.Nil(t, err)
+		require.Equal(t, "[{\"a\":1}\n]", string(data))
+	})
+
 }

--- a/dataviewer/workflows/workflow.go
+++ b/dataviewer/workflows/workflow.go
@@ -102,8 +102,8 @@ func runWorkFlow(sessionCtx workflow.Context, updateWorkflow dvCom.WorkflowUpdat
 	var repoFileClass dvCom.RepoFilesClass
 	err = workflow.ExecuteActivity(sessionCtx, DataViewerActivity.ScanRepoFiles,
 		dvCom.ScanRepoFileReq{
-			Req:         updateWorkflow.Req,
-			MaxFileSize: updateWorkflow.Config.DataViewer.MaxFileSize},
+			Req:              updateWorkflow.Req,
+			ConvertLimitSize: updateWorkflow.Config.DataViewer.ConvertLimitSize},
 	).Get(sessionCtx, &repoFileClass)
 	if err != nil {
 		return false, fmt.Errorf("run data viewer activity GetCardFromReadme error: %w", err)
@@ -171,7 +171,7 @@ func runWorkFlow(sessionCtx workflow.Context, updateWorkflow dvCom.WorkflowUpdat
 			},
 		).Get(sessionCtx, &downloadCard)
 		if err != nil {
-			return false, fmt.Errorf("run data viewer activity CopyParquetFiles error: %w", err)
+			return false, fmt.Errorf("run data viewer activity DownloadSplitFiles error: %w", err)
 		}
 
 		err = workflow.ExecuteActivity(sessionCtx, DataViewerActivity.ConvertToParquetFiles,

--- a/dataviewer/workflows/workflow_test.go
+++ b/dataviewer/workflows/workflow_test.go
@@ -68,13 +68,15 @@ func TestWorkflow_DataviewerWorkflow(t *testing.T) {
 		tester.mocks.mockact.EXPECT().GetCardFromReadme(mock.Anything, req).Return(&dvCom.CardData{}, nil)
 		tester.mocks.mockact.EXPECT().ScanRepoFiles(mock.Anything,
 			dvCom.ScanRepoFileReq{
-				Req:         req,
-				MaxFileSize: cfg.DataViewer.MaxFileSize,
+				Req:              req,
+				ConvertLimitSize: cfg.DataViewer.ConvertLimitSize,
 			}).Return(&dvCom.RepoFilesClass{
-			JsonlFiles: map[string]*types.File{
+			JsonlFiles: map[string]*dvCom.RepoFile{
 				"test": {
-					Path: "test",
-					Size: 1024,
+					File: &types.File{
+						Path: "test",
+						Size: 1024,
+					},
 				},
 			},
 		}, nil)
@@ -82,10 +84,12 @@ func TestWorkflow_DataviewerWorkflow(t *testing.T) {
 			dvCom.DetermineCardReq{
 				Card: dvCom.CardData{},
 				Class: dvCom.RepoFilesClass{
-					JsonlFiles: map[string]*types.File{
+					JsonlFiles: map[string]*dvCom.RepoFile{
 						"test": {
-							Path: "test",
-							Size: 1024,
+							File: &types.File{
+								Path: "test",
+								Size: 1024,
+							},
 						},
 					},
 				},
@@ -159,13 +163,15 @@ func TestWorkflow_DataviewerWorkflow(t *testing.T) {
 		tester.mocks.mockact.EXPECT().GetCardFromReadme(mock.Anything, req).Return(&dvCom.CardData{}, nil)
 		tester.mocks.mockact.EXPECT().ScanRepoFiles(mock.Anything,
 			dvCom.ScanRepoFileReq{
-				Req:         req,
-				MaxFileSize: cfg.DataViewer.MaxFileSize,
+				Req:              req,
+				ConvertLimitSize: cfg.DataViewer.ConvertLimitSize,
 			}).Return(&dvCom.RepoFilesClass{
-			ParquetFiles: map[string]*types.File{
+			ParquetFiles: map[string]*dvCom.RepoFile{
 				"test": {
-					Path: "test",
-					Size: 1024,
+					File: &types.File{
+						Path: "test",
+						Size: 1024,
+					},
 				},
 			},
 		}, nil)
@@ -173,10 +179,12 @@ func TestWorkflow_DataviewerWorkflow(t *testing.T) {
 			dvCom.DetermineCardReq{
 				Card: dvCom.CardData{},
 				Class: dvCom.RepoFilesClass{
-					ParquetFiles: map[string]*types.File{
+					ParquetFiles: map[string]*dvCom.RepoFile{
 						"test": {
-							Path: "test",
-							Size: 1024,
+							File: &types.File{
+								Path: "test",
+								Size: 1024,
+							},
 						},
 					},
 				},

--- a/dataviewer/workflows/writer.go
+++ b/dataviewer/workflows/writer.go
@@ -1,0 +1,25 @@
+package workflows
+
+import (
+	"os"
+)
+
+type FileWriterImpl struct {
+	file       *os.File
+	writeBytes int
+}
+
+func NewFileWriter(file *os.File) *FileWriterImpl {
+	return &FileWriterImpl{
+		file: file,
+	}
+}
+
+func (fw *FileWriterImpl) Write(p []byte) (n int, err error) {
+	fw.writeBytes, err = fw.file.Write(p)
+	return fw.writeBytes, err
+}
+
+func (fw *FileWriterImpl) GetWriteBytes() int {
+	return fw.writeBytes
+}


### PR DESCRIPTION
**What is this feature?**

merge code of support preview large json/csv file

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request introduces support for previewing large JSON/CSV files and optimizes the number of threads used for exporting data. Key updates include:

1. Increased maximum thread number for exports from 4 to 8 and introduced a conversion limit size of 5GB for large file handling.
2. Enhanced file handling in `dataviewer/common/types.go` to include total JSON and CSV file sizes, improving file management and processing.
3. Updated `dataset_viewer.go` to support efficient data retrieval and catalog generation for large datasets, including handling for parquet files.
4. Implemented new workflow activities in `activity.go` for scanning repository files, determining card data, and managing file conversions and uploads, with added support for JSON and CSV file types.
5. Added unit tests and utility functions to support the new features and ensure robustness.

This MR optimizes data processing capabilities, particularly for large datasets, and improves the system's scalability and efficiency.

<!-- @codegpt description end -->