### PR TITLE
feat(runner-server):  Migrating Space Builder functionality to Runner Server to optimize the uniformity of the build process

### DIFF
--- a/builder/store/database/image_builder.go
+++ b/builder/store/database/image_builder.go
@@ -1,0 +1,115 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+type imageBuilderWorkStoreImpl struct {
+	db *DB
+}
+
+type ImageBuilderWorkStore interface {
+	Create(ctx context.Context, imageBuilder *ImageBuilderWork) (*ImageBuilderWork, error)
+	CreateOrUpdateByBuildID(ctx context.Context, imageBuilder *ImageBuilderWork) (*ImageBuilderWork, error)
+	FindByWorkName(ctx context.Context, workName string) (*ImageBuilderWork, error)
+	QueryStatusByBuildID(ctx context.Context, buildId string) (*ImageBuilderWork, error)
+	QueryByBuildID(ctx context.Context, buildId string) (*ImageBuilderWork, error)
+	UpdateByWorkName(ctx context.Context, work *ImageBuilderWork) (*ImageBuilderWork, error)
+}
+
+func NewImageBuilderStore() ImageBuilderWorkStore {
+	return &imageBuilderWorkStoreImpl{
+		db: defaultDB,
+	}
+}
+
+func NewImageBuilderStoreWithDB(db *DB) ImageBuilderWorkStore {
+	return &imageBuilderWorkStoreImpl{
+		db: db,
+	}
+}
+
+func (i *imageBuilderWorkStoreImpl) CreateOrUpdateByBuildID(ctx context.Context, work *ImageBuilderWork) (*ImageBuilderWork, error) {
+	ibw := ImageBuilderWork{}
+	err := i.db.Operator.Core.NewSelect().Model(&ibw).Where("build_id = ?", work.BuildId).Scan(ctx, &ibw)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return i.Create(ctx, work)
+	}
+	work.ID = ibw.ID
+	_, err = i.db.Core.NewUpdate().Model(work).WherePK().Exec(ctx)
+
+	return work, err
+}
+
+func (i *imageBuilderWorkStoreImpl) Create(ctx context.Context, work *ImageBuilderWork) (*ImageBuilderWork, error) {
+	res, err := i.db.Core.NewInsert().Model(work).Exec(ctx, work)
+	if err := assertAffectedOneRow(res, err); err != nil {
+		return nil, fmt.Errorf("failed to save imageBuilder in db, error:%w", err)
+	}
+
+	return work, nil
+}
+
+func (i *imageBuilderWorkStoreImpl) FindByWorkName(ctx context.Context, workName string) (*ImageBuilderWork, error) {
+	ibw := ImageBuilderWork{}
+	err := i.db.Operator.Core.NewSelect().Model(&ibw).Where("work_name = ?", workName).Scan(ctx, &ibw)
+	if err != nil {
+		return nil, err
+	}
+	return &ibw, nil
+}
+
+func (i *imageBuilderWorkStoreImpl) UpdateByWorkName(ctx context.Context, work *ImageBuilderWork) (*ImageBuilderWork, error) {
+	w, err := i.FindByWorkName(ctx, work.WorkName)
+	if err != nil {
+		return nil, err
+	}
+
+	work.ID = w.ID
+	_, err = i.db.Core.NewUpdate().Model(work).WherePK().Exec(ctx)
+	return work, err
+}
+
+func (i *imageBuilderWorkStoreImpl) QueryStatusByBuildID(ctx context.Context, buildId string) (*ImageBuilderWork, error) {
+	ibw := ImageBuilderWork{}
+	err := i.db.Operator.Core.NewSelect().Model(&ibw).Where("build_id = ?", buildId).Scan(ctx, &ibw)
+	if err != nil {
+		return nil, err
+	}
+	return &ibw, nil
+}
+
+func (i *imageBuilderWorkStoreImpl) QueryByBuildID(ctx context.Context, buildId string) (*ImageBuilderWork, error) {
+	ibw := ImageBuilderWork{}
+	err := i.db.Operator.Core.NewSelect().Model(&ibw).Where("build_id = ?", buildId).Scan(ctx, &ibw)
+	if err != nil {
+		return nil, err
+	}
+	return &ibw, nil
+}
+
+type ImageBuilderWork struct {
+	ID int64 `bun:",pk,autoincrement" json:"id"`
+
+	WorkName   string `bun:"work_name,notnull,unique" json:"work_name"`
+	WorkStatus string `bun:"work_status,notnull" json:"work_status"`
+	Message    string `bun:"message" json:"message"`
+	PodName    string `bun:"pod_name" json:"pod_name"`
+	ClusterID  string `bun:"cluster_id" json:"cluster_id"`
+	Namespace  string `bun:"namespace,notnull" json:"namespace"`
+	ImagePath  string `bun:"image_path,notnull" json:"image_path"`
+	BuildId    string `bun:"build_id,notnull,unique" json:"build_id"`
+
+	InitContainerStatus string `bun:"init_container_status,notnull" json:"init_container_status"`
+	InitContainerLog    string `bun:"init_container_log" json:"init_container_log"`
+	MainContainerLog    string `bun:"main_container_log" json:"main_container_log"`
+
+	times
+}

--- a/builder/store/database/image_builder_test.go
+++ b/builder/store/database/image_builder_test.go
@@ -1,0 +1,54 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/tests"
+)
+
+func TestImagebuilderStore_CRUD(t *testing.T) {
+	db := tests.InitTestDB()                       // Initialize test database
+	defer db.Close()                               // Close database after test
+	ctx := context.TODO()                          // Create context
+	imd := database.NewImageBuilderStoreWithDB(db) // Create store instance with test database
+
+	newWork := &database.ImageBuilderWork{
+		WorkName:            "test-work",
+		WorkStatus:          "Pending",
+		Message:             "",
+		ImagePath:           "test:v1",
+		BuildId:             "test",
+		PodName:             "test-pod",
+		ClusterID:           "test-cluster",
+		Namespace:           "test-namespace",
+		InitContainerStatus: "Running",
+		InitContainerLog:    "Init log",
+		MainContainerLog:    "Main log",
+	}
+
+	// Test Create method
+	createdWork, err := imd.Create(ctx, newWork)
+	require.NoError(t, err)           // Verify that there is no error
+	require.NotNil(t, createdWork.ID) // Verify that the returned work ID is not nil
+
+	// Test FindByWorkName method
+	foundWork, err := imd.FindByWorkName(ctx, newWork.WorkName)
+	require.NoError(t, err)                                    // Verify that there is no error
+	require.Equal(t, newWork.WorkName, foundWork.WorkName)     // Validate work name
+	require.Equal(t, newWork.WorkStatus, foundWork.WorkStatus) // Verify work status
+
+	// Test UpdateByWorkName method
+	newWork.WorkStatus = "InProgress" // Update work status
+	updatedWork, err := imd.UpdateByWorkName(ctx, newWork)
+	require.NoError(t, err)                                      // Verify that there is no error
+	require.Equal(t, newWork.WorkStatus, updatedWork.WorkStatus) // Verify updated work status
+
+	// Test QueryStatusByBuildID method
+	statusWork, err := imd.QueryStatusByBuildID(ctx, newWork.BuildId)
+	require.NoError(t, err)                                     // Verify that there is no error
+	require.Equal(t, newWork.WorkStatus, statusWork.WorkStatus) // Verify work status by build ID
+
+}

--- a/builder/store/database/migrations/20250321023208_create_image_builder_work.go
+++ b/builder/store/database/migrations/20250321023208_create_image_builder_work.go
@@ -1,0 +1,56 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/uptrace/bun"
+)
+
+type ImageBuilderWork struct {
+	ID int64 `bun:",pk,autoincrement" json:"id"`
+
+	WorkName   string `bun:"work_name,notnull,unique" json:"work_name"`
+	WorkStatus string `bun:"work_status,notnull" json:"work_status"`
+	Message    string `bun:"message" json:"message"`
+	PodName    string `bun:"pod_name" json:"pod_name"`
+	ClusterID  string `bun:"cluster_id" json:"cluster_id"`
+	Namespace  string `bun:"namespace,notnull" json:"namespace"`
+	ImagePath  string `bun:"image_path,notnull" json:"image_path"`
+	BuildId    string `bun:"build_id,notnull,unique" json:"build_id"`
+
+	InitContainerStatus string `bun:"init_container_status,notnull" json:"init_container_status"`
+	InitContainerLog    string `bun:"init_container_log" json:"init_container_log"`
+	MainContainerLog    string `bun:"main_container_log" json:"main_container_log"`
+
+	times
+}
+
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		if err := createTables(ctx, db, ImageBuilderWork{}); err != nil {
+			return err
+		}
+		_, err := db.NewCreateIndex().
+			Model(&ImageBuilderWork{}).
+			Index("idx_image_builder_work_work_name").
+			Column("work_name").
+			IfNotExists().
+			Exec(ctx)
+		if err != nil {
+			return err
+		}
+
+		_, err = db.NewCreateIndex().
+			Model(&ImageBuilderWork{}).
+			Index("idx_image_builder_work_build_id").
+			Column("build_id").
+			IfNotExists().
+			Exec(ctx)
+		if err != nil {
+			return err
+		}
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		return dropTables(ctx, db, ImageBuilderWork{})
+	})
+}

--- a/cmd/csghub-server/cmd/deploy/runner.go
+++ b/cmd/csghub-server/cmd/deploy/runner.go
@@ -33,7 +33,7 @@ var startRunnerCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("fail to initialize message queue, %w", err)
 		}
-		s, err := router.NewHttpServer(config)
+		s, err := router.NewHttpServer(cmd.Context(), config)
 		if err != nil {
 			return err
 		}

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -266,6 +266,15 @@ type Config struct {
 	AIGateway struct {
 		Port int `env:"OPENCSG_AIGATEWAY_PORT, default=8094"`
 	}
+
+	Runner struct {
+		ImageBuilderClusterID   string `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_CLUSTER_ID, default="`
+		ImageBuilderNamespace   string `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_NAMESPACE, default=imagebuilder"`
+		ImageBuilderGitImage    string `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_GIT_IMAGE, default=opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/alpine/git:2.36.2"`
+		ImageBuilderKanikoImage string `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_IMAGE, default=opencsg-registry.cn-beijing.cr.aliyuncs.com/public/kaniko-project-executor:v1.23.2"`
+		ImageBuilderJobTTL      int    `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_JOB_TTL, default=120"`
+		ImageBuilderStatusTTL   int    `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_STATUS_TTL, default=300"`
+	}
 }
 
 func SetConfigFile(file string) {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -112,7 +112,7 @@ type Config struct {
 	}
 
 	Space struct {
-		BuilderEndpoint string `env:"STARHUB_SERVER_SPACE_BUILDER_ENDPOINT, default=http://localhost:8081"`
+		BuilderEndpoint string `env:"STARHUB_SERVER_SPACE_BUILDER_ENDPOINT, default=http://localhost:8082"`
 		// base url for space api running in k8s cluster
 		RunnerEndpoint   string `env:"STARHUB_SERVER_SPACE_RUNNER_ENDPOINT, default=http://localhost:8082"`
 		RunnerServerPort int    `env:"STARHUB_SERVER_SPACE_RUNNER_SERVER_PORT, default=8082"`

--- a/common/config/config.toml.example
+++ b/common/config/config.toml.example
@@ -165,3 +165,10 @@ calc_recom_score_cron_expression = "0 1 * * *"
 
 [proxy]
 hosts = ["opencsg.com", "sync.opencsg.com"]
+
+[runner]
+image_builder_namespace = "imagebuilder-stg"
+image_builder_git_image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/alpine/git:2.36.2"
+image_builder_kaniko_image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/public/kaniko-project-executor:v1.23.2"
+image_builder_job_ttl = 120
+image_builder_status_ttl = 300

--- a/docker/spaces/builder/Dockerfile-python3.10
+++ b/docker/spaces/builder/Dockerfile-python3.10
@@ -1,0 +1,68 @@
+# Download LFS content while building in order to make this step cacheable
+#===== LFS =====
+FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/alpine/git:2.36.2 AS lfs
+WORKDIR /app
+
+COPY --link .lfs.opencsg.co .
+COPY --link ./SPACE_REPOSITORY ./
+RUN git init \
+        && git remote add origin $(cat ./SPACE_REPOSITORY) \
+        && git add --all \
+        && git config user.email "name@mail.com" \
+        && git config user.name "Name" \
+        && git commit -m "lfs" \
+        && git lfs pull \
+        && rm -rf .git .gitattributes
+#===============
+
+FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/space-base:python3.10 as base
+
+USER user
+COPY --link --chown=1000 ./ /home/user/app
+
+USER root
+# User Debian packages
+## Security warning : Potential user code executed as root (build time)
+RUN xargs -r -a ./packages.txt apt-get install -y \
+	&& rm -rf /var/lib/apt/lists/*
+
+USER user
+
+# Pypi source
+ARG PyPI 
+
+RUN if [ -n "${PyPI}" ]; then \
+        pip config set global.index-url ${PyPI}; \
+    else \
+        echo "PyPI is not defined, skipping pip index url setting "; \
+    fi
+
+
+# Pre requirements and  Python packages (e.g. upgrading pip)
+RUN pip install  --default-timeout=60 -r pre-requirements.txt && \
+    pip install  --default-timeout=60  -r requirements.txt
+	
+FROM base as pipfreeze
+RUN pip freeze > /tmp/freeze.txt
+
+FROM base
+
+# HF_ENDPOINT parameter
+ARG HF_ENDPOINT
+
+COPY --link --chown=1000 --from=lfs /app /home/user/app
+# Warning, if you change something under this line, dont forget to change the PIP_FREEZE_REVERSED_INDEX
+COPY --from=pipfreeze --link --chown=1000 /tmp/freeze.txt .
+ENV PYTHONPATH=$HOME/app \
+	PYTHONUNBUFFERED=1 \
+	#HF_HUB_ENABLE_HF_TRANSFER=1 \  # need hf-transfer python package
+	GRADIO_ALLOW_FLAGGING=never \
+	GRADIO_NUM_PORTS=1 \
+	GRADIO_SERVER_NAME=0.0.0.0 \
+	GRADIO_THEME=huggingface \
+	TQDM_POSITION=-1 \
+	TQDM_MININTERVAL=1 \
+	SYSTEM=spaces \
+    HF_ENDPOINT=${HF_ENDPOINT}
+
+ENTRYPOINT ["./start_entrypoint.sh"]

--- a/docker/spaces/builder/Dockerfile-python3.10-cuda11.8.0
+++ b/docker/spaces/builder/Dockerfile-python3.10-cuda11.8.0
@@ -1,0 +1,70 @@
+# Download LFS content while building in order to make this step cacheable
+#===== LFS =====
+FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/alpine/git:2.36.2 AS lfs
+WORKDIR /app
+
+COPY --link .lfs.opencsg.co .
+COPY --link ./SPACE_REPOSITORY ./
+RUN  git init \
+        && git remote add origin $(cat ./SPACE_REPOSITORY) \
+        && git add --all \
+        && git config user.email "name@mail.com" \
+        && git config user.name "Name" \
+        && git commit -m "lfs" \
+        && git lfs pull \
+        && rm -rf .git .gitattributes
+#===============
+
+FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/space-base:python3.10-cuda11.8.0 as base
+
+# BEGIN Dynamic Part
+USER user
+COPY --link --chown=1000 ./  /home/user/app
+
+USER root
+# User Debian packages
+## Security warning : Potential user code executed as root (build time)
+RUN xargs -r -a ./packages.txt apt-get install -y \
+	&& rm -rf /var/lib/apt/lists/*
+
+USER user
+
+# Pypi source
+ARG PyPI 
+
+RUN if [ -n "$PyPI" ]; then \
+        pip config set global.index-url ${PyPI}; \
+    else \
+        echo "PyPI is not defined, skipping pip index url setting "; \
+    fi
+
+
+# Pre requirements and  Python packages (e.g. upgrading pip)
+RUN pip install  --default-timeout=60 -r pre-requirements.txt && \
+    pip install  --default-timeout=60  -r requirements.txt
+
+FROM base as pipfreeze
+RUN pip freeze > /tmp/freeze.txt
+
+FROM base
+
+# HF_ENDPOINT parameter
+ARG HF_ENDPOINT
+
+COPY --link --chown=1000 --from=lfs /app /home/user/app
+# Warning, if you change something under this line, dont forget to change the PIP_FREEZE_REVERSED_INDEX
+COPY --from=pipfreeze --link --chown=1000 /tmp/freeze.txt .
+
+ENV PYTHONPATH=$HOME/app \
+	PYTHONUNBUFFERED=1 \
+	#HF_HUB_ENABLE_HF_TRANSFER=1 \  # need hf_transfer python package
+	GRADIO_ALLOW_FLAGGING=never \
+	GRADIO_NUM_PORTS=1 \
+	GRADIO_SERVER_NAME=0.0.0.0 \
+	GRADIO_THEME=huggingface \
+	TQDM_POSITION=-1 \
+	TQDM_MININTERVAL=1 \
+	SYSTEM=spaces \
+    HF_ENDPOINT=${HF_ENDPOINT}
+
+ENTRYPOINT ["./start_entrypoint.sh"]

--- a/docker/spaces/builder/embed.go
+++ b/docker/spaces/builder/embed.go
@@ -1,0 +1,8 @@
+package builder
+
+import (
+	"embed"
+)
+
+//go:embed *
+var ImagebuilderFs embed.FS

--- a/docker/spaces/builder/init.sh
+++ b/docker/spaces/builder/init.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+SDK_GRADIO="gradio"
+SDK_STREAMLIT="streamlit"
+SDK_DOCKER="docker"
+SDK_MCPSERVER="mcp_server"
+
+CURRENT_DIR=$(
+   cd "$(dirname "$0")"
+   pwd
+)
+
+# generate .lfs.opencsg.co folder
+gen_lfs_folder(){
+  destfolder=$lfs_folder_name
+
+  mkdir $lfs_folder_name
+
+  attfile=$lfs_folder_name/.gitattributes
+  touch $attfile
+  echo "* filter=lfs diff=lfs merge=lfs -text" >> $attfile
+
+  for file in $(git lfs ls-files | awk {'print $3'}); do
+     echo $file
+     directory=$(dirname "$file")
+     subfolder=$destfolder/$directory
+     mkdir -p $subfolder
+     cp $file $destfolder/$file
+  done
+}
+
+# generate Dockerfile
+gen_dockerfile(){
+  if [[ $sdk == $SDK_DOCKER ]]; then
+    if [[ ! -f "$repo/Dockerfile" ]]; then
+      echo "docker file $repo/Dockerfile does not exist"
+      exit 1
+    fi
+    return 0
+  fi
+
+  file="Dockerfile-python$python_version"
+  
+  if [[ $device == 'gpu' ]]; then
+    file=$file"-cuda11.8.0"
+  fi
+
+  echo "the Dockerfile is $file"
+
+  sourcefile="$source_dir/$file"
+  echo $sourcefile
+  if [[ -f $sourcefile ]]; then
+      cp $sourcefile  $repo/Dockerfile
+  else
+      echo "docker file $sourcefile does not exist"
+      exit 1
+  fi
+}
+
+gen_start_script(){
+
+app_file="app.py"
+  if [[ $sdk == $SDK_GRADIO || $sdk == $SDK_MCPSERVER ]]; then
+      # echo "#!/bin/sh \n python3 app.py" > $repo/start_entrypoint.sh
+      cat >  $repo/start_entrypoint.sh <<EOF
+#!/bin/sh
+
+python3 $app_file
+EOF
+  elif [[ $sdk == $SDK_STREAMLIT ]]; then
+      # echo "#!/bin/sh \n streamlit run app.py" > $repo/start_entrypoint.sh
+      cat >  $repo/start_entrypoint.sh <<EOF
+#!/bin/sh
+
+streamlit run $app_file
+EOF
+  elif [[ $sdk == $SDK_DOCKER ]]; then
+      echo "do not create app file for docker sdk"
+  else 
+      echo "not supported sdk $sdk"
+      exit 1
+  fi 
+
+  if [ -f "$repo/start_entrypoint.sh" ]; then
+    chmod 755 $repo/start_entrypoint.sh
+  fi
+}
+
+lfs_folder_name='.lfs.opencsg.co'
+
+datafolder=$1
+reponame=$2
+username=$3
+gittoken=$4
+fullrepourl=$5 # must be http or https protocol
+gitref=$6
+
+sdk=$7
+python_version=$8
+device=$9  # cpu or gpu
+
+source_dir=$CURRENT_DIR
+echo "the full space clone url is $fullrepourl"
+
+if [[ ${fullrepourl:0:5} == "https" ]]; then
+  modified_repourl=$(echo "$fullrepourl" | sed 's/https:\/\///')
+  space_respository="https://"$username":"$gittoken"@"$modified_repourl
+elif [[ ${fullrepourl:0:4} == "http" ]]; then
+  modified_repourl=$(echo "$fullrepourl" | sed 's/http:\/\///')
+  space_respository="http://"$username":"$gittoken"@"$modified_repourl
+else
+  echo "Invalid Git URL format: $fullrepourl"
+  exit 1
+fi
+
+repo=$datafolder"/$reponame"
+git lfs install
+export GIT_LFS_SKIP_SMUDGE=1
+#git clone https://13581792646:6dbb294fce92283cd352a0dcecef1bca8ec2bf1b@portal.opencsg.com/models/13581792646/testspace.git  $repo
+git clone $space_respository $repo
+cd $repo
+git checkout $gitref
+
+if [[  ! $? -eq 0  ]]; then
+  echo "failed to clone repo"
+  exit 1
+fi
+
+cd $repo
+# prepare repo
+gen_lfs_folder
+gen_dockerfile
+gen_start_script
+
+if [[ $sdk == $SDK_GRADIO || $sdk == $SDK_STREAMLIT || $sdk == $SDK_MCPSERVER ]]; then
+  requirementsfile="$repo/requirements.txt"
+  if [ ! -f $requirementsfile ]; then
+      touch $requirementsfile
+      echo "requirements.txt is created"
+  fi
+
+  packagefile="$repo/packages.txt"
+  if [ ! -f $packagefile ]; then
+      touch $packagefile
+      echo "packages.txt is created"
+  fi
+
+  prerequirementsfile="$repo/pre-requirements.txt"
+  if [ ! -f $prerequirementsfile ]; then
+      touch $prerequirementsfile
+      echo "pre-requirements.txt is created"
+  fi
+fi
+
+echo $space_respository > ./SPACE_REPOSITORY
+
+rm -rf .git

--- a/runner/common/pod.go
+++ b/runner/common/pod.go
@@ -1,0 +1,85 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"opencsg.com/csghub-server/builder/deploy/cluster"
+)
+
+func GetPodLog(ctx context.Context, cluster *cluster.Cluster, podName string, namespace string, container string) ([]byte, error) {
+	logs, err := cluster.Client.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: container,
+	}).DoRaw(ctx)
+	return logs, err
+}
+
+func GetPod(ctx context.Context, cluster *cluster.Cluster, podName string, namespace string) (*corev1.Pod, error) {
+	pod, err := cluster.Client.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		slog.Error("fail to get pod ", slog.Any("error", err), slog.String("pod name", podName))
+		return nil, err
+	}
+
+	return pod, nil
+}
+
+func GetPodLogStream(ctx context.Context, cluster *cluster.Cluster, podName string, namespace string, container string) (chan []byte, string, error) {
+	logs := cluster.Client.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: container,
+		Follow:    true,
+	})
+
+	pod, err := GetPod(ctx, cluster, podName, namespace)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if pod.Status.Phase == "Pending" {
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == "PodScheduled" && condition.Status == "False" {
+				message := fmt.Sprintf("Pod is pending due to reason: %s, message: %s", condition.Reason, condition.Message)
+				return nil, message, nil
+			}
+		}
+	}
+
+	ch := make(chan []byte)
+	buf := make([]byte, 32*1024)
+
+	stream, err := logs.Stream(context.Background())
+	if err != nil {
+		return nil, "", err
+	}
+
+	go func() {
+		defer close(ch)
+		defer stream.Close()
+		for {
+			select {
+			case <-ctx.Done():
+				slog.Info("logs request context done", slog.Any("error", ctx.Err()))
+				return
+			default:
+				n, err := stream.Read(buf)
+				if err != nil {
+					slog.Error("read pod logs failed", slog.Any("error", err))
+					return
+				}
+				if n == 0 {
+					time.Sleep(5 * time.Second)
+				}
+
+				if n > 0 {
+					ch <- buf[:n]
+				}
+			}
+		}
+	}()
+
+	return ch, "", nil
+}

--- a/runner/common/pod_test.go
+++ b/runner/common/pod_test.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes/fake"
+	"opencsg.com/csghub-server/builder/deploy/cluster"
+)
+
+func TestGetPodLogValidation(t *testing.T) {
+	testCluster := &cluster.Cluster{
+		Client: fake.NewSimpleClientset(),
+	}
+
+	tests := []struct {
+		name      string
+		cluster   *cluster.Cluster
+		podName   string
+		namespace string
+		container string
+		wantErr   bool
+	}{
+		{
+			name:      "test-pod",
+			cluster:   testCluster,
+			podName:   "test-pod",
+			namespace: "default",
+			container: "main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GetPodLog(context.Background(), tt.cluster, tt.podName, tt.namespace, tt.container)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/runner/component/imagebuilder.go
+++ b/runner/component/imagebuilder.go
@@ -251,7 +251,7 @@ func (ibc *imagebuilderComponentImpl) workFlowInit(ctx context.Context) error {
 			}
 			if err := createOrUpdateConfigMap(ctx, cluster.Client, cmd); err != nil {
 				slog.Error(fmt.Sprintf("failed to create %s configmap", cfg.FileName), "err", err)
-				return err
+				continue
 			}
 
 		}

--- a/runner/component/imagebuilder.go
+++ b/runner/component/imagebuilder.go
@@ -1,0 +1,683 @@
+package component
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path"
+	"strings"
+	"time"
+
+	v1alpha1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"opencsg.com/csghub-server/builder/deploy/cluster"
+	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/config"
+	embed "opencsg.com/csghub-server/docker/spaces/builder"
+	rcommon "opencsg.com/csghub-server/runner/common"
+	"opencsg.com/csghub-server/runner/types"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
+)
+
+var (
+	workCreateStatus   string = "Create"
+	initContainerType  string = "init-repo"
+	buildContainerType string = "build"
+
+	containerStatusUnknown    string = "Unknown"
+	containerStatusWaiting    string = "Waiting"
+	containerStatusRunning    string = "Running"
+	containerStatusTerminated string = "Terminated"
+)
+
+type ImagebuilderComponent interface {
+	Build(ctx context.Context, spaceConfig types.SpaceBuilderConfig) (*types.ImageBuilderWork, error)
+	Status(ctx context.Context, buildId string) (*types.ImageBuilderWork, error)
+	Logs(ctx context.Context, buildId string) (chan []byte, error)
+}
+
+type imagebuilderComponentImpl struct {
+	config      *config.Config
+	clusterPool *cluster.ClusterPool
+	db          database.ImageBuilderWorkStore
+}
+
+func NewImagebuilderComponent(ctx context.Context, config *config.Config, clusterPool *cluster.ClusterPool) (ImagebuilderComponent, error) {
+	ibc := &imagebuilderComponentImpl{
+		config:      config,
+		clusterPool: clusterPool,
+		db:          database.NewImageBuilderStore(),
+	}
+	if err := ibc.workFlowInit(ctx); err != nil {
+		slog.Error("failed to init workflow", slog.Any("error", err))
+		return nil, err
+	}
+	go ibc.workInformer(ctx)
+	return ibc, nil
+}
+
+func (ibc *imagebuilderComponentImpl) GetCluster(ctx context.Context, clusterId string) (*cluster.Cluster, error) {
+	return ibc.clusterPool.GetClusterByID(ctx, clusterId)
+}
+
+func (ibc *imagebuilderComponentImpl) Build(ctx context.Context, spaceConfig types.SpaceBuilderConfig) (*types.ImageBuilderWork, error) {
+	namespace := ibc.config.Runner.ImageBuilderNamespace
+	cluster, err := ibc.GetCluster(ctx, ibc.config.Runner.ImageBuilderClusterID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster by id: %w", err)
+	}
+
+	imageName := buildImageName(spaceConfig.OrgName, spaceConfig.SpaceName, spaceConfig.BuildId)
+	imagePath := joinImagePath(ibc.config.Space.DockerRegBase, imageName)
+	wft, err := wfTemplateForImageBuilder(
+		ibc.config.Runner.ImageBuilderGitImage,
+		ibc.config.Runner.ImageBuilderKanikoImage,
+		imagePath,
+		spaceConfig,
+	)
+
+	if err != nil {
+		slog.Error("failed to create imagebuilder workflow template", "err", err)
+		return nil, fmt.Errorf("failed to create imagebuilder workflow template: %w", err)
+	}
+
+	wft.Spec.TTLStrategy = &v1alpha1.TTLStrategy{
+		SecondsAfterSuccess: ptr.To(int32(ibc.config.Argo.JobTTL)),
+	}
+
+	wft.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+		{
+			Name: ibc.config.Space.ImagePullSecret,
+		},
+	}
+
+	wft.Spec.Volumes = append(wft.Spec.Volumes, corev1.Volume{
+		Name: "docker-config",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: ibc.config.Space.ImagePullSecret,
+				Items: []corev1.KeyToPath{
+					{
+						Key:  ".dockerconfigjson",
+						Path: "config.json",
+					},
+				},
+			},
+		},
+	})
+	wft.Spec.ServiceAccountName = ibc.config.Argo.ServiceAccountName
+
+	wf, err := cluster.ArgoClient.ArgoprojV1alpha1().Workflows(namespace).Create(ctx, wft, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create imagebuilder workflow in argo: %w", err)
+	}
+
+	ibm := &database.ImageBuilderWork{
+		WorkName:            wf.Name,
+		WorkStatus:          workCreateStatus,
+		ImagePath:           imageName,
+		BuildId:             types.JointSpaceNameBuildId(spaceConfig.OrgName, spaceConfig.SpaceName, spaceConfig.BuildId),
+		Namespace:           namespace,
+		ClusterID:           ibc.config.Runner.ImageBuilderClusterID,
+		InitContainerStatus: containerStatusUnknown,
+	}
+	if _, err := ibc.db.CreateOrUpdateByBuildID(ctx, ibm); err != nil {
+		return nil, fmt.Errorf("failed to create imagebuilder in db: %w", err)
+	}
+
+	return &types.ImageBuilderWork{
+		WorkName:   ibm.WorkName,
+		WorkStatus: ibm.WorkStatus,
+		Message:    ibm.Message,
+		ImagePath:  ibm.ImagePath,
+		BuildId:    ibm.BuildId,
+	}, nil
+}
+
+func (ibc *imagebuilderComponentImpl) Status(ctx context.Context, buildId string) (*types.ImageBuilderWork, error) {
+	ibw, err := ibc.db.QueryStatusByBuildID(ctx, buildId)
+	if err != nil {
+		return nil, err
+	}
+
+	// check timeout with workflow status at unknown, running, pending
+	if ibw.WorkStatus == string(v1alpha1.WorkflowUnknown) ||
+		ibw.WorkStatus == string(v1alpha1.WorkflowRunning) ||
+		ibw.WorkStatus == string(v1alpha1.WorkflowPending) {
+
+		if time.Since(ibw.CreatedAt) > time.Duration(ibc.config.Runner.ImageBuilderStatusTTL)*time.Second {
+			cluster, err := ibc.GetCluster(ctx, ibw.ClusterID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to imagebuilder get cluster by id: %w", err)
+			}
+			// get workflow status for cluster
+			wf, err := cluster.ArgoClient.ArgoprojV1alpha1().Workflows(ibw.Namespace).Get(ctx, ibw.WorkName, metav1.GetOptions{})
+			if err != nil {
+				return nil, fmt.Errorf("failed to imagebuilder get workflow by name: %w", err)
+
+			}
+			// change status and get logs
+			err = ibc.updateImagebuilderWork(ctx, cluster, wf)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+				} else {
+					slog.Error("failed to imagebuilder update workflow", slog.Any("error", err))
+				}
+			}
+			ibw, err = ibc.db.QueryStatusByBuildID(ctx, ibw.BuildId)
+			if err != nil {
+				return nil, fmt.Errorf("failed to imagebuilder query status by build id: %w", err)
+			}
+		}
+	}
+
+	return &types.ImageBuilderWork{
+		WorkName:   ibw.WorkName,
+		WorkStatus: ibw.WorkStatus,
+		Message:    ibw.Message,
+		ImagePath:  ibw.ImagePath,
+		BuildId:    ibw.BuildId,
+	}, nil
+}
+
+func (ibc *imagebuilderComponentImpl) Logs(ctx context.Context, buildId string) (chan []byte, error) {
+	ch := make(chan []byte)
+	go func() {
+		defer close(ch)
+		ibw, err := ibc.db.QueryByBuildID(ctx, buildId)
+		if err != nil {
+			ch <- []byte(fmt.Sprintf("failed to query imagebuilder work by work name: error: %s", err.Error()))
+			return
+		}
+
+		if ibw.WorkStatus == string(v1alpha1.WorkflowUnknown) {
+			ch <- []byte(fmt.Sprintf("imagebuilder workflow %s is not running status: %s", ibw.WorkName, ibw.WorkStatus))
+			return
+		}
+
+		// get logs from cluster
+		cluster, err := ibc.GetCluster(ctx, ibw.ClusterID)
+		if err != nil {
+			ch <- []byte(fmt.Sprintf("failed to get cluster by id: %s", err.Error()))
+			return
+		}
+
+		initLogs := ibc.getInitContainerLogsStream(ctx, cluster, ibw)
+		for log := range initLogs {
+			ch <- []byte(log)
+		}
+		buildLogs := ibc.getMainContainerLogsStream(ctx, cluster, ibw)
+		for log := range buildLogs {
+			ch <- []byte(log)
+		}
+	}()
+	return ch, nil
+}
+
+func (ibc *imagebuilderComponentImpl) workFlowInit(ctx context.Context) error {
+	namespace := ibc.config.Runner.ImageBuilderNamespace
+
+	cmList := []types.FileCMConfig{
+		{FileName: "init.sh", CMName: "init-configmap"},
+		{FileName: "Dockerfile-python3.10", CMName: "cpu-docker-configmap"},
+		{FileName: "Dockerfile-python3.10-cuda11.8.0", CMName: "gpu-docker-configmap"},
+	}
+	fcMap := make(map[string][]byte)
+	for _, cfg := range cmList {
+		data, err := embed.ImagebuilderFs.ReadFile(cfg.FileName)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", cfg.FileName, err)
+		}
+		fcMap[cfg.FileName] = data
+	}
+
+	for _, cluster := range ibc.clusterPool.Clusters {
+		for _, cfg := range cmList {
+			data, exists := fcMap[cfg.FileName]
+			if !exists {
+				return fmt.Errorf("file %s not loaded", cfg.FileName)
+			}
+			cmd := types.CMConfig{
+				Namespace:   namespace,
+				CmName:      cfg.CMName,
+				DataKey:     cfg.FileName,
+				FileContent: data,
+			}
+			if err := createOrUpdateConfigMap(ctx, cluster.Client, cmd); err != nil {
+				slog.Error(fmt.Sprintf("failed to create %s configmap", cfg.FileName), "err", err)
+				return err
+			}
+
+		}
+	}
+
+	return nil
+}
+
+func (ibc *imagebuilderComponentImpl) workInformer(ctx context.Context) {
+	cluster, err := ibc.GetCluster(ctx, ibc.config.Runner.ImageBuilderClusterID)
+	if err != nil {
+		slog.Error("failed to get cluster", "error", err)
+		return
+	}
+	labelSelector := "workflow-scope=imagebuilder"
+
+	eventHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			wf := obj.(*v1alpha1.Workflow)
+			err := ibc.updateImagebuilderWork(ctx, cluster, wf)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				slog.Error("fail to update imagebuilder task", slog.Any("error", err), slog.Any("work_name", wf.Name))
+			}
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			newWF := newObj.(*v1alpha1.Workflow)
+			// compare status
+			if newWF.Status.Nodes == nil {
+				return
+			}
+			err := ibc.updateImagebuilderWork(ctx, cluster, newWF)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				slog.Error("fail to update imagebuilder task", slog.Any("error", err), slog.Any("work_name", newWF.Name))
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			wf := obj.(*v1alpha1.Workflow)
+			slog.Info("delete imagebuilder task", slog.Any("work_name", wf.Name), slog.Any("status", wf.Status.Phase))
+		},
+	}
+
+	CreateInfomerFactory(cluster.ArgoClient, ibc.config.Runner.ImageBuilderNamespace, labelSelector, eventHandler)
+}
+
+func wfTemplateForImageBuilder(gitImg, kanikoImg, ImageDestination string, params types.SpaceBuilderConfig) (*v1alpha1.Workflow, error) {
+	return &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "imagebuilder-",
+			Labels: map[string]string{
+				"workflow-scope": "imagebuilder",
+			},
+		},
+		Spec: v1alpha1.WorkflowSpec{
+			Entrypoint: "main",
+			Volumes: []corev1.Volume{
+				{
+					Name: "shared",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "init-volume",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "init-configmap",
+							},
+						},
+					},
+				},
+				{
+					Name: "cpu-docker-volume",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "cpu-docker-configmap",
+							},
+						},
+					},
+				},
+				{
+					Name: "gpu-docker-volume",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "gpu-docker-configmap",
+							},
+						},
+					},
+				},
+			},
+			Templates: []v1alpha1.Template{
+				{
+					Name: "main",
+					Steps: []v1alpha1.ParallelSteps{
+						{
+							Steps: []v1alpha1.WorkflowStep{
+								{
+									Name:     "imagebuilder",
+									Template: buildContainerType,
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: buildContainerType,
+					InitContainers: []v1alpha1.UserContainer{
+						{
+							Container: corev1.Container{
+								Name:    initContainerType,
+								Image:   gitImg,
+								Command: []string{"sh", "-c"},
+								Args: []string{
+									`sh /builder/config/init.sh  $REPO $REPO_NAME $USER_NAME $SECRET $SPACE_URL $GIT_REF $SDK $PYTHON_VERSION $HARDWARE && cp -r $REPO/$REPO_NAME/ /shared `,
+								},
+								SecurityContext: &corev1.SecurityContext{
+									RunAsUser: ptr.To(int64(0)),
+								},
+								Env: []corev1.EnvVar{
+									{Name: "REPO", Value: "/builder"},
+									{Name: "REPO_NAME", Value: params.SpaceName},
+									{Name: "USER_NAME", Value: params.UserId},
+									{Name: "SECRET", Value: params.GitAccessToken},
+									{Name: "SPACE_URL", Value: params.SpaceURL},
+									{Name: "GIT_REF", Value: params.GitRef},
+									{Name: "SDK", Value: params.Sdk},
+									{Name: "PYTHON_VERSION", Value: params.PythonVersion},
+									{Name: "HARDWARE", Value: params.Hardware},
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "shared",
+										MountPath: "/shared",
+									},
+									{
+										Name:      "init-volume",
+										MountPath: "/builder/config/init.sh",
+										SubPath:   "init.sh",
+										ReadOnly:  false,
+									},
+									{
+										Name:      "cpu-docker-volume",
+										MountPath: "/builder/config/Dockerfile-python3.10",
+										SubPath:   "Dockerfile-python3.10",
+									},
+									{
+										Name:      "gpu-docker-volume",
+										MountPath: "/builder/config/Dockerfile-python3.10-cuda11.8.0",
+										SubPath:   "Dockerfile-python3.10-cuda11.8.0",
+									},
+								},
+							},
+						},
+					},
+					Container: &corev1.Container{
+						Name:  buildContainerType,
+						Image: kanikoImg,
+						Args: []string{
+							"--context=/shared/" + params.SpaceName,
+							"--destination=" + ImageDestination,
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "shared",
+								MountPath: "/shared",
+							},
+							{
+								Name:      "docker-config",
+								MountPath: "/kaniko/.docker",
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (ibc *imagebuilderComponentImpl) updateImagebuilderWork(ctx context.Context, cluster *cluster.Cluster, wf *v1alpha1.Workflow) error {
+	if wf.Status.Nodes == nil {
+		return nil
+	}
+
+	// get imagebuilder work from db
+	ibw, err := ibc.db.FindByWorkName(ctx, wf.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get wf [%s] from db: %w", wf.Name, err)
+	}
+
+	podName := ibc.getPodNameFromWorkflow(wf)
+	if ibw.PodName == "" {
+		ibw.PodName = podName
+	}
+
+	if ibw.WorkStatus != string(wf.Status.Phase) {
+		ibw.WorkStatus = string(wf.Status.Phase)
+		ibw.Message = wf.Status.Message
+	}
+
+	// get container status and logs
+	pod, err := cluster.Client.CoreV1().Pods(ibw.Namespace).Get(ctx, ibw.PodName, metav1.GetOptions{})
+	if err != nil {
+		slog.Error("failed to get pod %s: %w", ibw.PodName, err)
+	} else {
+		ibw.InitContainerStatus = getInitContainerStatus(pod, initContainerType)
+		// get logs from cluster
+		if ibw.InitContainerStatus == containerStatusTerminated {
+			logs, err := getContainerLogs(ctx, cluster, pod, initContainerType)
+			if err != nil {
+				slog.Warn("failed to get init container logs from cluster: ", "err:", err.Error())
+			} else {
+				ibw.InitContainerLog = string(logs)
+			}
+		}
+		if ibw.WorkStatus != string(v1alpha1.WorkflowRunning) && ibw.WorkStatus != string(v1alpha1.WorkflowPending) && ibw.WorkStatus != string(v1alpha1.WorkflowUnknown) {
+			logs, err := getContainerLogs(ctx, cluster, pod, buildContainerType)
+			if err != nil {
+				slog.Warn("failed to get main container logs from cluster: ", "err:", err.Error())
+			} else {
+				ibw.MainContainerLog = string(logs)
+			}
+		}
+	}
+
+	if _, err = ibc.db.UpdateByWorkName(ctx, ibw); err != nil {
+		return fmt.Errorf("failed to update imagebuilder in db: %w", err)
+	}
+
+	return err
+}
+
+func createOrUpdateConfigMap(ctx context.Context, client kubernetes.Interface, cmc types.CMConfig) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cmc.CmName,
+		},
+		Data: map[string]string{
+			cmc.DataKey: string(cmc.FileContent),
+		},
+	}
+
+	existingCM, err := client.CoreV1().ConfigMaps(cmc.Namespace).Get(ctx, cmc.CmName, metav1.GetOptions{})
+	if err == nil {
+		// update ConfigMap
+		existingCM.Data[cmc.DataKey] = string(cmc.FileContent)
+		_, err := client.CoreV1().ConfigMaps(cmc.Namespace).Update(ctx, existingCM, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("%s ConfigMap update failed: %w", cmc.CmName, err)
+		}
+	} else {
+		// create ConfigMap
+		_, err := client.CoreV1().ConfigMaps(cmc.Namespace).Create(ctx, cm, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("%s ConfigMap creation failed: %w", cmc.CmName, err)
+		}
+	}
+
+	return nil
+}
+
+func buildImageName(orgName, spaceName, buildId string) string {
+	name := orgName + "_" + spaceName + ":" + buildId
+	imageName := strings.ToLower(name)
+	return imageName
+}
+
+func joinImagePath(base, imageName string) string {
+	return path.Join(base, imageName)
+}
+
+func (ibc *imagebuilderComponentImpl) constructPodName(wfName, templateName, nodeID string) string {
+	parts := strings.Split(nodeID, "-")
+	suffix := parts[len(parts)-1]
+	return fmt.Sprintf("%s-%s-%s", wfName, templateName, suffix)
+}
+
+func (ibc *imagebuilderComponentImpl) getPodNameFromWorkflow(wf *v1alpha1.Workflow) string {
+	var podName string
+	// get pod name
+	for _, node := range wf.Status.Nodes {
+		if node.Type == v1alpha1.NodeTypePod {
+			podName = ibc.constructPodName(wf.Name, node.TemplateName, node.ID)
+			break
+		}
+	}
+
+	return podName
+}
+
+func getInitContainerStatus(pod *corev1.Pod, containerName string) string {
+	var status string = containerStatusUnknown
+	for _, container := range pod.Status.InitContainerStatuses {
+		if container.Name == containerName {
+			if container.State.Waiting != nil {
+				status = containerStatusWaiting
+			}
+			if container.State.Running != nil {
+				status = containerStatusRunning
+			}
+			if container.State.Terminated != nil {
+				status = containerStatusTerminated
+			}
+			break
+		}
+	}
+	return status
+}
+
+func getContainerLogs(ctx context.Context, cluster *cluster.Cluster, pod *corev1.Pod, containerName string) ([]byte, error) {
+	if containerName == initContainerType {
+		return getInitContainerLogs(ctx, cluster, pod)
+	}
+	if containerName == buildContainerType {
+		return getMainContainerLogs(ctx, cluster, pod)
+	}
+	return nil, fmt.Errorf("container type %s not found", containerName)
+}
+
+func getInitContainerLogs(ctx context.Context, cluster *cluster.Cluster, pod *corev1.Pod) ([]byte, error) {
+	logs, err := rcommon.GetPodLog(ctx, cluster, pod.Name, pod.Namespace, "init-repo")
+	if err != nil {
+		return nil, err
+	}
+
+	return logs, nil
+}
+
+func getMainContainerLogs(ctx context.Context, cluster *cluster.Cluster, pod *corev1.Pod) ([]byte, error) {
+	logs, err := rcommon.GetPodLog(ctx, cluster, pod.Name, pod.Namespace, "main")
+	if err != nil {
+		return nil, err
+	}
+
+	return logs, nil
+}
+
+func (ibc *imagebuilderComponentImpl) getInitContainerLogsStream(ctx context.Context, cluster *cluster.Cluster, ibw *database.ImageBuilderWork) chan string {
+	ch := make(chan string)
+	go func() {
+		defer close(ch)
+		var err error
+		for {
+			if ibw.WorkStatus == string(v1alpha1.WorkflowUnknown) {
+				ch <- fmt.Sprintf("imagebuilder workflow %s is not running status: %s container init repo status: %s", ibw.WorkName, ibw.WorkStatus, ibw.InitContainerStatus)
+				return
+			}
+
+			if ibw.InitContainerStatus == containerStatusTerminated {
+				ch <- ibw.InitContainerLog
+				return
+			}
+
+			if ibw.InitContainerStatus == containerStatusRunning {
+				logs, msg, err := rcommon.GetPodLogStream(ctx, cluster, ibw.PodName, ibw.Namespace, "init-repo")
+				if err != nil {
+					ch <- fmt.Sprintf("failed to get container init repo logs: %s", err.Error())
+					return
+				}
+				if msg != "" {
+					ch <- msg
+				}
+				for log := range logs {
+					ch <- string(log)
+				}
+				return
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second):
+				ibw, err = ibc.db.QueryStatusByBuildID(ctx, ibw.BuildId)
+				if err != nil {
+					ch <- fmt.Sprintf("failed to get container init repo status: %s", err.Error())
+					return
+				}
+			}
+		}
+	}()
+	return ch
+}
+
+func (ibc *imagebuilderComponentImpl) getMainContainerLogsStream(ctx context.Context, cluster *cluster.Cluster, ibw *database.ImageBuilderWork) chan string {
+	ch := make(chan string)
+	go func() {
+		defer close(ch)
+		var err error
+		for {
+			if ibw.WorkStatus == string(v1alpha1.WorkflowUnknown) {
+				ch <- fmt.Sprintf("imagebuilder workflow %s is not running status: %s", ibw.WorkName, ibw.WorkStatus)
+				return
+			}
+			if ibw.WorkStatus != string(v1alpha1.WorkflowRunning) && ibw.WorkStatus != string(v1alpha1.WorkflowPending) {
+				ch <- ibw.MainContainerLog
+				return
+			}
+
+			if ibw.InitContainerStatus == containerStatusTerminated && ibw.WorkStatus == string(v1alpha1.WorkflowRunning) {
+				// get logs from cluster
+				logs, msg, err := rcommon.GetPodLogStream(ctx, cluster, ibw.PodName, ibw.Namespace, "main")
+				if err != nil {
+					ch <- fmt.Sprintf("failed to get container build logs: %s", err.Error())
+					return
+				}
+				if msg != "" {
+					ch <- msg
+				}
+				for log := range logs {
+					ch <- string(log)
+				}
+				return
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second):
+				ibw, err = ibc.db.QueryStatusByBuildID(ctx, ibw.BuildId)
+				if err != nil {
+					ch <- fmt.Sprintf("failed to get container build status: %s", err.Error())
+					return
+				}
+			}
+		}
+	}()
+	return ch
+}

--- a/runner/component/imagebuilder_test.go
+++ b/runner/component/imagebuilder_test.go
@@ -1,0 +1,44 @@
+package component
+
+import (
+	"context"
+	"testing"
+
+	argofake "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned/fake"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+	"opencsg.com/csghub-server/builder/deploy/cluster"
+	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/tests"
+	"opencsg.com/csghub-server/runner/types"
+)
+
+func TestImagebuilderComponent_Build(t *testing.T) {
+	conf := &config.Config{}
+	testCluster := &cluster.Cluster{
+		CID:        "config",
+		ID:         "config",
+		Client:     fake.NewSimpleClientset(),
+		ArgoClient: argofake.NewSimpleClientset(),
+	}
+
+	db := tests.InitTestDB()
+	defer db.Close()
+	ibc := &imagebuilderComponentImpl{
+		clusterPool: &cluster.ClusterPool{
+			Clusters: []cluster.Cluster{*testCluster},
+		},
+		config: conf,
+		db:     database.NewImageBuilderStoreWithDB(db),
+	}
+
+	_, err := ibc.Build(context.Background(), types.SpaceBuilderConfig{
+		OrgName:   "test-org",
+		SpaceName: "test-space",
+		BuildId:   "test-build-id",
+		SpaceURL:  "https://github.com/test-org/test-space",
+	})
+
+	require.Nil(t, err)
+}

--- a/runner/handler/imagebuilder.go
+++ b/runner/handler/imagebuilder.go
@@ -1,0 +1,151 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"github.com/gin-gonic/gin"
+	"opencsg.com/csghub-server/builder/deploy/cluster"
+	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/runner/component"
+	"opencsg.com/csghub-server/runner/types"
+)
+
+type ImagebuilderHandler struct {
+	ibc component.ImagebuilderComponent
+}
+
+func NewImagebuilderHandler(ctx context.Context, config *config.Config, clusterPool *cluster.ClusterPool) (*ImagebuilderHandler, error) {
+	ibc, err := component.NewImagebuilderComponent(ctx, config, clusterPool)
+	if err != nil {
+		return nil, err
+	}
+	return &ImagebuilderHandler{
+		ibc: ibc,
+	}, nil
+}
+
+// Build triggers new image building workflow
+// @Summary Create image build task
+// @Description Start new Docker image building process
+// @Tags ImageBuilder
+// @Accept json
+// @Produce json
+// @Param   request body types.SpaceBuilderConfig true "Build Configuration"
+// @Success 200 {object} types.ImagebuilderStatusRes "Build task accepted"
+// @Failure 400 {object} map[string]string "Invalid request format"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /imagebuilder/build [post]
+func (ibh *ImagebuilderHandler) Build(ctx *gin.Context) {
+	var spaceConfig types.SpaceBuilderConfig
+	if err := ctx.ShouldBindJSON(&spaceConfig); err != nil {
+		slog.Error("bad params imagebuilder request format", "error", err)
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "bad params imagebuilder request format:" + err.Error()})
+		return
+	}
+
+	ibm, err := ibh.ibc.Build(ctx.Request.Context(), spaceConfig)
+	if err != nil {
+		slog.Error("fail to image builder", slog.Any("error", err), slog.Any("req", spaceConfig))
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "fail to imagebuilder build:" + err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, types.ImagebuilderStatusRes{
+		WorkName: ibm.WorkName,
+		Status:   string(ibm.WorkStatus),
+	})
+}
+
+// Status checks build workflow status
+// @Summary Get build status
+// @Description Check image building workflow status
+// @Tags ImageBuilder
+// @Produce json
+// @Param   namespace path string true "Organization namespace"
+// @Param   name path string true "Space name"
+// @Param   build_id query string true "Unique build identifier"
+// @Success 200 {object} map[string]interface{} "Status codes: 0=Success, 1=Failed, 2=InProgress"
+// @Failure 400 {object} map[string]string "Missing build_id parameter"
+// @Failure 404 {object} map[string]string "Build not found"
+// @Router /imagebuilder/{namespace}/{name}/status [get]
+func (ibh *ImagebuilderHandler) Status(ctx *gin.Context) {
+	namespace := ctx.Param("namespace")
+	name := ctx.Param("name")
+
+	build_id := ctx.Query("build_id")
+	if build_id == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "imagebuilder build_id is required"})
+		return
+	}
+
+	build_id = types.JointSpaceNameBuildId(namespace, name, build_id)
+	ibw, err := ibh.ibc.Status(ctx.Request.Context(), build_id)
+	if err != nil {
+		slog.Error("fail to get image builder status", slog.Any("error", err), slog.Any("build_id", build_id))
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("fail to get imagebuilder status: %s", err.Error())})
+		return
+	}
+
+	var ret = make(map[string]interface{})
+
+	switch ibw.WorkStatus {
+	case string(v1alpha1.WorkflowSucceeded):
+		ret[ibw.ImagePath] = 0
+	case string(v1alpha1.WorkflowFailed):
+		ret[ibw.ImagePath] = 1
+	default:
+		ret[ibw.ImagePath] = 2
+	}
+
+	ctx.JSON(http.StatusOK, ret)
+
+}
+
+// Logs streams real-time build logs
+// @Summary Stream build logs
+// @Description Get real-time logs of image building process (SSE protocol)
+// @Tags ImageBuilder
+// @Produce text/event-stream
+// @Param   namespace path string true "Organization namespace"
+// @Param   name path string true "Space name"
+// @Param   build_id query string true "Unique build identifier"
+// @Success 200 {string} string "Event stream with log lines"
+// @Failure 400 {object} map[string]string "Missing build_id parameter"
+// @Failure 500 {object} map[string]string "Log stream error"
+// @Router /imagebuilder/{namespace}/{name}/logs [get]
+func (ibh *ImagebuilderHandler) Logs(ctx *gin.Context) {
+	namespace := ctx.Param("namespace")
+	name := ctx.Param("name")
+	build_id := ctx.Query("build_id")
+	if build_id == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "build_id is required"})
+		return
+	}
+
+	build_id = types.JointSpaceNameBuildId(namespace, name, build_id)
+
+	ctx.Writer.Header().Set("Content-Type", "text/event-stream")
+	ctx.Writer.Header().Set("Cache-Control", "no-cache")
+	ctx.Writer.Header().Set("Connection", "keep-alive")
+	ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+
+	ch, err := ibh.ibc.Logs(ctx.Request.Context(), build_id)
+	if err != nil {
+		slog.Error("fail to get image builder logs", slog.Any("error", err), slog.Any("build_id", build_id))
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("fail to get imagebuilder logs: %s", err.Error())})
+		return
+	}
+
+	for log := range ch {
+		_, err := ctx.Writer.Write(log)
+		if err != nil {
+			slog.Error("fail to write imagebuilder logs", slog.Any("error", err), slog.Any("build_id", build_id))
+			return
+		}
+		ctx.Writer.Flush()
+	}
+}

--- a/runner/types/imagebuilder.go
+++ b/runner/types/imagebuilder.go
@@ -1,0 +1,58 @@
+package types
+
+import (
+	"fmt"
+)
+
+// ImagebuilderStatusRes represents build status response
+// @Schema
+type ImagebuilderStatusRes struct {
+	WorkName string `json:"work_name"`
+	Status   string `json:"status"`
+	Message  string `json:"message"` // Optional: Additional message or error details
+}
+
+// SpaceBuilderConfig defines image build parameters
+// @Schema
+type SpaceBuilderConfig struct {
+	ClusterID      string `json:"cluster_id"`
+	SpaceName      string `json:"space_name"`
+	OrgName        string `json:"org_name"`
+	SpaceURL       string `json:"space_url"`
+	Sdk            string `json:"sdk"`
+	Sdk_version    string `json:"sdk_version"`
+	PythonVersion  string `json:"python_version"`
+	Hardware       string `json:"hardware,omitempty"`
+	FactoryBuild   bool   `json:"factory_build,omitempty"`
+	GitRef         string `json:"git_ref"`
+	UserId         string `json:"user_id"`
+	GitAccessToken string `json:"git_access_token"`
+	BuildId        string `json:"build_id,omitempty"`
+}
+
+func JointSpaceNameBuildId(spaceName, name, build_id string) string {
+	return fmt.Sprintf("%s_%s_%s", spaceName, name, build_id)
+}
+
+type CMConfig struct {
+	Namespace   string
+	CmName      string
+	DataKey     string
+	FileContent []byte
+}
+
+type FileCMConfig struct {
+	FileName string // file name
+	CMName   string // configMap ID
+}
+
+type ImageBuilderWork struct {
+	WorkName   string `bun:"work_name,notnull,unique" json:"work_name"`
+	WorkStatus string `bun:"work_status,notnull" json:"work_status"`
+	Message    string `bun:"message" json:"message"`
+
+	ImagePath string `bun:"image_path,notnull" json:"image_path"`
+
+	BuildId string `bun:"build_id,notnull,unique" json:"build_id"`
+	Log     string `bun:"log" json:"log"`
+}


### PR DESCRIPTION
Current situation issues
Space Builder, as an independent service, suffers from resource waste
High maintenance cost for multi environment configuration
Migration target
Unified construction of service entrances to reduce operational complexity
Implement dynamic resource allocation for building (supporting Kubernetes elastic scaling)
Improve task execution efficiency