### PR TITLE
fix: starhub_server high CPU usage

### DIFF
--- a/api/handler/repo.go
+++ b/api/handler/repo.go
@@ -1702,6 +1702,9 @@ func (h *RepoHandler) DeployInstanceLogs(ctx *gin.Context) {
 				ctx.SSEvent("Container", string(data))
 				ctx.Writer.Flush()
 			}
+		default:
+			// Add a small sleep to prevent CPU spinning when no data is available
+			time.Sleep(time.Second * 1)
 		}
 	}
 }
@@ -2203,6 +2206,9 @@ func (h *RepoHandler) ServerlessLogs(ctx *gin.Context) {
 				ctx.SSEvent("Container", string(data))
 				ctx.Writer.Flush()
 			}
+		default:
+			// Add a small sleep to prevent CPU spinning when no data is available
+			time.Sleep(time.Second * 1)
 		}
 	}
 }

--- a/api/handler/space.go
+++ b/api/handler/space.go
@@ -579,6 +579,9 @@ func (h *SpaceHandler) Logs(ctx *gin.Context) {
 				ctx.SSEvent("Container", string(data))
 				ctx.Writer.Flush()
 			}
+		default:
+			// Add a small sleep to prevent CPU spinning when no data is available
+			time.Sleep(time.Second)
 		}
 	}
 }

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -256,7 +256,8 @@ type Config struct {
 
 	Instrumentation struct {
 		OTLPEndpoint string `env:"OPENCSG_TRACING_OTLP_ENDPOINT"`
-		OTLPLogging  bool   `env:"OPENCSG_TRACING_OTLP_LOGGING"`
+		//Note: don't enable it unless you have no other way to collect service logs. It will leads to very high CPU usage.
+		OTLPLogging bool `env:"OPENCSG_TRACING_OTLP_LOGGING"`
 	}
 
 	Git struct {

--- a/common/config/config.toml.example
+++ b/common/config/config.toml.example
@@ -165,3 +165,7 @@ calc_recom_score_cron_expression = "0 1 * * *"
 
 [proxy]
 hosts = ["opencsg.com", "sync.opencsg.com"]
+
+[instrumentation]
+otlp_endpoint = "http://localhost:4317"
+otlp_logging = false


### PR DESCRIPTION
- Add sleep when no space logs data is available, to prevent CPU spinning in Logs method
- Disable otlp_logging as it uses too many CPU times