### PR TITLE
Fix rename file bug

### DIFF
--- a/builder/git/gitserver/gitaly/file.go
+++ b/builder/git/gitserver/gitaly/file.go
@@ -235,6 +235,16 @@ func (c *Client) UpdateRepoFile(req *types.UpdateFileReq) (err error) {
 		RelativePath: BuildRelativePath(repoType, req.Namespace, req.Name),
 		GlRepository: filepath.Join(repoType, req.Namespace, req.Name),
 	}
+	header := &gitalypb.UserCommitFilesActionHeader{
+		Action:        gitalypb.UserCommitFilesActionHeader_UPDATE,
+		Base64Content: true,
+		FilePath:      []byte(req.FilePath),
+	}
+
+	if req.OriginPath != "" {
+		header.Action = gitalypb.UserCommitFilesActionHeader_MOVE
+		header.PreviousPath = []byte(req.OriginPath)
+	}
 	actions := []*gitalypb.UserCommitFilesRequest{
 		{
 			UserCommitFilesRequestPayload: &gitalypb.UserCommitFilesRequest_Header{
@@ -260,11 +270,7 @@ func (c *Client) UpdateRepoFile(req *types.UpdateFileReq) (err error) {
 			UserCommitFilesRequestPayload: &gitalypb.UserCommitFilesRequest_Action{
 				Action: &gitalypb.UserCommitFilesAction{
 					UserCommitFilesActionPayload: &gitalypb.UserCommitFilesAction_Header{
-						Header: &gitalypb.UserCommitFilesActionHeader{
-							Action:        gitalypb.UserCommitFilesActionHeader_UPDATE,
-							Base64Content: true,
-							FilePath:      []byte(req.FilePath),
-						},
+						Header: header,
 					},
 				},
 			},


### PR DESCRIPTION
**What is this feature?**

- Fix the bug that api raise an error when renaming an exists file.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR titled 'Fix rename file bug' addresses an issue where the API was throwing an error when renaming an existing file. The changes are made in the 'file.go' file in the 'gitaly' directory. The code modifications include the addition of a condition to check if the 'OriginPath' is not empty, and if so, it changes the 'Action' to 'MOVE' and sets the 'PreviousPath'. This change is aimed at handling file renaming more effectively. The 'header' variable is then used in the 'UserCommitFilesActionHeader' to streamline the code.

<!-- @codegpt description end -->