### PR TITLE
[runtime] add RuntimeFramework structure in migration

### DIFF
--- a/builder/store/database/migrations/20240515100435_create_runtime_framework.go
+++ b/builder/store/database/migrations/20240515100435_create_runtime_framework.go
@@ -4,14 +4,22 @@ import (
 	"context"
 
 	"github.com/uptrace/bun"
-	"opencsg.com/csghub-server/builder/store/database"
 )
+
+type RuntimeFramework struct {
+	ID           int64  `bun:",pk,autoincrement" json:"id"`
+	FrameName    string `bun:",notnull" json:"frame_name"`
+	FrameVersion string `bun:",notnull" json:"frame_version"`
+	FrameImage   string `bun:",nullzero" json:"frame_image"`
+	Enabled      int64  `bun:",notnull" json:"enabled"`
+	times
+}
 
 func init() {
 	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
-		err := createTables(ctx, db, database.RuntimeFramework{})
+		err := createTables(ctx, db, RuntimeFramework{})
 		return err
 	}, func(ctx context.Context, db *bun.DB) error {
-		return dropTables(ctx, db, database.RuntimeFramework{})
+		return dropTables(ctx, db, RuntimeFramework{})
 	})
 }

--- a/builder/store/database/migrations/20250328033800_update_runtime_framework_columns.down.sql
+++ b/builder/store/database/migrations/20250328033800_update_runtime_framework_columns.down.sql
@@ -6,10 +6,6 @@ ALTER TABLE runtime_frameworks ALTER COLUMN frame_image SET NOT NULL;
 
 --bun:split
 
-ALTER TABLE runtime_frameworks ALTER COLUMN frame_npu_image SET NOT NULL;
-
---bun:split
-
 ALTER TABLE runtime_frameworks ALTER COLUMN frame_cpu_image SET NOT NULL;
 
 --bun:split

--- a/builder/store/database/migrations/20250328033800_update_runtime_framework_columns.down.sql
+++ b/builder/store/database/migrations/20250328033800_update_runtime_framework_columns.down.sql
@@ -1,0 +1,17 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE runtime_frameworks ALTER COLUMN frame_image SET NOT NULL;
+
+--bun:split
+
+ALTER TABLE runtime_frameworks ALTER COLUMN frame_npu_image SET NOT NULL;
+
+--bun:split
+
+ALTER TABLE runtime_frameworks ALTER COLUMN frame_cpu_image SET NOT NULL;
+
+--bun:split
+
+ALTER TABLE runtime_frameworks ALTER COLUMN engine_args SET NOT NULL;

--- a/builder/store/database/migrations/20250328033800_update_runtime_framework_columns.up.sql
+++ b/builder/store/database/migrations/20250328033800_update_runtime_framework_columns.up.sql
@@ -6,10 +6,6 @@ ALTER TABLE runtime_frameworks ALTER COLUMN frame_image DROP NOT NULL;
 
 --bun:split
 
-ALTER TABLE runtime_frameworks ALTER COLUMN frame_npu_image DROP NOT NULL;
-
---bun:split
-
 ALTER TABLE runtime_frameworks ALTER COLUMN frame_cpu_image DROP NOT NULL;
 
 --bun:split

--- a/builder/store/database/migrations/20250328033800_update_runtime_framework_columns.up.sql
+++ b/builder/store/database/migrations/20250328033800_update_runtime_framework_columns.up.sql
@@ -1,0 +1,17 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE runtime_frameworks ALTER COLUMN frame_image DROP NOT NULL;
+
+--bun:split
+
+ALTER TABLE runtime_frameworks ALTER COLUMN frame_npu_image DROP NOT NULL;
+
+--bun:split
+
+ALTER TABLE runtime_frameworks ALTER COLUMN frame_cpu_image DROP NOT NULL;
+
+--bun:split
+
+ALTER TABLE runtime_frameworks ALTER COLUMN engine_args DROP NOT NULL;

--- a/builder/store/database/runtime_framework.go
+++ b/builder/store/database/runtime_framework.go
@@ -42,7 +42,6 @@ type RuntimeFramework struct {
 	FrameName     string `bun:",notnull" json:"frame_name"`
 	FrameVersion  string `bun:",notnull" json:"frame_version"`
 	FrameImage    string `bun:",nullzero" json:"frame_image"`
-	FrameNpuImage string `bun:",nullzero" json:"frame_npu_image"`
 	FrameCpuImage string `bun:",nullzero" json:"frame_cpu_image"`
 	Enabled       int64  `bun:",notnull" json:"enabled"`
 	ContainerPort int    `bun:",notnull" json:"container_port"`

--- a/builder/store/database/runtime_framework.go
+++ b/builder/store/database/runtime_framework.go
@@ -41,13 +41,14 @@ type RuntimeFramework struct {
 	ID            int64  `bun:",pk,autoincrement" json:"id"`
 	FrameName     string `bun:",notnull" json:"frame_name"`
 	FrameVersion  string `bun:",notnull" json:"frame_version"`
-	FrameImage    string `bun:",notnull" json:"frame_image"`
-	FrameCpuImage string `bun:",notnull" json:"frame_cpu_image"`
+	FrameImage    string `bun:",nullzero" json:"frame_image"`
+	FrameNpuImage string `bun:",nullzero" json:"frame_npu_image"`
+	FrameCpuImage string `bun:",nullzero" json:"frame_cpu_image"`
 	Enabled       int64  `bun:",notnull" json:"enabled"`
 	ContainerPort int    `bun:",notnull" json:"container_port"`
 	Type          int    `bun:",notnull" json:"type"` // 0-space, 1-inference, 2-finetune
-	EngineArgs    string `bun:",notnull" json:"engine_args"`
-	ModelFormat   string `bun:"," json:"model_format"` // safetensors, gguf, or onnx
+	EngineArgs    string `bun:",nullzero" json:"engine_args"`
+	ModelFormat   string `bun:",nullzero" json:"model_format"` // safetensors, gguf, or onnx
 	times
 }
 


### PR DESCRIPTION
**What is this feature?**

Update runtime column nullable

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR introduces a new structure, 'RuntimeFramework', in the migration process. This structure includes fields like 'ID', 'FrameName', 'FrameVersion', 'FrameImage', and 'Enabled'. The 'FrameImage', 'FrameNpuImage', 'FrameCpuImage', 'EngineArgs', and 'ModelFormat' fields in the 'RuntimeFramework' structure have been updated to allow null values. The changes also include modifications in the 'createTables' and 'dropTables' functions to use the new 'RuntimeFramework' structure. 

Key updates:
1. Addition of 'RuntimeFramework' structure in the migration process.
2. Update of certain fields in 'RuntimeFramework' to allow null values.
3. Modification of 'createTables' and 'dropTables' functions to use the new structure.

<!-- @codegpt description end -->