### PR TITLE
Add new endpoints for MCP servers

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_MCPServerStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_MCPServerStore.go
@@ -83,6 +83,75 @@ func (_c *MockMCPServerStore_AddProperty_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// ByOrgPath provides a mock function with given fields: ctx, namespace, per, page, onlyPublic
+func (_m *MockMCPServerStore) ByOrgPath(ctx context.Context, namespace string, per int, page int, onlyPublic bool) ([]database.MCPServer, int, error) {
+	ret := _m.Called(ctx, namespace, per, page, onlyPublic)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ByOrgPath")
+	}
+
+	var r0 []database.MCPServer
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, int, bool) ([]database.MCPServer, int, error)); ok {
+		return rf(ctx, namespace, per, page, onlyPublic)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, int, bool) []database.MCPServer); ok {
+		r0 = rf(ctx, namespace, per, page, onlyPublic)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.MCPServer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, int, int, bool) int); ok {
+		r1 = rf(ctx, namespace, per, page, onlyPublic)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, string, int, int, bool) error); ok {
+		r2 = rf(ctx, namespace, per, page, onlyPublic)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// MockMCPServerStore_ByOrgPath_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ByOrgPath'
+type MockMCPServerStore_ByOrgPath_Call struct {
+	*mock.Call
+}
+
+// ByOrgPath is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+//   - per int
+//   - page int
+//   - onlyPublic bool
+func (_e *MockMCPServerStore_Expecter) ByOrgPath(ctx interface{}, namespace interface{}, per interface{}, page interface{}, onlyPublic interface{}) *MockMCPServerStore_ByOrgPath_Call {
+	return &MockMCPServerStore_ByOrgPath_Call{Call: _e.mock.On("ByOrgPath", ctx, namespace, per, page, onlyPublic)}
+}
+
+func (_c *MockMCPServerStore_ByOrgPath_Call) Run(run func(ctx context.Context, namespace string, per int, page int, onlyPublic bool)) *MockMCPServerStore_ByOrgPath_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(int), args[3].(int), args[4].(bool))
+	})
+	return _c
+}
+
+func (_c *MockMCPServerStore_ByOrgPath_Call) Return(_a0 []database.MCPServer, _a1 int, _a2 error) *MockMCPServerStore_ByOrgPath_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *MockMCPServerStore_ByOrgPath_Call) RunAndReturn(run func(context.Context, string, int, int, bool) ([]database.MCPServer, int, error)) *MockMCPServerStore_ByOrgPath_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ByPath provides a mock function with given fields: ctx, namespace, name
 func (_m *MockMCPServerStore) ByPath(ctx context.Context, namespace string, name string) (*database.MCPServer, error) {
 	ret := _m.Called(ctx, namespace, name)
@@ -257,6 +326,75 @@ func (_c *MockMCPServerStore_ByRepoIDs_Call) Return(_a0 []database.MCPServer, _a
 }
 
 func (_c *MockMCPServerStore_ByRepoIDs_Call) RunAndReturn(run func(context.Context, []int64) ([]database.MCPServer, error)) *MockMCPServerStore_ByRepoIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ByUsername provides a mock function with given fields: ctx, username, per, page, onlyPublic
+func (_m *MockMCPServerStore) ByUsername(ctx context.Context, username string, per int, page int, onlyPublic bool) ([]database.MCPServer, int, error) {
+	ret := _m.Called(ctx, username, per, page, onlyPublic)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ByUsername")
+	}
+
+	var r0 []database.MCPServer
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, int, bool) ([]database.MCPServer, int, error)); ok {
+		return rf(ctx, username, per, page, onlyPublic)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, int, bool) []database.MCPServer); ok {
+		r0 = rf(ctx, username, per, page, onlyPublic)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.MCPServer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, int, int, bool) int); ok {
+		r1 = rf(ctx, username, per, page, onlyPublic)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, string, int, int, bool) error); ok {
+		r2 = rf(ctx, username, per, page, onlyPublic)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// MockMCPServerStore_ByUsername_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ByUsername'
+type MockMCPServerStore_ByUsername_Call struct {
+	*mock.Call
+}
+
+// ByUsername is a helper method to define mock.On call
+//   - ctx context.Context
+//   - username string
+//   - per int
+//   - page int
+//   - onlyPublic bool
+func (_e *MockMCPServerStore_Expecter) ByUsername(ctx interface{}, username interface{}, per interface{}, page interface{}, onlyPublic interface{}) *MockMCPServerStore_ByUsername_Call {
+	return &MockMCPServerStore_ByUsername_Call{Call: _e.mock.On("ByUsername", ctx, username, per, page, onlyPublic)}
+}
+
+func (_c *MockMCPServerStore_ByUsername_Call) Run(run func(ctx context.Context, username string, per int, page int, onlyPublic bool)) *MockMCPServerStore_ByUsername_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(int), args[3].(int), args[4].(bool))
+	})
+	return _c
+}
+
+func (_c *MockMCPServerStore_ByUsername_Call) Return(_a0 []database.MCPServer, _a1 int, _a2 error) *MockMCPServerStore_ByUsername_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *MockMCPServerStore_ByUsername_Call) RunAndReturn(run func(context.Context, string, int, int, bool) ([]database.MCPServer, int, error)) *MockMCPServerStore_ByUsername_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -582,6 +720,74 @@ func (_c *MockMCPServerStore_Update_Call) Return(_a0 *database.MCPServer, _a1 er
 }
 
 func (_c *MockMCPServerStore_Update_Call) RunAndReturn(run func(context.Context, database.MCPServer) (*database.MCPServer, error)) *MockMCPServerStore_Update_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UserLikes provides a mock function with given fields: ctx, userID, per, page
+func (_m *MockMCPServerStore) UserLikes(ctx context.Context, userID int64, per int, page int) ([]database.MCPServer, int, error) {
+	ret := _m.Called(ctx, userID, per, page)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UserLikes")
+	}
+
+	var r0 []database.MCPServer
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int, int) ([]database.MCPServer, int, error)); ok {
+		return rf(ctx, userID, per, page)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int, int) []database.MCPServer); ok {
+		r0 = rf(ctx, userID, per, page)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.MCPServer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int64, int, int) int); ok {
+		r1 = rf(ctx, userID, per, page)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, int64, int, int) error); ok {
+		r2 = rf(ctx, userID, per, page)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// MockMCPServerStore_UserLikes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UserLikes'
+type MockMCPServerStore_UserLikes_Call struct {
+	*mock.Call
+}
+
+// UserLikes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID int64
+//   - per int
+//   - page int
+func (_e *MockMCPServerStore_Expecter) UserLikes(ctx interface{}, userID interface{}, per interface{}, page interface{}) *MockMCPServerStore_UserLikes_Call {
+	return &MockMCPServerStore_UserLikes_Call{Call: _e.mock.On("UserLikes", ctx, userID, per, page)}
+}
+
+func (_c *MockMCPServerStore_UserLikes_Call) Run(run func(ctx context.Context, userID int64, per int, page int)) *MockMCPServerStore_UserLikes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64), args[2].(int), args[3].(int))
+	})
+	return _c
+}
+
+func (_c *MockMCPServerStore_UserLikes_Call) Return(_a0 []database.MCPServer, _a1 int, _a2 error) *MockMCPServerStore_UserLikes_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *MockMCPServerStore_UserLikes_Call) RunAndReturn(run func(context.Context, int64, int, int) ([]database.MCPServer, int, error)) *MockMCPServerStore_UserLikes_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/_mocks/opencsg.com/csghub-server/component/mock_MCPServerComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_MCPServerComponent.go
@@ -197,6 +197,72 @@ func (_c *MockMCPServerComponent_Index_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
+// OrgMCPServers provides a mock function with given fields: ctx, req
+func (_m *MockMCPServerComponent) OrgMCPServers(ctx context.Context, req *types.OrgMCPsReq) ([]types.MCPServer, int, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OrgMCPServers")
+	}
+
+	var r0 []types.MCPServer
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, *types.OrgMCPsReq) ([]types.MCPServer, int, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *types.OrgMCPsReq) []types.MCPServer); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]types.MCPServer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *types.OrgMCPsReq) int); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, *types.OrgMCPsReq) error); ok {
+		r2 = rf(ctx, req)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// MockMCPServerComponent_OrgMCPServers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OrgMCPServers'
+type MockMCPServerComponent_OrgMCPServers_Call struct {
+	*mock.Call
+}
+
+// OrgMCPServers is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *types.OrgMCPsReq
+func (_e *MockMCPServerComponent_Expecter) OrgMCPServers(ctx interface{}, req interface{}) *MockMCPServerComponent_OrgMCPServers_Call {
+	return &MockMCPServerComponent_OrgMCPServers_Call{Call: _e.mock.On("OrgMCPServers", ctx, req)}
+}
+
+func (_c *MockMCPServerComponent_OrgMCPServers_Call) Run(run func(ctx context.Context, req *types.OrgMCPsReq)) *MockMCPServerComponent_OrgMCPServers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*types.OrgMCPsReq))
+	})
+	return _c
+}
+
+func (_c *MockMCPServerComponent_OrgMCPServers_Call) Return(_a0 []types.MCPServer, _a1 int, _a2 error) *MockMCPServerComponent_OrgMCPServers_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *MockMCPServerComponent_OrgMCPServers_Call) RunAndReturn(run func(context.Context, *types.OrgMCPsReq) ([]types.MCPServer, int, error)) *MockMCPServerComponent_OrgMCPServers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Properties provides a mock function with given fields: ctx, req
 func (_m *MockMCPServerComponent) Properties(ctx context.Context, req *types.MCPPropertyFilter) ([]types.MCPServerProperties, int, error) {
 	ret := _m.Called(ctx, req)

--- a/_mocks/opencsg.com/csghub-server/component/mock_UserComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_UserComponent.go
@@ -686,6 +686,72 @@ func (_c *MockUserComponent_LikesDatasets_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// LikesMCPServers provides a mock function with given fields: ctx, req
+func (_m *MockUserComponent) LikesMCPServers(ctx context.Context, req *types.UserMCPsReq) ([]types.MCPServer, int, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LikesMCPServers")
+	}
+
+	var r0 []types.MCPServer
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, *types.UserMCPsReq) ([]types.MCPServer, int, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *types.UserMCPsReq) []types.MCPServer); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]types.MCPServer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *types.UserMCPsReq) int); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, *types.UserMCPsReq) error); ok {
+		r2 = rf(ctx, req)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// MockUserComponent_LikesMCPServers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LikesMCPServers'
+type MockUserComponent_LikesMCPServers_Call struct {
+	*mock.Call
+}
+
+// LikesMCPServers is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *types.UserMCPsReq
+func (_e *MockUserComponent_Expecter) LikesMCPServers(ctx interface{}, req interface{}) *MockUserComponent_LikesMCPServers_Call {
+	return &MockUserComponent_LikesMCPServers_Call{Call: _e.mock.On("LikesMCPServers", ctx, req)}
+}
+
+func (_c *MockUserComponent_LikesMCPServers_Call) Run(run func(ctx context.Context, req *types.UserMCPsReq)) *MockUserComponent_LikesMCPServers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*types.UserMCPsReq))
+	})
+	return _c
+}
+
+func (_c *MockUserComponent_LikesMCPServers_Call) Return(_a0 []types.MCPServer, _a1 int, _a2 error) *MockUserComponent_LikesMCPServers_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *MockUserComponent_LikesMCPServers_Call) RunAndReturn(run func(context.Context, *types.UserMCPsReq) ([]types.MCPServer, int, error)) *MockUserComponent_LikesMCPServers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // LikesModels provides a mock function with given fields: ctx, req
 func (_m *MockUserComponent) LikesModels(ctx context.Context, req *types.UserModelsReq) ([]types.Model, int, error) {
 	ret := _m.Called(ctx, req)
@@ -1013,6 +1079,72 @@ func (_c *MockUserComponent_ListServerless_Call) Return(_a0 []types.DeployRepo, 
 }
 
 func (_c *MockUserComponent_ListServerless_Call) RunAndReturn(run func(context.Context, types.DeployReq) ([]types.DeployRepo, int, error)) *MockUserComponent_ListServerless_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MCPServers provides a mock function with given fields: ctx, req
+func (_m *MockUserComponent) MCPServers(ctx context.Context, req *types.UserMCPsReq) ([]types.MCPServer, int, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MCPServers")
+	}
+
+	var r0 []types.MCPServer
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, *types.UserMCPsReq) ([]types.MCPServer, int, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *types.UserMCPsReq) []types.MCPServer); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]types.MCPServer)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *types.UserMCPsReq) int); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, *types.UserMCPsReq) error); ok {
+		r2 = rf(ctx, req)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// MockUserComponent_MCPServers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MCPServers'
+type MockUserComponent_MCPServers_Call struct {
+	*mock.Call
+}
+
+// MCPServers is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *types.UserMCPsReq
+func (_e *MockUserComponent_Expecter) MCPServers(ctx interface{}, req interface{}) *MockUserComponent_MCPServers_Call {
+	return &MockUserComponent_MCPServers_Call{Call: _e.mock.On("MCPServers", ctx, req)}
+}
+
+func (_c *MockUserComponent_MCPServers_Call) Run(run func(ctx context.Context, req *types.UserMCPsReq)) *MockUserComponent_MCPServers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*types.UserMCPsReq))
+	})
+	return _c
+}
+
+func (_c *MockUserComponent_MCPServers_Call) Return(_a0 []types.MCPServer, _a1 int, _a2 error) *MockUserComponent_MCPServers_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *MockUserComponent_MCPServers_Call) RunAndReturn(run func(context.Context, *types.UserMCPsReq) ([]types.MCPServer, int, error)) *MockUserComponent_MCPServers_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/api/handler/user.go
+++ b/api/handler/user.go
@@ -589,7 +589,7 @@ func (h *UserHandler) LikesDatasets(ctx *gin.Context) {
 	req.PageSize = per
 	ds, total, err := h.user.LikesDatasets(ctx.Request.Context(), &req)
 	if err != nil {
-		slog.Error("Failed to gat user datasets", slog.Any("error", err))
+		slog.Error("Failed to get user datasets", slog.Any("error", err))
 		httpbase.ServerError(ctx, err)
 		return
 	}
@@ -893,4 +893,91 @@ func (h *UserHandler) GetEvaluations(ctx *gin.Context) {
 		"total": total,
 	}
 	ctx.JSON(http.StatusOK, respData)
+}
+
+// GetUserMCPs   godoc
+// @Security     ApiKey
+// @Summary      Get user mcp servers
+// @Description  Get user mcp servers
+// @Tags         User
+// @Accept       json
+// @Produce      json
+// @Param        username path string true "username"
+// @Param        per query int false "per" default(20)
+// @Param        page query int false "per page" default(1)
+// @Success      200  {object}  types.Response{data=[]types.MCPServer,total=int} "OK"
+// @Failure      400  {object}  types.APIBadRequest "Bad request"
+// @Failure      500  {object}  types.APIInternalServerError "Internal server error"
+// @Router       /user/{username}/mcps [get]
+func (h *UserHandler) MCPServers(ctx *gin.Context) {
+	var req types.UserMCPsReq
+	per, page, err := common.GetPerAndPageFromContext(ctx)
+	if err != nil {
+		slog.Error("Bad request format of page and per", "error", err)
+		httpbase.BadRequest(ctx, err.Error())
+		return
+	}
+
+	req.Owner = ctx.Param("username")
+	req.CurrentUser = httpbase.GetCurrentUser(ctx)
+	req.Page = page
+	req.PageSize = per
+	mcps, total, err := h.user.MCPServers(ctx.Request.Context(), &req)
+	if err != nil {
+		slog.Error("Failed to get user mcp servers", slog.Any("error", err), slog.Any("req", req))
+		httpbase.ServerError(ctx, err)
+		return
+	}
+
+	respData := gin.H{
+		"data":  mcps,
+		"total": total,
+	}
+
+	httpbase.OK(ctx, respData)
+}
+
+// GetUserLikesMCPServers godoc
+// @Security     ApiKey
+// @Summary      Get user likes mcp servers
+// @Description  get user likes mcp servers
+// @Tags         User
+// @Accept       json
+// @Produce      json
+// @Param        username path string true "username"
+// @Success      200  {object}  types.ResponseWithTotal{data=[]types.MCPServer,total=int} "OK"
+// @Failure      400  {object}  types.APIBadRequest "Bad request"
+// @Failure      500  {object}  types.APIInternalServerError "Internal server error"
+// @Router       /user/{username}/likes/mcps [get]
+func (h *UserHandler) LikesMCPServers(ctx *gin.Context) {
+	currentUser := httpbase.GetCurrentUser(ctx)
+	if currentUser == "" {
+		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		return
+	}
+	var req types.UserMCPsReq
+	per, page, err := common.GetPerAndPageFromContext(ctx)
+	if err != nil {
+		slog.Error("Bad request format of page and per", "error", err)
+		httpbase.BadRequest(ctx, err.Error())
+		return
+	}
+
+	req.Owner = ctx.Param("username")
+	req.CurrentUser = currentUser
+	req.Page = page
+	req.PageSize = per
+	data, total, err := h.user.LikesMCPServers(ctx.Request.Context(), &req)
+	if err != nil {
+		slog.Error("Failed to get user likes mcp servers", slog.Any("error", err), slog.Any("req", req))
+		httpbase.ServerError(ctx, err)
+		return
+	}
+
+	respData := gin.H{
+		"data":  data,
+		"total": total,
+	}
+
+	httpbase.OK(ctx, respData)
 }

--- a/api/handler/user_test.go
+++ b/api/handler/user_test.go
@@ -438,3 +438,48 @@ func TestUserHandler_GetEvaluations(t *testing.T) {
 		"total": 100,
 	})
 }
+
+func TestUserHandler_MCPServers(t *testing.T) {
+	tester := NewUserTester(t).WithHandleFunc(func(h *UserHandler) gin.HandlerFunc {
+		return h.MCPServers
+	})
+
+	tester.mocks.user.EXPECT().MCPServers(tester.Ctx(), &types.UserMCPsReq{
+		CurrentUser: "u",
+		Owner:       "u",
+		PageOpts: types.PageOpts{
+			Page:     1,
+			PageSize: 10,
+		},
+	}).Return([]types.MCPServer{{ID: 123}}, 1, nil)
+
+	tester.WithUser().WithParam("username", "u").AddPagination(1, 10).Execute()
+
+	tester.ResponseEq(t, 200, tester.OKText, gin.H{
+		"data":  []types.MCPServer{{ID: 123}},
+		"total": 1,
+	})
+}
+
+func TestUserHandler_LikesMCPServers(t *testing.T) {
+	tester := NewUserTester(t).WithHandleFunc(func(h *UserHandler) gin.HandlerFunc {
+		return h.LikesMCPServers
+	})
+	tester.RequireUser(t)
+
+	tester.mocks.user.EXPECT().LikesMCPServers(tester.Ctx(), &types.UserMCPsReq{
+		Owner:       "foo",
+		CurrentUser: "u",
+		PageOpts: types.PageOpts{
+			Page:     1,
+			PageSize: 10,
+		},
+	}).Return([]types.MCPServer{{Name: "sp"}}, 100, nil)
+
+	tester.WithParam("username", "foo").AddPagination(1, 10).Execute()
+
+	tester.ResponseEq(t, 200, tester.OKText, gin.H{
+		"data":  []types.MCPServer{{Name: "sp"}},
+		"total": 100,
+	})
+}

--- a/api/router/api.go
+++ b/api/router/api.go
@@ -251,28 +251,8 @@ func NewRouter(config *config.Config, enableSwagger bool) (*gin.Engine, error) {
 		apiGroup.DELETE("/user/:username/ssh_key/:name", authCollection.UserMatch, sshKeyHandler.Delete)
 	}
 
-	{
-		apiGroup.GET("/organizations", userProxyHandler.Proxy)
-		apiGroup.POST("/organizations", userProxyHandler.Proxy)
-		apiGroup.GET("/organization/:namespace", userProxyHandler.ProxyToApi("/api/v1/organization/%s", "namespace"))
-		apiGroup.PUT("/organization/:namespace", userProxyHandler.ProxyToApi("/api/v1/organization/%s", "namespace"))
-		apiGroup.DELETE("/organization/:namespace", userProxyHandler.ProxyToApi("/api/v1/organization/%s", "namespace"))
-		// Organization assets
-		apiGroup.GET("/organization/:namespace/models", orgHandler.Models)
-		apiGroup.GET("/organization/:namespace/datasets", orgHandler.Datasets)
-		apiGroup.GET("/organization/:namespace/codes", orgHandler.Codes)
-		apiGroup.GET("/organization/:namespace/spaces", orgHandler.Spaces)
-		apiGroup.GET("/organization/:namespace/collections", orgHandler.Collections)
-		apiGroup.GET("/organization/:namespace/prompts", orgHandler.Prompts)
-	}
-
-	{
-		apiGroup.GET("/organization/:namespace/members", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members", "namespace"))
-		apiGroup.POST("/organization/:namespace/members", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members", "namespace"))
-		apiGroup.GET("/organization/:namespace/members/:username", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members/%s", "namespace", "username"))
-		apiGroup.PUT("/organization/:namespace/members/:username", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members/%s", "namespace", "username"))
-		apiGroup.DELETE("/organization/:namespace/members/:username", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members/%s", "namespace", "username"))
-	}
+	// Organization routes
+	createOrgRoutes(apiGroup, userProxyHandler, orgHandler)
 
 	// Tag
 	tagCtrl, err := handler.NewTagHandler(config)
@@ -717,7 +697,7 @@ func createSpaceRoutes(config *config.Config, apiGroup *gin.RouterGroup, spaceHa
 }
 
 func createUserRoutes(apiGroup *gin.RouterGroup, authCollection middleware.AuthenticatorCollection, userProxyHandler *handler.InternalServiceProxyHandler, userHandler *handler.UserHandler) {
-	// depricated
+	// deprecated
 	{
 		apiGroup.POST("/users", userProxyHandler.ProxyToApi("/api/v1/user"))
 		apiGroup.PUT("/users/:username", userProxyHandler.ProxyToApi("/api/v1/user/%v", "username"))
@@ -738,6 +718,7 @@ func createUserRoutes(apiGroup *gin.RouterGroup, authCollection middleware.Authe
 		apiGroup.GET("/user/:username/codes", userHandler.Codes)
 		apiGroup.GET("/user/:username/spaces", userHandler.Spaces)
 		apiGroup.GET("/user/:username/prompts", userHandler.Prompts)
+		apiGroup.GET("/user/:username/mcps", userHandler.MCPServers)
 		// User likes
 		apiGroup.PUT("/user/:username/likes/:repo_id", userHandler.LikesAdd)
 		apiGroup.DELETE("/user/:username/likes/:repo_id", userHandler.LikesDelete)
@@ -745,6 +726,7 @@ func createUserRoutes(apiGroup *gin.RouterGroup, authCollection middleware.Authe
 		apiGroup.GET("/user/:username/likes/codes", userHandler.LikesCodes)
 		apiGroup.GET("/user/:username/likes/models", userHandler.LikesModels)
 		apiGroup.GET("/user/:username/likes/datasets", userHandler.LikesDatasets)
+		apiGroup.GET("/user/:username/likes/mcps", userHandler.LikesMCPServers)
 		apiGroup.GET("/user/:username/run/:repo_type", userHandler.GetRunDeploys)
 		apiGroup.GET("/user/:username/finetune/instances", userHandler.GetFinetuneInstances)
 		// User evaluations
@@ -912,5 +894,31 @@ func createSpaceTemplateRoutes(apiGroup *gin.RouterGroup, authCollection middlew
 		spaceTemplateGrp.PUT("/:id", authCollection.NeedAdmin, templateHandler.Update)
 		spaceTemplateGrp.DELETE("/:id", authCollection.NeedAdmin, templateHandler.Delete)
 		spaceTemplateGrp.GET("/:type", templateHandler.List)
+	}
+}
+
+func createOrgRoutes(apiGroup *gin.RouterGroup, userProxyHandler *handler.InternalServiceProxyHandler, orgHandler *handler.OrganizationHandler) {
+	{
+		apiGroup.GET("/organizations", userProxyHandler.Proxy)
+		apiGroup.POST("/organizations", userProxyHandler.Proxy)
+		apiGroup.GET("/organization/:namespace", userProxyHandler.ProxyToApi("/api/v1/organization/%s", "namespace"))
+		apiGroup.PUT("/organization/:namespace", userProxyHandler.ProxyToApi("/api/v1/organization/%s", "namespace"))
+		apiGroup.DELETE("/organization/:namespace", userProxyHandler.ProxyToApi("/api/v1/organization/%s", "namespace"))
+		// Organization assets
+		apiGroup.GET("/organization/:namespace/models", orgHandler.Models)
+		apiGroup.GET("/organization/:namespace/datasets", orgHandler.Datasets)
+		apiGroup.GET("/organization/:namespace/codes", orgHandler.Codes)
+		apiGroup.GET("/organization/:namespace/spaces", orgHandler.Spaces)
+		apiGroup.GET("/organization/:namespace/collections", orgHandler.Collections)
+		apiGroup.GET("/organization/:namespace/prompts", orgHandler.Prompts)
+		apiGroup.GET("/organization/:namespace/mcps", orgHandler.MCPServers)
+	}
+
+	{
+		apiGroup.GET("/organization/:namespace/members", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members", "namespace"))
+		apiGroup.POST("/organization/:namespace/members", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members", "namespace"))
+		apiGroup.GET("/organization/:namespace/members/:username", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members/%s", "namespace", "username"))
+		apiGroup.PUT("/organization/:namespace/members/:username", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members/%s", "namespace", "username"))
+		apiGroup.DELETE("/organization/:namespace/members/:username", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members/%s", "namespace", "username"))
 	}
 }

--- a/common/types/organization.go
+++ b/common/types/organization.go
@@ -108,6 +108,7 @@ type (
 	OrgSpacesReq      = OrgDatasetsReq
 	OrgCollectionsReq = OrgDatasetsReq
 	OrgPromptsReq     = OrgDatasetsReq
+	OrgMCPsReq        = OrgDatasetsReq
 )
 
 type Organization struct {

--- a/common/types/user.go
+++ b/common/types/user.go
@@ -150,6 +150,7 @@ type (
 	DeleteUserTokenRequest = CreateUserTokenRequest
 	UserPromptsReq         = UserDatasetsReq
 	UserEvaluationReq      = UserDatasetsReq
+	UserMCPsReq            = UserDatasetsReq
 )
 
 type PageOpts struct {

--- a/component/wireset.go
+++ b/component/wireset.go
@@ -216,6 +216,7 @@ func NewTestUserComponent(
 		accountingComponent: accountingComponent,
 		promptStore:         stores.Prompt,
 		deployTaskStore:     stores.DeployTask,
+		mcpServerStore:      stores.MCPServerStore,
 	}
 }
 

--- a/user/component/member.go
+++ b/user/component/member.go
@@ -147,15 +147,15 @@ func (c *memberComponentImpl) GetMemberRole(ctx context.Context, orgName, userNa
 	)
 	org, err = c.orgStore.FindByPath(ctx, orgName)
 	if err != nil {
-		return membership.RoleUnknown, fmt.Errorf("failed to find org,caused by:%w", err)
+		return membership.RoleUnknown, fmt.Errorf("failed to find org %s, caused by:%w", orgName, err)
 	}
 	user, err = c.userStore.FindByUsername(ctx, userName)
 	if err != nil {
-		return membership.RoleUnknown, fmt.Errorf("failed to find user,caused by:%w", err)
+		return membership.RoleUnknown, fmt.Errorf("failed to find user %s, caused by:%w", userName, err)
 	}
 	m, err := c.memberStore.Find(ctx, org.ID, user.ID)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return membership.RoleUnknown, fmt.Errorf("failed to check memberhsip existence,caused by:%w", err)
+		return membership.RoleUnknown, fmt.Errorf("failed to check memberhsip existence, caused by:%w", err)
 	}
 	if m == nil {
 		return membership.RoleUnknown, nil

--- a/user/handler/member.go
+++ b/user/handler/member.go
@@ -208,6 +208,7 @@ func (h *MemberHandler) GetMemberRole(ctx *gin.Context) {
 	// Assuming GetMemberRole returns a role (or similar) and an error
 	role, err := h.c.GetMemberRole(ctx.Request.Context(), org, userName)
 	if err != nil {
+		slog.Error("fail to get org member", slog.Any("org", org), slog.Any("member", userName), slog.Any("err", err))
 		httpbase.ServerError(ctx, err)
 		return
 	}


### PR DESCRIPTION
**What is this feature?**
- Add ByOrgPath method to MCPServerStore
- Add ByUsername method to MCPServerStore
- Implement UserLikes method in MCPServerStore
- Create OrgMCPServers method in MCPServerComponent
- Create MCPServers method in UserHandler
- Add LikesMCPServers method in UserHandler
- Update API routes for MCP servers
- Add tests for new MCP server methods and handlers

