### PR TITLE
[dataviewer] replace temporal default log level

### DIFF
--- a/cmd/csghub-server/cmd/dataviewer/launch.go
+++ b/cmd/csghub-server/cmd/dataviewer/launch.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/log"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/builder/instrumentation"
 	"opencsg.com/csghub-server/builder/store/database"
@@ -42,6 +43,7 @@ var launchCmd = &cobra.Command{
 
 		client, err := temporal.NewClient(client.Options{
 			HostPort: cfg.WorkFLow.Endpoint,
+			Logger:   log.NewStructuredLogger(slog.Default()),
 		}, "dataset-viewer")
 		if err != nil {
 			return fmt.Errorf("unable to create workflow client, error: %w", err)


### PR DESCRIPTION
**What is this feature?**

replace temporal default log level

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request introduces a modification to the dataviewer component, specifically aiming to replace the default log level used within the temporal workflow client configuration. Key updates include:
1. Addition of the temporal SDK log package import.
2. Configuration of the temporal client to use a new structured logger as its default logger.

<!-- @codegpt description end -->