### PR TITLE
Fix docker-compose.yml error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,8 @@ services:
     volumes:
       - ./nats-server.conf:/nats-server.conf
       - ./jetstream:/data/jetstream
+    networks:
+      - my_network
     restart: always
 
   account_server:
@@ -142,6 +144,8 @@ services:
       GIN_MODE: release
     ports:
       - "8086:8086"
+    networks:
+      - my_network
     restart: always
   
   user_server:
@@ -175,6 +179,8 @@ services:
       - "8088:8088"
     volumes:
       - ./casdoor:/starhub-bin/casdoor:r
+    networks:
+      - my_network
 
 networks:
   my_network:


### PR DESCRIPTION
**What is this feature?**

给docker-compose.yml文件的natsmaster、account_server、user_server服务添加了networks

**Why do we need this feature?**

解决natsmaster、account_server、user_server无法解析postgres的域名

**Who is this feature for?**

fix bugs，修复了漏洞

**Which issue(s) does this PR fix?**:

Fixes #

没有修复什么issue，是我自己发现的

**Special notes for your reviewer:**
