### PR TITLE
write user data back casdoor

### DIFF
--- a/user/component/user.go
+++ b/user/component/user.go
@@ -268,9 +268,10 @@ func (c *userComponentImpl) Update(ctx context.Context, req *types.UpdateUserReq
 	}
 
 	//skip casdoor update if it's not a casdoor user
-	if req.UUID == nil || user.RegProvider != "casdoor" {
+	if user.UUID == "" || user.RegProvider != "casdoor" {
 		return nil
 	}
+	req.UUID = &user.UUID
 	err = c.updateCasdoorUser(req)
 	if err != nil {
 		newError := fmt.Errorf("failed to update casdoor user '%s',error:%w", req.Username, err)

--- a/user/component/user.go
+++ b/user/component/user.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -710,6 +711,7 @@ func (c *userComponentImpl) updateCasdoorUser(req *types.UpdateUserRequest) erro
 
 	// get id by user name before changed
 	id := c.casc.GetId(casu.Name)
+	id = url.QueryEscape(id) // wechat user's name may contain special characters
 	if req.NewUserName != nil {
 		casu.Name = *req.NewUserName
 	}


### PR DESCRIPTION
**What is this feature?**

Users registered via WeChat can modify their username once. It is necessary to write the new username back to Casdoor; otherwise, the usernames in the CSGHub and Casdoor systems will be inconsistent. This inconsistency may result in newly registered users in Casdoor having the same username as existing users in CSGHub, leading to login failures.

**Why do we need this feature?**
user may not login successfully after registration.

**Who is this feature for?**

if you need to support wechat login.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR introduces a feature to synchronize username changes made by WeChat registered users back to the Casdoor system, preventing login issues due to username inconsistencies. Key updates include:
1. Added checks to ensure UUID is present before updating Casdoor user.
2. Enhanced the updateCasdoorUser function to handle changes in email, phone, username, and nickname.
3. Replaced the UpdateUserForColumns method with UpdateUserById to update user details in Casdoor.
4. Added error handling for cases when user details are not found in Casdoor.

<!-- @codegpt description end -->