### PR TITLE
Fix support add kaniko args

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -270,12 +270,13 @@ type Config struct {
 	}
 
 	Runner struct {
-		ImageBuilderClusterID   string `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_CLUSTER_ID, default="`
-		ImageBuilderNamespace   string `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_NAMESPACE, default=imagebuilder"`
-		ImageBuilderGitImage    string `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_GIT_IMAGE, default=opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/alpine/git:2.36.2"`
-		ImageBuilderKanikoImage string `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_IMAGE, default=opencsg-registry.cn-beijing.cr.aliyuncs.com/public/kaniko-project-executor:v1.23.2"`
-		ImageBuilderJobTTL      int    `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_JOB_TTL, default=120"`
-		ImageBuilderStatusTTL   int    `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_STATUS_TTL, default=300"`
+		ImageBuilderClusterID   string   `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_CLUSTER_ID, default="`
+		ImageBuilderNamespace   string   `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_NAMESPACE, default=imagebuilder"`
+		ImageBuilderGitImage    string   `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_GIT_IMAGE, default=opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/alpine/git:2.36.2"`
+		ImageBuilderKanikoImage string   `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_IMAGE, default=opencsg-registry.cn-beijing.cr.aliyuncs.com/public/kaniko-project-executor:v1.23.2"`
+		ImageBuilderJobTTL      int      `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_JOB_TTL, default=120"`
+		ImageBuilderStatusTTL   int      `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_STATUS_TTL, default=300"`
+		ImageBuilderKanikoArgs  []string `env:"STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_ARGS"`
 	}
 }
 

--- a/common/config/config.toml.example
+++ b/common/config/config.toml.example
@@ -176,3 +176,11 @@ image_builder_git_image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_p
 image_builder_kaniko_image = "opencsg-registry.cn-beijing.cr.aliyuncs.com/public/kaniko-project-executor:v1.23.2"
 image_builder_job_ttl = 120
 image_builder_status_ttl = 300
+# Kaniko arguments to configure logging and registry access.
+# See official flags: https://github.com/GoogleContainerTools/kaniko?tab=readme-ov-file#additional-flags
+# --log-format=json : Output logs in JSON format for structured parsing.
+# --log-timestamp=true : Include timestamps in log entries.
+# --insecure : Allow connections to HTTP registries (non-HTTPS).
+# --skip-tls-verify : Disable TLS certificate validation for registries.
+# Uncomment the following line to enable pull images from a private registry without https
+# image_builder_kaniko_args = ["--insecure", "--skip-tls-verify"]

--- a/runner/component/imagebuilder.go
+++ b/runner/component/imagebuilder.go
@@ -526,7 +526,9 @@ func createOrUpdateConfigMap(ctx context.Context, client kubernetes.Interface, c
 }
 
 func buildImageName(orgName, spaceName, buildId string) string {
-	name := orgName + "_" + spaceName + ":" + buildId
+	// Example: opencsg_test-model:1-1678901234
+	timestamp := time.Now().Unix()
+	name := orgName + "_" + spaceName + ":" + buildId + "-" + fmt.Sprintf("%d", timestamp)
 	imageName := strings.ToLower(name)
 	return imageName
 }


### PR DESCRIPTION
Support add kaniko args
Add seconds to the image tag

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR titled 'Fix support add kaniko args' enhances the support for adding Kaniko arguments and adds seconds to the image tag. Key updates include:
1. Addition of 'ImageBuilderKanikoArgs' in the 'Config' struct in 'config.go' file.
2. Modification of 'Build' and 'wfTemplateForImageBuilder' functions in 'imagebuilder.go' to include 'ImageBuilderKanikoArgs'.
3. Changes in 'wfTemplateForImageBuilder' to prevent '--context' and '--destination' from being overwritten.
4. Addition of timestamp to the image name in 'buildImageName' function.
5. Several error messages have been updated for better clarity.

<!-- @codegpt description end -->