### PR TITLE
Add error handling for invalid Parquet files

### DIFF
--- a/common/errorx/error_dataset.go
+++ b/common/errorx/error_dataset.go
@@ -5,11 +5,13 @@ const errDataSetPrefix = "DAT-ERR"
 const (
 	dataviewerCardNotFound = iota
 	datasetBadFormat
+	noValidParquetFile
 )
 
 var (
 	ErrDataviewerCardNotFound = CustomError{prefix: errDataSetPrefix, code: dataviewerCardNotFound}
 	ErrDatasetBadFormat       = CustomError{prefix: errDataSetPrefix, code: datasetBadFormat}
+	ErrNoValidParquetFile     = CustomError{prefix: errDataSetPrefix, code: noValidParquetFile}
 )
 
 func DataviewerCardNotFound(err error, ctx context) error {
@@ -28,6 +30,16 @@ func DatasetBadFormat(err error, ctx context) error {
 		context: ctx,
 		err:     err,
 		code:    int(datasetBadFormat),
+	}
+	return customErr
+}
+
+func NoValidParquetFile(err error, ctx context) error {
+	customErr := CustomError{
+		prefix:  errDataSetPrefix,
+		context: ctx,
+		err:     err,
+		code:    int(noValidParquetFile),
 	}
 	return customErr
 }

--- a/common/errorx/error_dataset.go
+++ b/common/errorx/error_dataset.go
@@ -1,0 +1,33 @@
+package errorx
+
+const errDataSetPrefix = "DAT-ERR"
+
+const (
+	dataviewerCardNotFound = iota
+	datasetBadFormat
+)
+
+var (
+	ErrDataviewerCardNotFound = CustomError{prefix: errDataSetPrefix, code: dataviewerCardNotFound}
+	ErrDatasetBadFormat       = CustomError{prefix: errDataSetPrefix, code: datasetBadFormat}
+)
+
+func DataviewerCardNotFound(err error, ctx context) error {
+	customErr := CustomError{
+		prefix:  errDataSetPrefix,
+		context: ctx,
+		err:     err,
+		code:    int(dataviewerCardNotFound),
+	}
+	return customErr
+}
+
+func DatasetBadFormat(err error, ctx context) error {
+	customErr := CustomError{
+		prefix:  errDataSetPrefix,
+		context: ctx,
+		err:     err,
+		code:    int(datasetBadFormat),
+	}
+	return customErr
+}

--- a/common/errorx/error_git.go
+++ b/common/errorx/error_git.go
@@ -126,3 +126,12 @@ func DeleteBranchFailed(err error, ctx context) error {
 		context: ctx,
 	}
 }
+
+func GitFileNotFound(err error, ctx context) error {
+	return CustomError{
+		prefix:  errGitPrefix,
+		code:    gitFileNotFound,
+		err:     err,
+		context: ctx,
+	}
+}

--- a/common/errorx/error_system.go
+++ b/common/errorx/error_system.go
@@ -19,6 +19,8 @@ const (
 	// Replace sql.ErrNoRows
 	databaseNoRows
 	databaseDuplicateKey
+
+	lfsNotFound
 )
 
 var (
@@ -34,6 +36,8 @@ var (
 	// Convert it to specific error in component or handler
 	ErrDatabaseNoRows       = CustomError{prefix: errSysPrefix, code: databaseNoRows}
 	ErrDatabaseDuplicateKey = CustomError{prefix: errSysPrefix, code: databaseDuplicateKey}
+
+	ErrLFSNotFound = CustomError{prefix: errSysPrefix, code: lfsNotFound}
 )
 
 // Used in DB to convert db error to custom error
@@ -82,6 +86,19 @@ func RemoteSvcFail(err error, ctx context) error {
 		prefix:  errSysPrefix,
 		context: ctx,
 		code:    int(remoteServiceFail),
+		err:     err,
+	}
+	return customErr
+}
+
+func LFSNotFound(err error, ctx context) error {
+	if err == nil {
+		return nil
+	}
+	customErr := CustomError{
+		prefix:  errSysPrefix,
+		context: ctx,
+		code:    int(lfsNotFound),
 		err:     err,
 	}
 	return customErr

--- a/common/i18n/en-US/err_dataset.json
+++ b/common/i18n/en-US/err_dataset.json
@@ -1,11 +1,11 @@
 {
-    "errors.DAT-ERR-0": {
+    "error.DAT-ERR-0": {
         "other": "Dataviewer card not found"
     },
-    "errors.DAT-ERR-1": {
+    "error.DAT-ERR-1": {
         "other": "Dataset format error"
     },
-    "errors.DAT-ERR-2": {
+    "error.DAT-ERR-2": {
         "other": "No valid Parquet file"
     }
 }

--- a/common/i18n/en-US/err_dataset.json
+++ b/common/i18n/en-US/err_dataset.json
@@ -1,0 +1,11 @@
+{
+    "errors.DAT-ERR-0": {
+        "other": "Dataviewer card not found"
+    },
+    "errors.DAT-ERR-1": {
+        "other": "Dataset format error"
+    },
+    "errors.DAT-ERR-2": {
+        "other": "No valid Parquet file"
+    }
+}

--- a/common/i18n/zh-CN/err_dataset.json
+++ b/common/i18n/zh-CN/err_dataset.json
@@ -1,0 +1,11 @@
+{
+    "errors.DAT-ERR-0": {
+        "other": "未找到数据集卡片"
+    },
+    "errors.DAT-ERR-1": {
+        "other": "数据集格式错误"
+    },
+    "errors.DAT-ERR-2": {
+        "other": "没有有效的 Parquet 文件"
+    }
+}

--- a/common/i18n/zh-CN/err_dataset.json
+++ b/common/i18n/zh-CN/err_dataset.json
@@ -1,11 +1,11 @@
 {
-    "errors.DAT-ERR-0": {
+    "error.DAT-ERR-0": {
         "other": "未找到数据集卡片"
     },
-    "errors.DAT-ERR-1": {
+    "error.DAT-ERR-1": {
         "other": "数据集格式错误"
     },
-    "errors.DAT-ERR-2": {
+    "error.DAT-ERR-2": {
         "other": "没有有效的 Parquet 文件"
     }
 }

--- a/common/i18n/zh-HK/err_dataset.json
+++ b/common/i18n/zh-HK/err_dataset.json
@@ -1,0 +1,11 @@
+{
+    "errors.DAT-ERR-0": {
+        "other": "未找到數據集卡片"
+    },
+    "errors.DAT-ERR-1": {
+        "other": "數據集格式錯誤"
+    },
+    "errors.DAT-ERR-2": {
+        "other": "沒有有效的 Parquet 檔案"
+    }
+}

--- a/common/i18n/zh-HK/err_dataset.json
+++ b/common/i18n/zh-HK/err_dataset.json
@@ -1,11 +1,11 @@
 {
-    "errors.DAT-ERR-0": {
+    "error.DAT-ERR-0": {
         "other": "未找到數據集卡片"
     },
-    "errors.DAT-ERR-1": {
+    "error.DAT-ERR-1": {
         "other": "數據集格式錯誤"
     },
-    "errors.DAT-ERR-2": {
+    "error.DAT-ERR-2": {
         "other": "沒有有效的 Parquet 檔案"
     }
 }

--- a/dataviewer/component/dataset_viewer.go
+++ b/dataviewer/component/dataset_viewer.go
@@ -212,7 +212,11 @@ func (c *datasetViewerComponentImpl) LimitOffsetRows(ctx context.Context, req *d
 	}
 
 	if len(paths) < 1 {
-		return nil, fmt.Errorf("no valid parquet file in request for row data")
+		err := fmt.Errorf("no valid parquet file in request for row data")
+		return nil, errorx.NoValidParquetFile(err,
+			errorx.Ctx().
+				Set("path", fmt.Sprintf("%s/%s", req.Namespace, req.RepoName)),
+		)
 	}
 
 	offset := int64(req.Page-1) * int64(req.Per)
@@ -267,7 +271,11 @@ func (c *datasetViewerComponentImpl) Rows(ctx context.Context, req *dvCom.ViewPa
 	}
 
 	if len(parquetObjs) < 1 {
-		return nil, fmt.Errorf("no valid parquet file in request for row data")
+		err := fmt.Errorf("no valid parquet file in request for row data")
+		return nil, errorx.NoValidParquetFile(err,
+			errorx.Ctx().
+				Set("path", fmt.Sprintf("%s/%s", req.Namespace, req.RepoName)),
+		)
 	}
 
 	sqlReq := types.QueryReq{
@@ -328,7 +336,11 @@ func (c *datasetViewerComponentImpl) getRepoParquetObjs(ctx context.Context, req
 	}
 	parquetObjs := c.getFilesOBJs(ctx, req, realReqFiles)
 	if len(parquetObjs) < 1 {
-		return nil, fmt.Errorf("no valid files in request")
+		err := fmt.Errorf("no valid parquet file in request for row data")
+		return nil, errorx.NoValidParquetFile(err,
+			errorx.Ctx().
+				Set("path", fmt.Sprintf("%s/%s", req.Namespace, req.RepoName)),
+		)
 	}
 	return parquetObjs, nil
 }

--- a/dataviewer/component/dataset_viewer_test.go
+++ b/dataviewer/component/dataset_viewer_test.go
@@ -2,12 +2,15 @@ package component
 
 import (
 	"context"
+	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"opencsg.com/csghub-server/builder/git/gitserver"
 	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	dvCom "opencsg.com/csghub-server/dataviewer/common"
 )
@@ -140,6 +143,68 @@ func TestDatasetViewerComponent_Rows(t *testing.T) {
 		Total: 100,
 	}, resp)
 
+}
+
+func TestDatasetViewerComponent_Rows_NoValidParquetFile(t *testing.T) {
+	ctx := context.TODO()
+	dc := initializeTestDatasetViewerComponent(ctx, t)
+
+	repo := &database.Repository{DefaultBranch: "main"}
+
+	// Mock repository lookup
+	dc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.DatasetRepo, "ns", "repo").Return(
+		repo, nil,
+	)
+
+	// Mock permission check
+	dc.mocks.components.repo.EXPECT().AllowReadAccessRepo(ctx, repo, "user").Return(true, nil)
+
+	// Mock viewer card lookup
+	dc.mocks.stores.ViewerMock().EXPECT().GetViewerByRepoID(ctx, int64(0)).Return(nil, nil)
+
+	// Mock readme.md file content lookup
+	dc.mocks.gitServer.EXPECT().GetRepoFileContents(mock.Anything, gitserver.GetRepoInfoByPathReq{
+		Namespace: "ns",
+		Name:      "repo",
+		Ref:       "main",
+		Path:      types.REPOCARD_FILENAME,
+		RepoType:  types.DatasetRepo,
+	}).Return(&types.File{
+		LfsRelativePath: "a/b",
+		LfsSHA256:       "c5185c4794be2d8a9784d5753c9922db38df478ce11f9ed0b415b7304d896836",
+		Content:         "LS0tCmNvbmZpZ3M6Ci0gY29uZmlnX25hbWU6ICJmb28iCiAgZGF0YV9maWxlczoKICAtIHNwbGl0OiB0cmFpbgogICAgcGF0aDogZm9vLy4qCi0gY29uZmlnX25hbWU6ICJiYXIiCiAgZGF0YV9maWxlczoKICAtIHNwbGl0OiB0cmFpbgpwYXRoOiBiYXIvLioKLS0tCg==",
+	}, nil)
+	dc.mocks.gitServer.EXPECT().GetRepoFileContents(mock.Anything, gitserver.GetRepoInfoByPathReq{
+		Namespace: "ns",
+		Name:      "repo",
+		Ref:       "main",
+		Path:      "foo/.*",
+		RepoType:  types.DatasetRepo,
+	}).Return(nil, errors.New("no file found"))
+	// Mock GetTree to return no files
+	dc.mocks.gitServer.EXPECT().GetTree(mock.Anything, types.GetTreeRequest{
+		Namespace: "ns",
+		Name:      "repo",
+		Ref:       "main",
+		RepoType:  types.DatasetRepo,
+		Limit:     500,
+		Recursive: true,
+	}).Return(&types.GetRepoFileTreeResp{Files: []*types.File{}}, nil)
+
+	resp, err := dc.Rows(ctx, &dvCom.ViewParquetFileReq{
+		Namespace:   "ns",
+		RepoName:    "repo",
+		Branch:      "main",
+		Path:        "foo",
+		Per:         10,
+		Page:        1,
+		CurrentUser: "user",
+	}, types.DataViewerReq{Split: "train", Config: "foo"})
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+
+	require.True(t, errors.Is(err, errorx.ErrNoValidParquetFile))
 }
 
 func TestDatasetViewerComponent_LimitOffsetRowsNoCard(t *testing.T) {
@@ -419,4 +484,60 @@ func TestDatasetViewerComponent_GetCatalog(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, &dvCom.CataLogRespone{Configs: []dvCom.ConfigData{{ConfigName: "default", DataFiles: []dvCom.DataFiles{{Split: "train", Path: []string{"foo/train.parquet"}}}}}, DatasetInfos: []dvCom.DatasetInfo{{ConfigName: "default", Splits: []dvCom.Split{{Name: "train", NumExamples: 100}}}}}, data)
 	})
+}
+
+func TestDatasetViewerComponent_LimitOffsetRows_NoValidParquetFile(t *testing.T) {
+	ctx := context.TODO()
+	dc := initializeTestDatasetViewerComponent(ctx, t)
+
+	repo := &database.Repository{DefaultBranch: "main"}
+
+	// Mock repository lookup
+	dc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.DatasetRepo, "ns", "repo").Return(
+		repo, nil,
+	)
+
+	// Mock permission check
+	dc.mocks.components.repo.EXPECT().AllowReadAccessRepo(ctx, repo, "user").Return(true, nil)
+
+	// Mock viewer card lookup
+	dc.mocks.stores.ViewerMock().EXPECT().GetViewerByRepoID(ctx, int64(0)).Return(nil, nil)
+
+	// Mock readme.md file content lookup
+	dc.mocks.gitServer.EXPECT().GetRepoFileContents(mock.Anything, gitserver.GetRepoInfoByPathReq{
+		Namespace: "ns",
+		Name:      "repo",
+		Ref:       "main",
+		Path:      types.REPOCARD_FILENAME,
+		RepoType:  types.DatasetRepo,
+	}).Return(&types.File{
+		Content: "invalid yaml content",
+	}, nil)
+
+	// Mock GetTree to return no files
+	dc.mocks.gitServer.EXPECT().GetTree(mock.Anything, types.GetTreeRequest{
+		Namespace: "ns",
+		Name:      "repo",
+		Ref:       "main",
+		Path:      "foo",
+		RepoType:  types.DatasetRepo,
+		Limit:     math.MaxInt,
+		Recursive: true,
+	}).Return(&types.GetRepoFileTreeResp{Files: []*types.File{}}, nil)
+
+	resp, err := dc.LimitOffsetRows(ctx, &dvCom.ViewParquetFileReq{
+		Namespace:   "ns",
+		RepoName:    "repo",
+		Branch:      "main",
+		Path:        "foo",
+		Per:         10,
+		Page:        1,
+		CurrentUser: "user",
+	}, types.DataViewerReq{Split: "train", Config: "foo"})
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+
+	// Check that error is of type NoValidParquetFile
+	require.True(t, errors.Is(err, errorx.ErrNoValidParquetFile))
 }

--- a/dataviewer/component/dataset_viewer_test.go
+++ b/dataviewer/component/dataset_viewer_test.go
@@ -3,7 +3,6 @@ package component
 import (
 	"context"
 	"errors"
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -237,7 +236,7 @@ func TestDatasetViewerComponent_LimitOffsetRowsNoCard(t *testing.T) {
 		Ref:       "main",
 		Path:      "foo",
 		RepoType:  types.DatasetRepo,
-		Limit:     500,
+		Limit:     types.MaxFileTreeSize,
 		Recursive: true,
 	}).Return(
 		&types.GetRepoFileTreeResp{Files: []*types.File{
@@ -521,7 +520,7 @@ func TestDatasetViewerComponent_LimitOffsetRows_NoValidParquetFile(t *testing.T)
 		Ref:       "main",
 		Path:      "foo",
 		RepoType:  types.DatasetRepo,
-		Limit:     math.MaxInt,
+		Limit:     types.MaxFileTreeSize,
 		Recursive: true,
 	}).Return(&types.GetRepoFileTreeResp{Files: []*types.File{}}, nil)
 


### PR DESCRIPTION
Introduce error handling for invalid Parquet files and localize error messages for better user experience. Update types and tests to ensure proper error reporting.