### PR TITLE
add sensitive check api route, no op if sensitive check not enable

### DIFF
--- a/api/router/api.go
+++ b/api/router/api.go
@@ -294,14 +294,12 @@ func NewRouter(config *config.Config, enableSwagger bool) (*gin.Engine, error) {
 	apiGroup.POST("/callback/git", callbackCtrl.Handle)
 	apiGroup.GET("/callback/casdoor", userProxyHandler.Proxy)
 	// Sensive check
-	if config.SensitiveCheck.Enable {
-		sensitiveCtrl, err := handler.NewSensitiveHandler(config)
-		if err != nil {
-			return nil, fmt.Errorf("error creating sensitive handler:%w", err)
-		}
-		apiGroup.POST("/sensitive/text", sensitiveCtrl.Text)
-		apiGroup.POST("/sensitive/image", sensitiveCtrl.Image)
+	sensitiveCtrl, err := handler.NewSensitiveHandler(config)
+	if err != nil {
+		return nil, fmt.Errorf("error creating sensitive handler:%w", err)
 	}
+	apiGroup.POST("/sensitive/text", sensitiveCtrl.Text)
+	apiGroup.POST("/sensitive/image", sensitiveCtrl.Image)
 
 	// MirrorSource
 	msHandler, err := handler.NewMirrorSourceHandler(config)


### PR DESCRIPTION
**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR introduces a new API route for sensitive content checks. The changes in the code indicate that the sensitive check feature will now be always initialized, but it will not operate if it's not enabled in the configuration. This is reflected in the 'api/router/api.go' file where the initialization of the sensitive check handler is moved outside the conditional statement checking if the feature is enabled. The API routes for text and image sensitive checks remain the same.

<!-- @codegpt description end -->