### PR TITLE
[SDK] add space routes for SDK access with file resolution and listing

### DIFF
--- a/api/router/api.go
+++ b/api/router/api.go
@@ -798,6 +798,11 @@ func createMappingRoutes(r *gin.Engine, group string, hfdsHandler *handler.HFDat
 			hfdsFileGroup.GET("/:namespace/:name/resolve/:branch/*file_path", middleware.RepoMapping(types.DatasetRepo), repoCommonHandler.SDKDownload)
 			hfdsFileGroup.HEAD("/:namespace/:name/resolve/:branch/*file_path", middleware.RepoMapping(types.DatasetRepo), repoCommonHandler.HeadSDKDownload)
 		}
+		hfSpaceFileGroup := hfGroup.Group("/spaces")
+		{
+			hfSpaceFileGroup.GET("/:namespace/:name/resolve/:branch/*file_path", middleware.RepoMapping(types.SpaceRepo), repoCommonHandler.SDKDownload)
+			hfSpaceFileGroup.HEAD("/:namespace/:name/resolve/:branch/*file_path", middleware.RepoMapping(types.SpaceRepo), repoCommonHandler.HeadSDKDownload)
+		}
 		hfAPIGroup := hfGroup.Group("/api")
 		{
 			hfAPIGroup.GET("/whoami-v2", userHandler.UserPermission)
@@ -815,6 +820,11 @@ func createMappingRoutes(r *gin.Engine, group string, hfdsHandler *handler.HFDat
 				hfDSAPIGroup.POST("/:namespace/:name/paths-info/:ref", hfdsHandler.DatasetPathsInfo)
 				hfDSAPIGroup.GET("/:namespace/:name/tree/:ref/*path_in_repo", hfdsHandler.DatasetTree)
 				hfDSAPIGroup.GET("/:namespace/:name/resolve/:ref/.huggingface.yaml", hfdsHandler.HandleHFYaml)
+			}
+			hfSpaceAPIGroup := hfAPIGroup.Group("/spaces")
+			{
+				hfSpaceAPIGroup.GET("/:namespace/:name/revision/:ref", middleware.RepoMapping(types.SpaceRepo), repoCommonHandler.SDKListFiles)
+				hfSpaceAPIGroup.GET("/:namespace/:name", middleware.RepoMapping(types.SpaceRepo), repoCommonHandler.SDKListFiles)
 			}
 		}
 	}


### PR DESCRIPTION
**What is this feature?**

add api route to support sdk download space

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR introduces new API routes to support SDK access for file resolution and listing in the 'spaces' section. Key updates include:
1. Addition of GET and HEAD methods for 'spaces' in 'hfSpaceFileGroup' to support SDK download.
2. Addition of GET methods for 'spaces' in 'hfSpaceAPIGroup' to support SDK file listing.
These changes are made in the 'api/router/api.go' file. The new routes will map to the 'SDKDownload' and 'SDKListFiles' functions in the 'repoCommonHandler'.

<!-- @codegpt description end -->