### PR TITLE
Add options to skip lfs file validation

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -258,6 +258,10 @@ type Config struct {
 		OTLPEndpoint string `env:"OPENCSG_TRACING_OTLP_ENDPOINT"`
 		OTLPLogging  bool   `env:"OPENCSG_TRACING_OTLP_LOGGING"`
 	}
+
+	Git struct {
+		SkipLfsFileValidation bool `env:"STARHUB_SERVER_SKIP_LFS_FILE_VALIDATION, default=false"`
+	}
 }
 
 func SetConfigFile(file string) {


### PR DESCRIPTION
**What is this feature?**

Add options to skip lfs file validation to speed up the lfs file upload.

set `STARHUB_SERVER_SKIP_LFS_FILE_VALIDATION` to `true` to skip lfs file validation.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**
