### PR TITLE
Dataset viewer workflow refactor and bug fix

### DIFF
--- a/api/workflow/worker_ce.go
+++ b/api/workflow/worker_ce.go
@@ -38,13 +38,12 @@ func StartWorkflow(cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	temporalClient, err := client.Dial(client.Options{
+	client, err := temporal.NewClient(client.Options{
 		HostPort: cfg.WorkFLow.Endpoint,
-	})
+	}, "csghub-api")
 	if err != nil {
 		return fmt.Errorf("unable to create workflow client, error: %w", err)
 	}
-	client, err := temporal.NewClient(temporalClient)
 	if err != nil {
 		return err
 	}

--- a/builder/temporal/temporal_test.go
+++ b/builder/temporal/temporal_test.go
@@ -34,15 +34,14 @@ func TestTemporalClient(t *testing.T) {
 	c := ts.GetDefaultClient()
 
 	tester := &Tester{client: temporal.GetClient()}
-	_, err := temporal.NewClient(c)
-	require.NoError(t, err)
+	temporal.Assign(c)
 
 	worker1 := tester.client.NewWorker("q1", worker.Options{})
 	worker1.RegisterWorkflow(tester.Count)
 	worker2 := tester.client.NewWorker("q2", worker.Options{})
 	worker2.RegisterWorkflow(tester.Add)
 
-	err = tester.client.Start()
+	err := tester.client.Start()
 	require.NoError(t, err)
 
 	r, err := tester.client.ExecuteWorkflow(context.TODO(), client.StartWorkflowOptions{

--- a/dataviewer/component/callback.go
+++ b/dataviewer/component/callback.go
@@ -100,8 +100,10 @@ func (c *callbackComponentImpl) TriggerDataviewUpdateWorkflow(ctx context.Contex
 		WorkflowExecutionTimeout: executeTimeOut,
 		WorkflowTaskTimeout:      taskTimeout,
 	}
-	wfRun, err := c.workflowClient.ExecuteWorkflow(ctx, options, workflows.DataViewerUpdateWorkflow,
-		dvCom.WorkflowUpdateParams{Req: req, Config: c.cfg})
+	wfRun, err := c.workflowClient.ExecuteWorkflow(
+		context.Background(), options, workflows.DataViewerUpdateWorkflow,
+		dvCom.WorkflowUpdateParams{Req: req, Config: c.cfg},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("fail to execute workflow, error: %w", err)
 	}

--- a/dataviewer/workflows/activity_test.go
+++ b/dataviewer/workflows/activity_test.go
@@ -3,6 +3,7 @@ package workflows
 import (
 	"context"
 	"encoding/base64"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -91,15 +92,18 @@ func TestActivity_ScanRepoFiles(t *testing.T) {
 		RepoID:    int64(1),
 	}
 
-	mockGitServer.EXPECT().GetRepoFileTree(mock.Anything, gitserver.GetRepoInfoByPathReq{
+	mockGitServer.EXPECT().GetTree(mock.Anything, types.GetTreeRequest{
 		Namespace: req.Namespace,
 		Name:      req.Name,
 		Ref:       req.Branch,
 		RepoType:  req.RepoType,
+		Limit:     math.MaxInt,
+		Recursive: true,
 	}).Return(
-		[]*types.File{
-			{Name: "foobar.parquet", Path: "foo/foobar.parquet"},
-		}, nil,
+		&types.GetRepoFileTreeResp{
+			Files: []*types.File{
+				{Name: "foobar.parquet", Path: "foo/foobar.parquet"},
+			}}, nil,
 	)
 
 	dvActivity, err := NewTestDataViewerActivity(config, mockGitServer, s3Client, dvstore)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/alibabacloud-go/green-20220302 v1.2.0
 	github.com/alibabacloud-go/tea v1.2.1
 	github.com/aliyun/alibaba-cloud-sdk-go v1.62.648
+	github.com/bmatcuk/doublestar/v4 v4.8.1
 	github.com/casdoor/casdoor-go-sdk v0.41.0
 	github.com/chenyahui/gin-cache v1.9.0
 	github.com/d5/tengo/v2 v2.17.0
@@ -61,6 +62,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.33.0
 	go.temporal.io/api v1.43.0
 	go.temporal.io/sdk v1.31.0
+	go.temporal.io/sdk/contrib/opentelemetry v0.6.0
 	go.temporal.io/server v1.26.2
 	google.golang.org/grpc v1.68.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
+github.com/bmatcuk/doublestar/v4 v4.8.1 h1:54Bopc5c2cAvhLRAzqOGCYHYyhcDHsFF4wWIR5wKP38=
+github.com/bmatcuk/doublestar/v4 v4.8.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
@@ -828,6 +830,8 @@ go.temporal.io/api v1.43.0 h1:lBhq+u5qFJqGMXwWsmg/i8qn1UA/3LCwVc88l2xUMHg=
 go.temporal.io/api v1.43.0/go.mod h1:1WwYUMo6lao8yl0371xWUm13paHExN5ATYT/B7QtFis=
 go.temporal.io/sdk v1.31.0 h1:CLYiP0R5Sdj0gq8LyYKDDz4ccGOdJPR8wNGJU0JGwj8=
 go.temporal.io/sdk v1.31.0/go.mod h1:8U8H7rF9u4Hyb4Ry9yiEls5716DHPNvVITPNkgWUwE8=
+go.temporal.io/sdk/contrib/opentelemetry v0.6.0 h1:rNBArDj5iTUkcMwKocUShoAW59o6HdS7Nq4CTp4ldj8=
+go.temporal.io/sdk/contrib/opentelemetry v0.6.0/go.mod h1:Lem8VrE2ks8P+FYcRM3UphPoBr+tfM3v/Kaf0qStzSg=
 go.temporal.io/server v1.26.2 h1:vDW11lxslYPlGDbQklWi/tqbkVZ2ExtRO1jNjvZmUUI=
 go.temporal.io/server v1.26.2/go.mod h1:tgY+4z/PuIdqs6ouV1bT90RWSWfEioWkzmrNrLYLUrk=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=


### PR DESCRIPTION
#### What this PR includes:

**Enabling Tracing for Temporal Workflow**
![screenshot-20250211-162605](https://github.com/user-attachments/assets/6820e3c7-da84-4de5-b7a2-b61bdd8e0315)


**Refactor `ScanRepoFiles` in Dataset Viewer Workflows**

The `ScanRepoFiles` function is triggered every time there is a dataset repository git push. When there are a large number of files, it has a significant impact on performance and generates massive logs in Gitaly. Therefore, the function has been modified to use the new Gitaly Tree API to retrieve files. The optimization effect is similar to the tree API optimization PR: when there are many files, the number of Gitaly requests reduces from 100+ to 1, and the time taken reduces from seconds/minutes to microseconds.

**Fix README Dataset Config Parsing**

Hugging Face dataset cards allow the definition of dataset configurations in the README using YAML:

```
---
configs:
- config_name: default
  data_files:
  - split: train
    path: "data/*.csv"
  - split: test
    path: "holdout/*.csv"
---
```

In this case, the `path` uses a wildcard format, and through manual testing, the `**` syntax is also supported, for example, `data/**/*.csv`.

**Issue**: The current code uses regex for matching instead of the wildcard format, which is completely incompatible with the Hugging Face syntax.

**Fix**: The code has been updated to use [doublestar](https://github.com/bmatcuk/doublestar) for matching (since Go's built-in `filepath` does not support the `**` syntax). Relevant tests have also been added.