### PR TITLE
style: move error.go to common

### DIFF
--- a/api/handler/cluster.go
+++ b/api/handler/cluster.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/component"
 )
@@ -38,7 +39,7 @@ type ClusterHandler struct {
 func (h *ClusterHandler) Index(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	clusters, err := h.c.Index(ctx.Request.Context())
@@ -64,7 +65,7 @@ func (h *ClusterHandler) Index(ctx *gin.Context) {
 func (h *ClusterHandler) GetClusterById(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	id := ctx.Param("id")

--- a/api/handler/code.go
+++ b/api/handler/code.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 	"opencsg.com/csghub-server/component"
@@ -51,7 +52,7 @@ type CodeHandler struct {
 func (h *CodeHandler) Create(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req *types.CreateCodeReq
@@ -71,7 +72,7 @@ func (h *CodeHandler) Create(ctx *gin.Context) {
 
 	code, err := h.code.Create(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -157,7 +158,7 @@ func (h *CodeHandler) Index(ctx *gin.Context) {
 func (h *CodeHandler) Update(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req *types.UpdateCodeReq
@@ -186,7 +187,7 @@ func (h *CodeHandler) Update(ctx *gin.Context) {
 
 	code, err := h.code.Update(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -216,7 +217,7 @@ func (h *CodeHandler) Update(ctx *gin.Context) {
 func (h *CodeHandler) Delete(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -227,7 +228,7 @@ func (h *CodeHandler) Delete(ctx *gin.Context) {
 	}
 	err = h.code.Delete(ctx.Request.Context(), namespace, name, currentUser)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -263,7 +264,7 @@ func (h *CodeHandler) Show(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	detail, err := h.code.Show(ctx.Request.Context(), namespace, name, currentUser)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -298,7 +299,7 @@ func (h *CodeHandler) Relations(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	detail, err := h.code.Relations(ctx.Request.Context(), namespace, name, currentUser)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}

--- a/api/handler/dataset.go
+++ b/api/handler/dataset.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 	"opencsg.com/csghub-server/component"
@@ -58,7 +59,7 @@ type DatasetHandler struct {
 func (h *DatasetHandler) Create(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req *types.CreateDatasetReq
@@ -81,7 +82,7 @@ func (h *DatasetHandler) Create(ctx *gin.Context) {
 
 	dataset, err := h.dataset.Create(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -167,7 +168,7 @@ func (h *DatasetHandler) Index(ctx *gin.Context) {
 func (h *DatasetHandler) Update(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req *types.UpdateDatasetReq
@@ -196,7 +197,7 @@ func (h *DatasetHandler) Update(ctx *gin.Context) {
 
 	dataset, err := h.dataset.Update(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -226,7 +227,7 @@ func (h *DatasetHandler) Update(ctx *gin.Context) {
 func (h *DatasetHandler) Delete(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -237,7 +238,7 @@ func (h *DatasetHandler) Delete(ctx *gin.Context) {
 	}
 	err = h.dataset.Delete(ctx.Request.Context(), namespace, name, currentUser)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -273,7 +274,7 @@ func (h *DatasetHandler) Show(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	detail, err := h.dataset.Show(ctx.Request.Context(), namespace, name, currentUser)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -309,7 +310,7 @@ func (h *DatasetHandler) Relations(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	detail, err := h.dataset.Relations(ctx.Request.Context(), namespace, name, currentUser)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -359,7 +360,7 @@ func (h *DatasetHandler) AllFiles(ctx *gin.Context) {
 	req.Ref = ""
 	detail, err := h.repo.AllFiles(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}

--- a/api/handler/dataset_test.go
+++ b/api/handler/dataset_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	mockcomponent "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/component"
 	"opencsg.com/csghub-server/builder/testutil"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
-	"opencsg.com/csghub-server/component"
 )
 
 type DatasetTester struct {
@@ -102,7 +102,7 @@ func TestDatasetHandler_Update(t *testing.T) {
 				Namespace: "u-other",
 				Name:      "r",
 			},
-		}).Return(nil, component.ErrForbiddenMsg("user not allowed to update dataset"))
+		}).Return(nil, errorx.ErrForbiddenMsg("user not allowed to update dataset"))
 		tester.WithParam("namespace", "u-other").WithParam("name", "r").
 			WithBody(t, &types.UpdateDatasetReq{
 				UpdateRepoReq: types.UpdateRepoReq{Name: "r"},
@@ -142,7 +142,7 @@ func TestDatasetHandler_Delete(t *testing.T) {
 		})
 		tester.RequireUser(t)
 
-		tester.mocks.dataset.EXPECT().Delete(tester.Ctx(), "u-other", "r", "u").Return(component.ErrForbidden)
+		tester.mocks.dataset.EXPECT().Delete(tester.Ctx(), "u-other", "r", "u").Return(errorx.ErrForbidden)
 		tester.WithParam("namespace", "u-other").WithParam("name", "r")
 		tester.WithUser().Execute()
 
@@ -168,7 +168,7 @@ func TestDatasetHandler_Show(t *testing.T) {
 			return h.Show
 		})
 
-		tester.mocks.dataset.EXPECT().Show(tester.Ctx(), "u-other", "r", "u").Return(nil, component.ErrForbidden)
+		tester.mocks.dataset.EXPECT().Show(tester.Ctx(), "u-other", "r", "u").Return(nil, errorx.ErrForbidden)
 		tester.WithParam("namespace", "u-other").WithParam("name", "r")
 		tester.WithUser().Execute()
 
@@ -195,7 +195,7 @@ func TestDatasetHandler_Relations(t *testing.T) {
 			return h.Relations
 		})
 
-		tester.mocks.dataset.EXPECT().Relations(tester.Ctx(), "u-other", "r", "u").Return(nil, component.ErrForbidden)
+		tester.mocks.dataset.EXPECT().Relations(tester.Ctx(), "u-other", "r", "u").Return(nil, errorx.ErrForbidden)
 		tester.WithParam("namespace", "u-other").WithParam("name", "r")
 		tester.WithUser().Execute()
 
@@ -230,7 +230,7 @@ func TestDatasetHandler_AllFiles(t *testing.T) {
 			Name:        "r",
 			RepoType:    types.DatasetRepo,
 			CurrentUser: "u",
-		}).Return(nil, component.ErrForbidden)
+		}).Return(nil, errorx.ErrForbidden)
 		tester.WithParam("namespace", "u-other").WithParam("name", "r")
 		tester.WithUser().Execute()
 

--- a/api/handler/discussion.go
+++ b/api/handler/discussion.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 	"opencsg.com/csghub-server/component"
@@ -50,7 +51,7 @@ func NewDiscussionHandler(cfg *config.Config) (*DiscussionHandler, error) {
 func (h *DiscussionHandler) CreateRepoDiscussion(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	repoType := h.getRepoType(ctx)
@@ -104,7 +105,7 @@ func (h *DiscussionHandler) CreateRepoDiscussion(ctx *gin.Context) {
 func (h *DiscussionHandler) UpdateDiscussion(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	id := ctx.Param("id")
@@ -153,7 +154,7 @@ func (h *DiscussionHandler) UpdateDiscussion(ctx *gin.Context) {
 func (h *DiscussionHandler) DeleteDiscussion(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	id := ctx.Param("id")
@@ -255,7 +256,7 @@ func (h *DiscussionHandler) ListRepoDiscussions(ctx *gin.Context) {
 func (h *DiscussionHandler) CreateDiscussionComment(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -306,7 +307,7 @@ func (h *DiscussionHandler) CreateDiscussionComment(ctx *gin.Context) {
 func (h *DiscussionHandler) UpdateComment(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	id := ctx.Param("id")
@@ -353,7 +354,7 @@ func (h *DiscussionHandler) UpdateComment(ctx *gin.Context) {
 func (h *DiscussionHandler) DeleteComment(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	id := ctx.Param("id")

--- a/api/handler/git_http_test.go
+++ b/api/handler/git_http_test.go
@@ -13,8 +13,8 @@ import (
 	mockcomponent "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/component"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/builder/testutil"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
-	"opencsg.com/csghub-server/component"
 )
 
 type GitHTTPTester struct {
@@ -110,7 +110,7 @@ func TestGitHTTPHandler_GitUploadPack(t *testing.T) {
 			Request:     tester.Gctx().Request,
 			Writer:      tester.Gctx().Writer,
 			CurrentUser: "u",
-		}).Return(component.ErrForbidden)
+		}).Return(errorx.ErrForbidden)
 		tester.SetPath("git").WithQuery("service", "git-upload-pack").WithHeader("Git-Protocol", "ssh")
 		tester.WithKV("namespace", "u-other").WithKV("name", "r")
 		tester.WithKV("repo_type", "model").WithUser().WithHeader("Accept-Encoding", "gzip").Execute()
@@ -174,9 +174,9 @@ func TestGitHTTPHandler_LfsBatch(t *testing.T) {
 		err        error
 		statusCode int
 	}{
-		{component.ErrUnauthorized, 401},
-		{component.ErrForbidden, 403},
-		{&component.HTTPError{
+		{errorx.ErrUnauthorized, 401},
+		{errorx.ErrForbidden, 403},
+		{&errorx.HTTPError{
 			StatusCode: 499,
 			Message:    "xxx",
 		}, 499},

--- a/api/handler/mcp_server.go
+++ b/api/handler/mcp_server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 	"opencsg.com/csghub-server/component"
@@ -70,7 +71,7 @@ func (h *MCPServerHandler) Create(ctx *gin.Context) {
 
 	mcpServer, err := h.mcpComp.Create(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -114,7 +115,7 @@ func (h *MCPServerHandler) Delete(ctx *gin.Context) {
 
 	err = h.mcpComp.Delete(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -170,7 +171,7 @@ func (h *MCPServerHandler) Update(ctx *gin.Context) {
 
 	res, err := h.mcpComp.Update(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -221,7 +222,7 @@ func (h *MCPServerHandler) Show(ctx *gin.Context) {
 
 	detail, err := h.mcpComp.Show(ctx.Request.Context(), namespace, name, currentUser, needOpWeight, needMultiSync)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -391,7 +392,7 @@ func (h *MCPServerHandler) Deploy(ctx *gin.Context) {
 
 	respData, err := h.mcpComp.Deploy(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}

--- a/api/handler/mirror.go
+++ b/api/handler/mirror.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 	"opencsg.com/csghub-server/component"
@@ -40,7 +41,7 @@ type MirrorHandler struct {
 func (h *MirrorHandler) CreateMirrorRepo(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -78,7 +79,7 @@ func (h *MirrorHandler) CreateMirrorRepo(ctx *gin.Context) {
 func (h *MirrorHandler) Repos(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -118,7 +119,7 @@ func (h *MirrorHandler) Repos(ctx *gin.Context) {
 func (h *MirrorHandler) Index(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 

--- a/api/handler/mirror_source.go
+++ b/api/handler/mirror_source.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/component"
 )
@@ -40,7 +41,7 @@ type MirrorSourceHandler struct {
 func (h *MirrorSourceHandler) Create(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -74,7 +75,7 @@ func (h *MirrorSourceHandler) Create(ctx *gin.Context) {
 func (h *MirrorSourceHandler) Index(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	ms, err := h.mirrorSource.Index(ctx.Request.Context(), currentUser)
@@ -101,7 +102,7 @@ func (h *MirrorSourceHandler) Index(ctx *gin.Context) {
 func (h *MirrorSourceHandler) Update(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -150,7 +151,7 @@ func (h *MirrorSourceHandler) Update(ctx *gin.Context) {
 func (h *MirrorSourceHandler) Get(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -192,7 +193,7 @@ func (h *MirrorSourceHandler) Get(ctx *gin.Context) {
 func (h *MirrorSourceHandler) Delete(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 

--- a/api/handler/model.go
+++ b/api/handler/model.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 	"opencsg.com/csghub-server/component"
@@ -121,7 +122,7 @@ func (h *ModelHandler) Index(ctx *gin.Context) {
 func (h *ModelHandler) Create(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req *types.CreateModelReq
@@ -141,7 +142,7 @@ func (h *ModelHandler) Create(ctx *gin.Context) {
 
 	model, err := h.model.Create(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -171,7 +172,7 @@ func (h *ModelHandler) Create(ctx *gin.Context) {
 func (h *ModelHandler) Update(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req *types.UpdateModelReq
@@ -200,7 +201,7 @@ func (h *ModelHandler) Update(ctx *gin.Context) {
 
 	model, err := h.model.Update(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -230,7 +231,7 @@ func (h *ModelHandler) Update(ctx *gin.Context) {
 func (h *ModelHandler) Delete(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -241,7 +242,7 @@ func (h *ModelHandler) Delete(ctx *gin.Context) {
 	}
 	err = h.model.Delete(ctx.Request.Context(), namespace, name, currentUser)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -278,7 +279,7 @@ func (h *ModelHandler) Show(ctx *gin.Context) {
 	detail, err := h.model.Show(ctx.Request.Context(), namespace, name, currentUser, false)
 
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -310,7 +311,7 @@ func (h *ModelHandler) SDKModelInfo(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	modelInfo, err := h.model.SDKModelInfo(ctx.Request.Context(), namespace, name, ref, currentUser, blobs)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -345,7 +346,7 @@ func (h *ModelHandler) Relations(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	detail, err := h.model.Relations(ctx.Request.Context(), namespace, name, currentUser)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -374,7 +375,7 @@ func (h *ModelHandler) Relations(ctx *gin.Context) {
 func (h *ModelHandler) SetRelations(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -397,7 +398,7 @@ func (h *ModelHandler) SetRelations(ctx *gin.Context) {
 
 	err = h.model.SetRelationDatasets(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -425,7 +426,7 @@ func (h *ModelHandler) SetRelations(ctx *gin.Context) {
 func (h *ModelHandler) AddDatasetRelation(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -448,7 +449,7 @@ func (h *ModelHandler) AddDatasetRelation(ctx *gin.Context) {
 
 	err = h.model.AddRelationDataset(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -476,7 +477,7 @@ func (h *ModelHandler) AddDatasetRelation(ctx *gin.Context) {
 func (h *ModelHandler) DelDatasetRelation(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -499,7 +500,7 @@ func (h *ModelHandler) DelDatasetRelation(ctx *gin.Context) {
 
 	err = h.model.DelRelationDataset(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -592,7 +593,7 @@ func convertFilePathFromRoute(path string) string {
 func (h *ModelHandler) DeployDedicated(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -677,7 +678,7 @@ func (h *ModelHandler) DeployDedicated(ctx *gin.Context) {
 func (h *ModelHandler) FinetuneCreate(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -764,7 +765,7 @@ func (h *ModelHandler) DeployDelete(ctx *gin.Context) {
 	)
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -789,7 +790,7 @@ func (h *ModelHandler) DeployDelete(ctx *gin.Context) {
 	}
 	err = h.repo.DeleteDeploy(ctx.Request.Context(), delReq)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			slog.Info("not allowed to delete inference", slog.Any("error", err), slog.Any("req", delReq))
 			httpbase.ForbiddenError(ctx, err)
 			return
@@ -823,7 +824,7 @@ func (h *ModelHandler) FinetuneDelete(ctx *gin.Context) {
 	)
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -849,7 +850,7 @@ func (h *ModelHandler) FinetuneDelete(ctx *gin.Context) {
 	}
 	err = h.repo.DeleteDeploy(ctx.Request.Context(), delReq)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			slog.Error("not allowed to delete finetune", slog.Any("error", err), slog.Any("req", delReq))
 			httpbase.ForbiddenError(ctx, err)
 			return
@@ -883,7 +884,7 @@ func (h *ModelHandler) DeployStop(ctx *gin.Context) {
 	)
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -908,7 +909,7 @@ func (h *ModelHandler) DeployStop(ctx *gin.Context) {
 	}
 	err = h.repo.DeployStop(ctx.Request.Context(), stopReq)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			slog.Info("not allowed to stop inference", slog.Any("error", err), slog.Any("req", stopReq))
 			httpbase.ForbiddenError(ctx, err)
 			return
@@ -942,7 +943,7 @@ func (h *ModelHandler) DeployStart(ctx *gin.Context) {
 	)
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -969,7 +970,7 @@ func (h *ModelHandler) DeployStart(ctx *gin.Context) {
 
 	err = h.repo.DeployStart(ctx.Request.Context(), startReq)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			slog.Info("not allowed to start inference", slog.Any("error", err), slog.Any("req", startReq))
 			httpbase.ForbiddenError(ctx, err)
 			return
@@ -1000,7 +1001,7 @@ func (h *ModelHandler) DeployStart(ctx *gin.Context) {
 func (h *ModelHandler) ListByRuntimeFrameworkID(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	deployTypeStr := ctx.Query("deploy_type")
@@ -1062,7 +1063,7 @@ func (h *ModelHandler) FinetuneStop(ctx *gin.Context) {
 	)
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -1087,7 +1088,7 @@ func (h *ModelHandler) FinetuneStop(ctx *gin.Context) {
 	}
 	err = h.repo.DeployStop(ctx.Request.Context(), stopReq)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			slog.Info("not allowed to stop finetune", slog.Any("req", stopReq), slog.Any("error", err))
 			httpbase.ForbiddenError(ctx, err)
 			return
@@ -1121,7 +1122,7 @@ func (h *ModelHandler) FinetuneStart(ctx *gin.Context) {
 	)
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -1146,7 +1147,7 @@ func (h *ModelHandler) FinetuneStart(ctx *gin.Context) {
 	}
 	err = h.repo.DeployStart(ctx.Request.Context(), startReq)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			slog.Info("not allowed to start finetune", slog.Any("error", err), slog.Any("req", startReq))
 			httpbase.ForbiddenError(ctx, err)
 			return
@@ -1173,7 +1174,7 @@ func (h *ModelHandler) FinetuneStart(ctx *gin.Context) {
 func (h *ModelHandler) ListAllRuntimeFramework(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -1215,7 +1216,7 @@ func (h *ModelHandler) UpdateModelRuntimeFrameworks(ctx *gin.Context) {
 
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -1242,7 +1243,7 @@ func (h *ModelHandler) UpdateModelRuntimeFrameworks(ctx *gin.Context) {
 
 	list, err := h.model.SetRuntimeFrameworkModes(ctx.Request.Context(), currentUser, deployType, id, req.Models)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -1279,7 +1280,7 @@ func (h *ModelHandler) DeleteModelRuntimeFrameworks(ctx *gin.Context) {
 
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -1306,7 +1307,7 @@ func (h *ModelHandler) DeleteModelRuntimeFrameworks(ctx *gin.Context) {
 
 	list, err := h.model.DeleteRuntimeFrameworkModes(ctx.Request.Context(), currentUser, deployType, id, req.Models)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -1339,7 +1340,7 @@ func (h *ModelHandler) ListModelsOfRuntimeFrameworks(ctx *gin.Context) {
 	filter := new(types.RepoFilter)
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	filter = getFilterFromContext(ctx, filter)
@@ -1401,7 +1402,7 @@ func (h *ModelHandler) AllFiles(ctx *gin.Context) {
 	req.CurrentUser = httpbase.GetCurrentUser(ctx)
 	detail, err := h.repo.AllFiles(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			slog.Info("not allowed to get model all files", slog.Any("error", err), slog.Any("req", req))
 			httpbase.ForbiddenError(ctx, err)
 			return
@@ -1431,7 +1432,7 @@ func (h *ModelHandler) AllFiles(ctx *gin.Context) {
 func (h *ModelHandler) DeployServerless(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -1465,7 +1466,7 @@ func (h *ModelHandler) DeployServerless(ctx *gin.Context) {
 	req.SecureLevel = 1 // public for serverless
 	deployID, err := h.model.Deploy(ctx.Request.Context(), deployReq, req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			slog.Info("not allowed to deploy model as serverless", slog.Any("error", err), slog.Any("deploy_req", deployReq))
 
 			httpbase.ForbiddenError(ctx, err)
@@ -1507,7 +1508,7 @@ func (h *ModelHandler) ServerlessStart(ctx *gin.Context) {
 	)
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -1534,7 +1535,7 @@ func (h *ModelHandler) ServerlessStart(ctx *gin.Context) {
 
 	err = h.repo.DeployStart(ctx.Request.Context(), startReq)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			slog.Info("not allowed to start model serverless deploy", slog.Any("error", err), slog.Any("req", startReq))
 
 			httpbase.ForbiddenError(ctx, err)
@@ -1569,7 +1570,7 @@ func (h *ModelHandler) ServerlessStop(ctx *gin.Context) {
 	)
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)

--- a/api/handler/multi_sync.go
+++ b/api/handler/multi_sync.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/component"
 )
@@ -39,7 +40,7 @@ func NewSyncHandler(config *config.Config) (*SyncHandler, error) {
 func (h *SyncHandler) Latest(c *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(c)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(c, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(c, errorx.ErrUserNotFound)
 		return
 	}
 

--- a/api/handler/prompt.go
+++ b/api/handler/prompt.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 	"opencsg.com/csghub-server/component"
@@ -126,7 +127,7 @@ func (h *PromptHandler) ListPrompt(ctx *gin.Context) {
 
 	detail, err := h.prompt.Show(ctx.Request.Context(), namespace, name, currentUser)
 	if err != nil {
-		if errors.Is(err, component.ErrUnauthorized) {
+		if errors.Is(err, errorx.ErrUnauthorized) {
 			httpbase.UnauthorizedError(ctx, err)
 			return
 		}
@@ -215,7 +216,7 @@ func (h *PromptHandler) GetPrompt(ctx *gin.Context) {
 func (h *PromptHandler) CreatePrompt(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -270,7 +271,7 @@ func (h *PromptHandler) CreatePrompt(ctx *gin.Context) {
 func (h *PromptHandler) UpdatePrompt(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -332,7 +333,7 @@ func (h *PromptHandler) UpdatePrompt(ctx *gin.Context) {
 func (h *PromptHandler) DeletePrompt(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -387,7 +388,7 @@ func (h *PromptHandler) Relations(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	detail, err := h.prompt.Relations(ctx.Request.Context(), namespace, name, currentUser)
 	if err != nil {
-		if errors.Is(err, component.ErrUnauthorized) {
+		if errors.Is(err, errorx.ErrUnauthorized) {
 			httpbase.UnauthorizedError(ctx, err)
 			return
 		}
@@ -416,7 +417,7 @@ func (h *PromptHandler) Relations(ctx *gin.Context) {
 func (h *PromptHandler) SetRelations(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -463,7 +464,7 @@ func (h *PromptHandler) SetRelations(ctx *gin.Context) {
 func (h *PromptHandler) AddModelRelation(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -510,7 +511,7 @@ func (h *PromptHandler) AddModelRelation(ctx *gin.Context) {
 func (h *PromptHandler) DelModelRelation(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -556,7 +557,7 @@ func (h *PromptHandler) DelModelRelation(ctx *gin.Context) {
 func (h *PromptHandler) Create(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req *types.CreatePromptRepoReq
@@ -604,7 +605,7 @@ func (h *PromptHandler) Create(ctx *gin.Context) {
 func (h *PromptHandler) Update(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req *types.UpdatePromptRepoReq
@@ -658,7 +659,7 @@ func (h *PromptHandler) Update(ctx *gin.Context) {
 func (h *PromptHandler) Delete(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -776,7 +777,7 @@ func (h *PromptHandler) Tags(ctx *gin.Context) {
 func (h *PromptHandler) UpdateTags(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)

--- a/api/handler/repo_test.go
+++ b/api/handler/repo_test.go
@@ -22,8 +22,8 @@ import (
 	"opencsg.com/csghub-server/builder/deploy"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/builder/testutil"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
-	"opencsg.com/csghub-server/component"
 )
 
 type RepoTester struct {
@@ -143,7 +143,7 @@ func TestRepoHandler_LastCommit(t *testing.T) {
 		})
 
 		//user does not have permission to access repo
-		tester.mocks.repo.EXPECT().LastCommit(mock.Anything, mock.Anything).Return(nil, component.ErrForbidden).Once()
+		tester.mocks.repo.EXPECT().LastCommit(mock.Anything, mock.Anything).Return(nil, errorx.ErrForbidden).Once()
 		tester.Execute()
 		require.Equal(t, http.StatusForbidden, tester.Response().Code)
 	})
@@ -353,7 +353,7 @@ func TestRepoHandler_Tree(t *testing.T) {
 			return rp.Tree
 		})
 		//user does not have permission to access repo
-		tester.mocks.repo.EXPECT().Tree(mock.Anything, mock.Anything).Return(nil, component.ErrForbidden).Once()
+		tester.mocks.repo.EXPECT().Tree(mock.Anything, mock.Anything).Return(nil, errorx.ErrForbidden).Once()
 		tester.Execute()
 		require.Equal(t, http.StatusForbidden, tester.Response().Code)
 	})

--- a/api/handler/space.go
+++ b/api/handler/space.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 	"opencsg.com/csghub-server/component"
@@ -128,7 +129,7 @@ func (h *SpaceHandler) Show(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	detail, err := h.space.Show(ctx.Request.Context(), namespace, name, currentUser, false)
 	if err != nil {
-		if errors.Is(err, component.ErrUnauthorized) {
+		if errors.Is(err, errorx.ErrUnauthorized) {
 			httpbase.UnauthorizedError(ctx, err)
 			return
 		}
@@ -156,7 +157,7 @@ func (h *SpaceHandler) Show(ctx *gin.Context) {
 func (h *SpaceHandler) Create(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.CreateSpaceReq
@@ -200,7 +201,7 @@ func (h *SpaceHandler) Create(ctx *gin.Context) {
 func (h *SpaceHandler) Update(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req *types.UpdateSpaceReq
@@ -254,7 +255,7 @@ func (h *SpaceHandler) Update(ctx *gin.Context) {
 func (h *SpaceHandler) Delete(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -289,7 +290,7 @@ func (h *SpaceHandler) Delete(ctx *gin.Context) {
 func (h *SpaceHandler) Run(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
@@ -367,7 +368,7 @@ func (h *SpaceHandler) Wakeup(ctx *gin.Context) {
 func (h *SpaceHandler) Stop(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)

--- a/api/handler/sshkey.go
+++ b/api/handler/sshkey.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 	"opencsg.com/csghub-server/component"
@@ -61,7 +62,7 @@ func (h *SSHKeyHandler) Create(ctx *gin.Context) {
 	}
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 

--- a/api/handler/sync_client_setting.go
+++ b/api/handler/sync_client_setting.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/component"
 )
@@ -46,12 +47,12 @@ func (h *SyncClientSettingHandler) Create(ctx *gin.Context) {
 	}
 	req.CurrentUser = httpbase.GetCurrentUser(ctx)
 	if req.CurrentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	ms, err := h.c.Create(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, component.ErrUnauthorized) {
+		if errors.Is(err, errorx.ErrUnauthorized) {
 			httpbase.UnauthorizedError(ctx, err)
 			return
 		}
@@ -76,12 +77,12 @@ func (h *SyncClientSettingHandler) Create(ctx *gin.Context) {
 func (h *SyncClientSettingHandler) Show(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	ms, err := h.c.Show(ctx.Request.Context(), currentUser)
 	if err != nil {
-		if errors.Is(err, component.ErrUnauthorized) {
+		if errors.Is(err, errorx.ErrUnauthorized) {
 			httpbase.UnauthorizedError(ctx, err)
 			return
 		}

--- a/api/handler/tag.go
+++ b/api/handler/tag.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/component"
 )
@@ -72,7 +73,7 @@ func (t *TagsHandler) AllTags(ctx *gin.Context) {
 func (t *TagsHandler) CreateTag(ctx *gin.Context) {
 	userName := httpbase.GetCurrentUser(ctx)
 	if userName == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.CreateTag
@@ -105,7 +106,7 @@ func (t *TagsHandler) CreateTag(ctx *gin.Context) {
 func (t *TagsHandler) GetTagByID(ctx *gin.Context) {
 	userName := httpbase.GetCurrentUser(ctx)
 	if userName == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	id, err := strconv.ParseInt(ctx.Param("id"), 10, 64)
@@ -139,7 +140,7 @@ func (t *TagsHandler) GetTagByID(ctx *gin.Context) {
 func (t *TagsHandler) UpdateTag(ctx *gin.Context) {
 	userName := httpbase.GetCurrentUser(ctx)
 	if userName == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	id, err := strconv.ParseInt(ctx.Param("id"), 10, 64)
@@ -178,7 +179,7 @@ func (t *TagsHandler) UpdateTag(ctx *gin.Context) {
 func (t *TagsHandler) DeleteTag(ctx *gin.Context) {
 	userName := httpbase.GetCurrentUser(ctx)
 	if userName == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	id, err := strconv.ParseInt(ctx.Param("id"), 10, 64)
@@ -235,7 +236,7 @@ func (t *TagsHandler) AllCategories(ctx *gin.Context) {
 func (t *TagsHandler) CreateCategory(ctx *gin.Context) {
 	userName := httpbase.GetCurrentUser(ctx)
 	if userName == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.CreateCategory
@@ -246,7 +247,7 @@ func (t *TagsHandler) CreateCategory(ctx *gin.Context) {
 	}
 	category, err := t.tag.CreateCategory(ctx.Request.Context(), userName, req)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -272,7 +273,7 @@ func (t *TagsHandler) CreateCategory(ctx *gin.Context) {
 func (t *TagsHandler) UpdateCategory(ctx *gin.Context) {
 	userName := httpbase.GetCurrentUser(ctx)
 	if userName == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.UpdateCategory
@@ -289,7 +290,7 @@ func (t *TagsHandler) UpdateCategory(ctx *gin.Context) {
 	}
 	category, err := t.tag.UpdateCategory(ctx.Request.Context(), userName, req, id)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}
@@ -314,7 +315,7 @@ func (t *TagsHandler) UpdateCategory(ctx *gin.Context) {
 func (t *TagsHandler) DeleteCategory(ctx *gin.Context) {
 	userName := httpbase.GetCurrentUser(ctx)
 	if userName == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	id, err := strconv.ParseInt(ctx.Param("id"), 10, 64)
@@ -325,7 +326,7 @@ func (t *TagsHandler) DeleteCategory(ctx *gin.Context) {
 	}
 	err = t.tag.DeleteCategory(ctx.Request.Context(), userName, id)
 	if err != nil {
-		if errors.Is(err, component.ErrForbidden) {
+		if errors.Is(err, errorx.ErrForbidden) {
 			httpbase.ForbiddenError(ctx, err)
 			return
 		}

--- a/api/handler/user.go
+++ b/api/handler/user.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 	"opencsg.com/csghub-server/component"
@@ -209,7 +210,7 @@ func (h *UserHandler) Spaces(ctx *gin.Context) {
 func (h *UserHandler) LikesAdd(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.UserLikesRequest
@@ -243,7 +244,7 @@ func (h *UserHandler) LikesAdd(ctx *gin.Context) {
 func (h *UserHandler) LikesCollections(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.UserCollectionReq
@@ -327,7 +328,7 @@ func (h *UserHandler) UserCollections(ctx *gin.Context) {
 func (h *UserHandler) LikeCollection(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.UserLikesRequest
@@ -361,7 +362,7 @@ func (h *UserHandler) LikeCollection(ctx *gin.Context) {
 func (h *UserHandler) UnLikeCollection(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.UserLikesRequest
@@ -396,7 +397,7 @@ func (h *UserHandler) UnLikeCollection(ctx *gin.Context) {
 func (h *UserHandler) LikesDelete(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.UserLikesRequest
@@ -431,7 +432,7 @@ func (h *UserHandler) LikesDelete(ctx *gin.Context) {
 func (h *UserHandler) LikesSpaces(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.UserCollectionReq
@@ -478,7 +479,7 @@ func (h *UserHandler) LikesSpaces(ctx *gin.Context) {
 func (h *UserHandler) LikesCodes(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.UserDatasetsReq
@@ -525,7 +526,7 @@ func (h *UserHandler) LikesCodes(ctx *gin.Context) {
 func (h *UserHandler) LikesModels(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.UserDatasetsReq
@@ -572,7 +573,7 @@ func (h *UserHandler) LikesModels(ctx *gin.Context) {
 func (h *UserHandler) LikesDatasets(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.UserDatasetsReq
@@ -606,7 +607,7 @@ func (h *UserHandler) LikesDatasets(ctx *gin.Context) {
 func (h *UserHandler) UserPermission(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	response := types.WhoamiResponse{
@@ -642,7 +643,7 @@ func (h *UserHandler) UserPermission(ctx *gin.Context) {
 func (h *UserHandler) GetRunDeploys(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -776,7 +777,7 @@ func (h *UserHandler) GetFinetuneInstances(ctx *gin.Context) {
 func (h *UserHandler) GetRunServerless(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 
@@ -952,7 +953,7 @@ func (h *UserHandler) MCPServers(ctx *gin.Context) {
 func (h *UserHandler) LikesMCPServers(ctx *gin.Context) {
 	currentUser := httpbase.GetCurrentUser(ctx)
 	if currentUser == "" {
-		httpbase.UnauthorizedError(ctx, component.ErrUserNotFound)
+		httpbase.UnauthorizedError(ctx, errorx.ErrUserNotFound)
 		return
 	}
 	var req types.UserMCPsReq

--- a/builder/testutil/gintester.go
+++ b/builder/testutil/gintester.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/require"
 	"opencsg.com/csghub-server/api/httpbase"
-	"opencsg.com/csghub-server/component"
+	"opencsg.com/csghub-server/common/errorx"
 )
 
 type GinTester struct {
@@ -148,7 +148,7 @@ func (g *GinTester) RequireUser(t *testing.T) {
 	tmp.gctx.Params = g.gctx.Params
 	g.ginHandler(tmp.gctx)
 	tmp._executed = true
-	tmp.ResponseEq(t, http.StatusUnauthorized, component.ErrUserNotFound.Error(), nil)
+	tmp.ResponseEq(t, http.StatusUnauthorized, errorx.ErrUserNotFound.Error(), nil)
 	// add user to original test ctx now
 	_ = g.WithUser()
 

--- a/common/errorx/errorx.go
+++ b/common/errorx/errorx.go
@@ -1,4 +1,4 @@
-package component
+package errorx
 
 import (
 	"errors"
@@ -10,10 +10,12 @@ var (
 	ErrUnauthorized = errors.New("unauthorized")
 	ErrNotFound     = errors.New("not found")
 	// not enough permission for current user
-	ErrForbidden        = errors.New("forbidden")
-	ErrUserNotFound     = errors.New("user not found, please login first")
-	ErrAlreadyExists    = errors.New("the record already exists")
-	ErrPermissionDenied = errors.New("permission denied")
+	ErrForbidden             = errors.New("forbidden")
+	ErrUserNotFound          = errors.New("user not found, please login first")
+	ErrAlreadyExists         = errors.New("the record already exists")
+	ErrPermissionDenied      = errors.New("permission denied")
+	ErrContentLengthTooLarge = errors.New("content length too large")
+	ErrBadRequest            = errors.New("bad request")
 )
 
 // ErrForbiddenMsg returns a new ErrForbidden with extra message

--- a/component/code.go
+++ b/component/code.go
@@ -11,6 +11,7 @@ import (
 	"opencsg.com/csghub-server/builder/rpc"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 )
@@ -297,7 +298,7 @@ func (c *codeComponentImpl) Show(ctx context.Context, namespace, name, currentUs
 		return nil, fmt.Errorf("failed to get user repo permission, error: %w", err)
 	}
 	if !permission.CanRead {
-		return nil, ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 
 	ns, err := c.repoComponent.GetNameSpaceInfo(ctx, namespace)
@@ -367,7 +368,7 @@ func (c *codeComponentImpl) Relations(ctx context.Context, namespace, name, curr
 
 	allow, _ := c.repoComponent.AllowReadAccessRepo(ctx, code.Repository, currentUser)
 	if !allow {
-		return nil, ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 
 	return c.getRelations(ctx, code.RepositoryID, currentUser)

--- a/component/collection.go
+++ b/component/collection.go
@@ -13,6 +13,7 @@ import (
 	"opencsg.com/csghub-server/builder/rpc"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 )
 
@@ -122,7 +123,7 @@ func (cc *collectionComponentImpl) GetCollection(ctx context.Context, currentUse
 	}
 
 	if !permission.CanRead {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 
 	var newCollection types.Collection

--- a/component/dataset.go
+++ b/component/dataset.go
@@ -13,6 +13,7 @@ import (
 	"opencsg.com/csghub-server/builder/rpc"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 )
@@ -365,7 +366,7 @@ func (c *datasetComponentImpl) Show(ctx context.Context, namespace, name, curren
 		return nil, fmt.Errorf("failed to get user repo permission, error: %w", err)
 	}
 	if !permission.CanRead {
-		return nil, ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 
 	ns, err := c.repoComponent.GetNameSpaceInfo(ctx, namespace)
@@ -442,7 +443,7 @@ func (c *datasetComponentImpl) Relations(ctx context.Context, namespace, name, c
 
 	allow, _ := c.repoComponent.AllowReadAccessRepo(ctx, dataset.Repository, currentUser)
 	if !allow {
-		return nil, ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 
 	return c.getRelations(ctx, dataset.RepositoryID, currentUser)

--- a/component/git_http_test.go
+++ b/component/git_http_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"opencsg.com/csghub-server/builder/git/gitserver"
 	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 )
 
@@ -164,14 +165,14 @@ func TestGitHTTPComponent_Batch(t *testing.T) {
 			name:      "download no read access, no write access",
 			operation: types.LFSBatchDownload,
 			exist:     true,
-			err:       ErrNotFound,
+			err:       errorx.ErrNotFound,
 		},
 		{
 			name:           "download no read access, has write access",
 			operation:      types.LFSBatchDownload,
 			exist:          true,
 			hasWriteAccess: true,
-			err:            ErrNotFound,
+			err:            errorx.ErrNotFound,
 		},
 		{
 			name:          "download file not exist",
@@ -216,13 +217,13 @@ func TestGitHTTPComponent_Batch(t *testing.T) {
 		{
 			name:      "upload no read access, no write access",
 			operation: types.LFSBatchUpload,
-			err:       ErrNotFound,
+			err:       errorx.ErrNotFound,
 		},
 		{
 			name:          "upload has read access, no write access",
 			operation:     types.LFSBatchUpload,
 			hasReadAccess: true,
-			err:           ErrForbidden,
+			err:           errorx.ErrForbidden,
 		},
 		// {
 		// 	name:           "upload file exist",
@@ -241,21 +242,21 @@ func TestGitHTTPComponent_Batch(t *testing.T) {
 		{
 			name:      "upload and current user empty, 401",
 			operation: types.LFSBatchUpload,
-			err:       ErrUnauthorized,
+			err:       errorx.ErrUnauthorized,
 			noUser:    true,
 		},
 		{
 			name:          "download and current user empty, 401",
 			operation:     types.LFSBatchDownload,
-			err:           ErrUnauthorized,
-			readAccessErr: ErrUserNotFound,
+			err:           errorx.ErrUnauthorized,
+			readAccessErr: errorx.ErrUserNotFound,
 			noUser:        true,
 		},
 		{
 			name:          "download and user not found",
 			operation:     types.LFSBatchDownload,
-			err:           ErrUserNotFound,
-			readAccessErr: ErrUserNotFound,
+			err:           errorx.ErrUserNotFound,
+			readAccessErr: errorx.ErrUserNotFound,
 		},
 	}
 

--- a/component/hf_dataset.go
+++ b/component/hf_dataset.go
@@ -10,6 +10,7 @@ import (
 	"opencsg.com/csghub-server/builder/git/gitserver"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 )
 
@@ -59,7 +60,7 @@ func (h *hFDatasetComponentImpl) GetPathsInfo(ctx context.Context, req types.Pat
 		return nil, fmt.Errorf("failed to check dataset permission, error: %w", err)
 	}
 	if !allow {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 
 	getRepoFileTree := gitserver.GetRepoInfoByPathReq{
@@ -98,7 +99,7 @@ func (h *hFDatasetComponentImpl) GetDatasetTree(ctx context.Context, req types.P
 		return nil, fmt.Errorf("failed to check dataset permission, error: %w", err)
 	}
 	if !allow {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 
 	var treeFiles []types.HFDSPathInfo

--- a/component/internal.go
+++ b/component/internal.go
@@ -14,6 +14,7 @@ import (
 	"opencsg.com/csghub-server/builder/git/gitserver/gitaly"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 )
@@ -86,19 +87,19 @@ func (c *internalComponentImpl) SSHAllowed(ctx context.Context, req types.SSHAll
 	if req.Action == "git-receive-pack" {
 		allowed, err := c.repoComponent.AllowWriteAccess(ctx, req.RepoType, req.Namespace, req.Name, sshKey.User.Username)
 		if err != nil {
-			return nil, ErrUnauthorized
+			return nil, errorx.ErrUnauthorized
 		}
 		if !allowed {
-			return nil, ErrForbidden
+			return nil, errorx.ErrForbidden
 		}
 	} else if req.Action == "git-upload-pack" {
 		if repo.Private {
 			allowed, err := c.repoComponent.AllowReadAccess(ctx, req.RepoType, req.Namespace, req.Name, sshKey.User.Username)
 			if err != nil {
-				return nil, ErrUnauthorized
+				return nil, errorx.ErrUnauthorized
 			}
 			if !allowed {
-				return nil, ErrForbidden
+				return nil, errorx.ErrForbidden
 			}
 		}
 	}
@@ -181,10 +182,10 @@ func (c *internalComponentImpl) LfsAuthenticate(ctx context.Context, req types.L
 	if repo.Private {
 		allowed, err := c.repoComponent.AllowReadAccess(ctx, req.RepoType, req.Namespace, req.Name, sshKey.User.Username)
 		if err != nil {
-			return nil, ErrUnauthorized
+			return nil, errorx.ErrUnauthorized
 		}
 		if !allowed {
-			return nil, ErrForbidden
+			return nil, errorx.ErrForbidden
 		}
 	}
 	token, err := c.tokenStore.GetUserGitToken(ctx, sshKey.User.Username)

--- a/component/mcp_server.go
+++ b/component/mcp_server.go
@@ -21,6 +21,7 @@ import (
 	"opencsg.com/csghub-server/builder/rpc"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 )
@@ -201,7 +202,7 @@ func (m *mcpServerComponentImpl) Delete(ctx context.Context, req *types.UpdateMC
 	}
 
 	if !permission.CanAdmin {
-		return ErrForbidden
+		return errorx.ErrForbidden
 	}
 
 	deleteRepoReq := types.DeleteRepoReq{
@@ -234,7 +235,7 @@ func (m *mcpServerComponentImpl) Update(ctx context.Context, req *types.UpdateMC
 		return nil, fmt.Errorf("failed to get user %s permission for repo %s/%s, error: %w", req.Namespace, req.Namespace, req.Name, err)
 	}
 	if !permission.CanAdmin {
-		return nil, ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 
 	req.RepoType = types.MCPServerRepo
@@ -308,7 +309,7 @@ func (m *mcpServerComponentImpl) Show(ctx context.Context, namespace string, nam
 		return nil, fmt.Errorf("failed to get user %s permission for repo %s/%s, error: %w", currentUser, namespace, name, err)
 	}
 	if !permission.CanRead {
-		return nil, ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 
 	ns, err := m.repoComponent.GetNameSpaceInfo(ctx, namespace)
@@ -613,7 +614,7 @@ func (m *mcpServerComponentImpl) Deploy(ctx context.Context, req *types.DeployMC
 			req.CurrentUser, req.MCPRepo.Namespace, req.MCPRepo.Name, err)
 	}
 	if !permission.CanRead {
-		return nil, ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 
 	token, err := m.tokenStore.GetUserGitToken(ctx, req.CurrentUser)
@@ -659,11 +660,11 @@ func (m *mcpServerComponentImpl) Deploy(ctx context.Context, req *types.DeployMC
 				return nil, fmt.Errorf("failed to check user %s permission for namespace %s, error: %w", req.CurrentUser, req.Namespace, err)
 			}
 			if !canWrite {
-				return nil, ErrForbiddenMsg("users do not have permission to create repo in this organization")
+				return nil, errorx.ErrForbiddenMsg("users do not have permission to create repo in this organization")
 			}
 		} else {
 			if namespace.Path != user.Username {
-				return nil, ErrForbiddenMsg("users do not have permission to create repo in this namespace")
+				return nil, errorx.ErrForbiddenMsg("users do not have permission to create repo in this namespace")
 			}
 		}
 	}

--- a/component/model.go
+++ b/component/model.go
@@ -18,6 +18,7 @@ import (
 	"opencsg.com/csghub-server/builder/rpc"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 )
@@ -420,7 +421,7 @@ func (c *modelComponentImpl) Show(ctx context.Context, namespace, name, currentU
 		return nil, fmt.Errorf("failed to get user repo permission, error: %w", err)
 	}
 	if !permission.CanRead {
-		return nil, ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 
 	ns, err := c.repoComponent.GetNameSpaceInfo(ctx, namespace)
@@ -522,7 +523,7 @@ func (c *modelComponentImpl) GetServerless(ctx context.Context, namespace, name,
 	}
 	allow, _ := c.repoComponent.AllowReadAccessRepo(ctx, model.Repository, currentUser)
 	if !allow {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 	deploy, err := c.deployTaskStore.GetServerlessDeployByRepID(ctx, model.Repository.ID)
 	if err != nil {
@@ -574,7 +575,7 @@ func (c *modelComponentImpl) SDKModelInfo(ctx context.Context, namespace, name, 
 
 	allow, _ := c.repoComponent.AllowReadAccessRepo(ctx, model.Repository, currentUser)
 	if !allow {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 
 	var pipelineTag, libraryTag, sha string
@@ -681,7 +682,7 @@ func (c *modelComponentImpl) Relations(ctx context.Context, namespace, name, cur
 
 	allow, _ := c.repoComponent.AllowReadAccessRepo(ctx, model.Repository, currentUser)
 	if !allow {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 
 	return c.getRelations(ctx, model.RepositoryID, currentUser)
@@ -969,7 +970,7 @@ func (c *modelComponentImpl) Deploy(ctx context.Context, deployReq types.DeployA
 		// Check if the user is an admin
 		isAdmin := c.repoComponent.IsAdminRole(user)
 		if !isAdmin {
-			return -1, ErrForbiddenMsg("need admin permission for Serverless deploy")
+			return -1, errorx.ErrForbiddenMsg("need admin permission for Serverless deploy")
 		}
 	}
 
@@ -1132,7 +1133,7 @@ func (c *modelComponentImpl) SetRuntimeFrameworkModes(ctx context.Context, curre
 	}
 	isAdmin := c.repoComponent.IsAdminRole(user)
 	if !isAdmin {
-		return nil, ErrForbiddenMsg("need admin permission for runtime framework")
+		return nil, errorx.ErrForbiddenMsg("need admin permission for runtime framework")
 	}
 	runtimeRepos, err := c.runtimeFrameworksStore.FindByID(ctx, id)
 	if err != nil {
@@ -1188,7 +1189,7 @@ func (c *modelComponentImpl) DeleteRuntimeFrameworkModes(ctx context.Context, cu
 	}
 	isAdmin := c.repoComponent.IsAdminRole(user)
 	if !isAdmin {
-		return nil, ErrForbiddenMsg("need admin permission for runtime framework")
+		return nil, errorx.ErrForbiddenMsg("need admin permission for runtime framework")
 	}
 	models, err := c.modelStore.ListByPath(ctx, paths)
 	if err != nil {

--- a/component/prompt.go
+++ b/component/prompt.go
@@ -18,6 +18,7 @@ import (
 	"opencsg.com/csghub-server/builder/rpc"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 )
@@ -115,7 +116,7 @@ func (c *promptComponentImpl) ListPrompt(ctx context.Context, req types.PromptRe
 		return nil, fmt.Errorf("failed to check prompt set permission, error: %w", err)
 	}
 	if !allow {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 
 	slog.Debug("ListPrompt get repo file tree begin")
@@ -186,7 +187,7 @@ func (c *promptComponentImpl) GetPrompt(ctx context.Context, req types.PromptReq
 		return nil, fmt.Errorf("failed to get user repo permission, error: %w", err)
 	}
 	if !permission.CanRead {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 
 	getFileContentReq := gitserver.GetRepoInfoByPathReq{
@@ -872,7 +873,7 @@ func (c *promptComponentImpl) Show(ctx context.Context, namespace, name, current
 		return nil, fmt.Errorf("failed to get user repo permission, error: %w", err)
 	}
 	if !permission.CanRead {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 
 	ns, err := c.repoComponent.GetNameSpaceInfo(ctx, namespace)
@@ -940,7 +941,7 @@ func (c *promptComponentImpl) Relations(ctx context.Context, namespace, name, cu
 
 	allow, _ := c.repoComponent.AllowReadAccessRepo(ctx, prompt.Repository, currentUser)
 	if !allow {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 
 	return c.getRelations(ctx, prompt.RepositoryID, currentUser)

--- a/component/repo_test.go
+++ b/component/repo_test.go
@@ -21,6 +21,7 @@ import (
 	"opencsg.com/csghub-server/builder/git/mirrorserver"
 	"opencsg.com/csghub-server/builder/rpc"
 	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/tests"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/mirror/queue"
@@ -540,7 +541,7 @@ func TestRepoComponent_Commits(t *testing.T) {
 				CurrentUser: user,
 			})
 			if user == "" {
-				require.Equal(t, ErrUnauthorized, err)
+				require.Equal(t, errorx.ErrUnauthorized, err)
 				return
 			}
 			require.Nil(t, err)
@@ -588,7 +589,7 @@ func TestRepoComponent_FileRaw(t *testing.T) {
 					Path:        c.path,
 					CurrentUser: currentUser,
 				})
-				require.True(t, errors.Is(err, ErrForbidden))
+				require.True(t, errors.Is(err, errorx.ErrForbidden))
 				return
 			}
 
@@ -1731,7 +1732,7 @@ func TestRepoComponent_LastCommit(t *testing.T) {
 
 		actualCommit, err := repoComp.LastCommit(context.Background(), &types.GetCommitsReq{})
 		require.Nil(t, actualCommit)
-		require.ErrorIs(t, err, ErrForbidden)
+		require.ErrorIs(t, err, errorx.ErrForbidden)
 
 	})
 }
@@ -1785,7 +1786,7 @@ func TestRepoComponent_Tree(t *testing.T) {
 
 			actualTree, err := repoComp.Tree(context.Background(), &types.GetFileReq{})
 			require.Nil(t, actualTree)
-			require.ErrorIs(t, err, ErrForbidden)
+			require.ErrorIs(t, err, errorx.ErrForbidden)
 
 		})
 	}
@@ -1814,7 +1815,7 @@ func TestRepoComponent_AllowWriteAccess(t *testing.T) {
 			Private: false,
 		}, nil)
 		allow, err := repoComp.AllowWriteAccess(ctx, types.ModelRepo, "namespace", "name", "")
-		require.Error(t, err, ErrUserNotFound)
+		require.Error(t, err, errorx.ErrUserNotFound)
 		require.False(t, allow)
 	})
 
@@ -1864,7 +1865,7 @@ func TestRepoComponent_AllowAdminAccess(t *testing.T) {
 			Private: false,
 		}, nil)
 		allow, err := repoComp.AllowAdminAccess(ctx, types.ModelRepo, "namespace", "name", "")
-		require.Error(t, err, ErrUserNotFound)
+		require.Error(t, err, errorx.ErrUserNotFound)
 		require.False(t, allow)
 	})
 
@@ -1928,7 +1929,7 @@ func TestRepoComponent_AllowReadAccessRepo(t *testing.T) {
 			Path:    "namespace/name",
 			Private: true,
 		}, "")
-		require.Error(t, err, ErrUserNotFound)
+		require.Error(t, err, errorx.ErrUserNotFound)
 		require.False(t, allow)
 	})
 }
@@ -1985,7 +1986,7 @@ func TestRepoComponent_TreeV2(t *testing.T) {
 
 			actualTree, err := repoComp.TreeV2(context.Background(), &types.GetTreeRequest{})
 			require.Nil(t, actualTree)
-			require.ErrorIs(t, err, ErrForbidden)
+			require.ErrorIs(t, err, errorx.ErrForbidden)
 
 		})
 	}
@@ -2098,7 +2099,7 @@ func TestRepoComponent_LogsTree(t *testing.T) {
 
 			actualTree, err := repoComp.LogsTree(context.Background(), &types.GetLogsTreeRequest{})
 			require.Nil(t, actualTree)
-			require.ErrorIs(t, err, ErrForbidden)
+			require.ErrorIs(t, err, errorx.ErrForbidden)
 
 		})
 	}

--- a/component/space.go
+++ b/component/space.go
@@ -17,6 +17,7 @@ import (
 	"opencsg.com/csghub-server/builder/git/gitserver"
 	"opencsg.com/csghub-server/builder/git/membership"
 	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 )
@@ -411,7 +412,7 @@ func (c *spaceComponentImpl) Show(ctx context.Context, namespace, name, currentU
 		return nil, fmt.Errorf("failed to get user %s repo permission, error: %w", currentUser, err)
 	}
 	if !permission.CanRead {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 
 	ns, err := c.repoComponent.GetNameSpaceInfo(ctx, namespace)
@@ -777,7 +778,7 @@ func (c *spaceComponentImpl) ListByPath(ctx context.Context, paths []string) ([]
 
 func (c *spaceComponentImpl) AllowCallApi(ctx context.Context, spaceID int64, username string) (bool, error) {
 	if username == "" {
-		return false, ErrUserNotFound
+		return false, errorx.ErrUserNotFound
 	}
 	s, err := c.spaceStore.ByID(ctx, spaceID)
 	if err != nil {

--- a/component/sync_client_setting.go
+++ b/component/sync_client_setting.go
@@ -8,6 +8,7 @@ import (
 
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 )
 
@@ -31,7 +32,7 @@ func NewSyncClientSettingComponent(config *config.Config) (SyncClientSettingComp
 func (c *syncClientSettingComponentImpl) Create(ctx context.Context, req types.CreateSyncClientSettingReq) (*database.SyncClientSetting, error) {
 	user, err := c.userStore.FindByUsername(ctx, req.CurrentUser)
 	if err != nil {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 	if !user.CanAdmin() {
 		return nil, fmt.Errorf("only admin was allowed create sync client setting")
@@ -60,7 +61,7 @@ func (c *syncClientSettingComponentImpl) Create(ctx context.Context, req types.C
 func (c *syncClientSettingComponentImpl) Show(ctx context.Context, currentUser string) (*database.SyncClientSetting, error) {
 	user, err := c.userStore.FindByUsername(ctx, currentUser)
 	if err != nil {
-		return nil, ErrUnauthorized
+		return nil, errorx.ErrUnauthorized
 	}
 	if !user.CanAdmin() {
 		return nil, fmt.Errorf("only admin was allowed get sync client setting")

--- a/component/tag.go
+++ b/component/tag.go
@@ -10,6 +10,7 @@ import (
 	"opencsg.com/csghub-server/builder/sensitive"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/component/tagparser"
 )
@@ -336,7 +337,7 @@ func (c *tagComponentImpl) CreateCategory(ctx context.Context, username string, 
 		return nil, fmt.Errorf("failed to get user, error: %w", err)
 	}
 	if !user.CanAdmin() {
-		return nil, ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 
 	newCategory := database.TagCategory{
@@ -360,7 +361,7 @@ func (c *tagComponentImpl) UpdateCategory(ctx context.Context, username string, 
 		return nil, fmt.Errorf("failed to get user, error: %w", err)
 	}
 	if !user.CanAdmin() {
-		return nil, ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 
 	newCategory := database.TagCategory{
@@ -385,7 +386,7 @@ func (c *tagComponentImpl) DeleteCategory(ctx context.Context, username string, 
 		return fmt.Errorf("failed to get user, error: %w", err)
 	}
 	if !user.CanAdmin() {
-		return ErrForbidden
+		return errorx.ErrForbidden
 	}
 
 	err = c.tagStore.DeleteCategory(ctx, id)

--- a/dataviewer/component/dataset_viewer.go
+++ b/dataviewer/component/dataset_viewer.go
@@ -18,6 +18,7 @@ import (
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/builder/store/s3"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 	hubCom "opencsg.com/csghub-server/component"
@@ -102,7 +103,7 @@ func (c *datasetViewerComponentImpl) ViewParquetFile(ctx context.Context, req *d
 		return nil, fmt.Errorf("failed to check dataset permission, error: %w", err)
 	}
 	if !allow {
-		return nil, hubCom.ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 	req.Branch = r.DefaultBranch
 	objName, err := c.getParquetObject(ctx, req)
@@ -185,7 +186,7 @@ func (c *datasetViewerComponentImpl) LimitOffsetRows(ctx context.Context, req *d
 		return nil, fmt.Errorf("failed to check dataset permission, error: %w", err)
 	}
 	if !allow {
-		return nil, hubCom.ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 	req.Branch = r.DefaultBranch
 	req.RepoID = r.ID
@@ -245,7 +246,7 @@ func (c *datasetViewerComponentImpl) Rows(ctx context.Context, req *dvCom.ViewPa
 		return nil, fmt.Errorf("failed to check dataset permission, error: %w", err)
 	}
 	if !allow {
-		return nil, hubCom.ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 	req.Branch = r.DefaultBranch
 	req.RepoID = r.ID
@@ -343,7 +344,7 @@ func (c *datasetViewerComponentImpl) GetCatalog(ctx context.Context, req *dvCom.
 		return nil, fmt.Errorf("failed to check dataset permission, error: %w", err)
 	}
 	if !allow {
-		return nil, hubCom.ErrForbidden
+		return nil, errorx.ErrForbidden
 	}
 	req.Branch = r.DefaultBranch
 	req.RepoID = r.ID


### PR DESCRIPTION
This feature moves the error handling logic from component/errors.go into a shared package located at common/errorx/errorx.go. This change allows multiple components and modules across the codebase to reuse standardized error definitions and utilities, reducing duplication and improving maintainability.