### PR TITLE
perf: use BatchGet for better pagination performance in recom component

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoStore.go
@@ -134,9 +134,9 @@ func (_c *MockRepoStore_BatchCreateRepoTags_Call) RunAndReturn(run func(context.
 	return _c
 }
 
-// BatchGet provides a mock function with given fields: ctx, repoType, lastRepoID, batch
-func (_m *MockRepoStore) BatchGet(ctx context.Context, repoType types.RepositoryType, lastRepoID int64, batch int) ([]database.Repository, error) {
-	ret := _m.Called(ctx, repoType, lastRepoID, batch)
+// BatchGet provides a mock function with given fields: ctx, lastRepoID, batch, filter
+func (_m *MockRepoStore) BatchGet(ctx context.Context, lastRepoID int64, batch int, filter *types.BatchGetFilter) ([]database.Repository, error) {
+	ret := _m.Called(ctx, lastRepoID, batch, filter)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BatchGet")
@@ -144,19 +144,19 @@ func (_m *MockRepoStore) BatchGet(ctx context.Context, repoType types.Repository
 
 	var r0 []database.Repository
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, int64, int) ([]database.Repository, error)); ok {
-		return rf(ctx, repoType, lastRepoID, batch)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int, *types.BatchGetFilter) ([]database.Repository, error)); ok {
+		return rf(ctx, lastRepoID, batch, filter)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, int64, int) []database.Repository); ok {
-		r0 = rf(ctx, repoType, lastRepoID, batch)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int, *types.BatchGetFilter) []database.Repository); ok {
+		r0 = rf(ctx, lastRepoID, batch, filter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]database.Repository)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, types.RepositoryType, int64, int) error); ok {
-		r1 = rf(ctx, repoType, lastRepoID, batch)
+	if rf, ok := ret.Get(1).(func(context.Context, int64, int, *types.BatchGetFilter) error); ok {
+		r1 = rf(ctx, lastRepoID, batch, filter)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -171,16 +171,16 @@ type MockRepoStore_BatchGet_Call struct {
 
 // BatchGet is a helper method to define mock.On call
 //   - ctx context.Context
-//   - repoType types.RepositoryType
 //   - lastRepoID int64
 //   - batch int
-func (_e *MockRepoStore_Expecter) BatchGet(ctx interface{}, repoType interface{}, lastRepoID interface{}, batch interface{}) *MockRepoStore_BatchGet_Call {
-	return &MockRepoStore_BatchGet_Call{Call: _e.mock.On("BatchGet", ctx, repoType, lastRepoID, batch)}
+//   - filter *types.BatchGetFilter
+func (_e *MockRepoStore_Expecter) BatchGet(ctx interface{}, lastRepoID interface{}, batch interface{}, filter interface{}) *MockRepoStore_BatchGet_Call {
+	return &MockRepoStore_BatchGet_Call{Call: _e.mock.On("BatchGet", ctx, lastRepoID, batch, filter)}
 }
 
-func (_c *MockRepoStore_BatchGet_Call) Run(run func(ctx context.Context, repoType types.RepositoryType, lastRepoID int64, batch int)) *MockRepoStore_BatchGet_Call {
+func (_c *MockRepoStore_BatchGet_Call) Run(run func(ctx context.Context, lastRepoID int64, batch int, filter *types.BatchGetFilter)) *MockRepoStore_BatchGet_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(types.RepositoryType), args[2].(int64), args[3].(int))
+		run(args[0].(context.Context), args[1].(int64), args[2].(int), args[3].(*types.BatchGetFilter))
 	})
 	return _c
 }
@@ -190,7 +190,7 @@ func (_c *MockRepoStore_BatchGet_Call) Return(_a0 []database.Repository, _a1 err
 	return _c
 }
 
-func (_c *MockRepoStore_BatchGet_Call) RunAndReturn(run func(context.Context, types.RepositoryType, int64, int) ([]database.Repository, error)) *MockRepoStore_BatchGet_Call {
+func (_c *MockRepoStore_BatchGet_Call) RunAndReturn(run func(context.Context, int64, int, *types.BatchGetFilter) ([]database.Repository, error)) *MockRepoStore_BatchGet_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/common/types/repo.go
+++ b/common/types/repo.go
@@ -253,6 +253,11 @@ type RepoFilter struct {
 	SpaceSDK       string
 }
 
+type BatchGetFilter struct {
+	RepoType             RepositoryType        `json:"repo_type"`
+	SensitiveCheckStatus *SensitiveCheckStatus `json:"sensitive_check_status"`
+}
+
 type TagReq struct {
 	Name     string `json:"name"`
 	Category string `json:"category"`

--- a/component/recom.go
+++ b/component/recom.go
@@ -60,9 +60,9 @@ func (rc *recomComponentImpl) CalculateRecomScore(ctx context.Context, batchSize
 	if batchSize <= 0 {
 		batchSize = 500
 	}
-	batch := 0
+	lastRepoID := int64(0)
 	for {
-		repos, err := rc.repoStore.FindWithBatch(ctx, batchSize, batch)
+		repos, err := rc.repoStore.BatchGet(ctx, lastRepoID, batchSize, nil)
 		if err != nil {
 			return errors.New("error fetching repositories")
 		}
@@ -105,7 +105,10 @@ func (rc *recomComponentImpl) CalculateRecomScore(ctx context.Context, batchSize
 			break
 		}
 
-		batch++
+		// Update lastRepoID to the ID of the last repository in this batch
+		if len(repos) > 0 {
+			lastRepoID = repos[len(repos)-1].ID
+		}
 	}
 
 	return nil

--- a/component/recom_test.go
+++ b/component/recom_test.go
@@ -42,11 +42,11 @@ func TestRecomComponent_CalculateRecomScore(t *testing.T) {
 	repo3 := database.Repository{ID: 3, Path: "foo/bar3"}
 	repo3.UpdatedAt = time.Now().Add(24 * time.Hour)
 	// loop 1
-	rc.mocks.stores.RepoMock().EXPECT().FindWithBatch(ctx, batchSize, 0).Return([]database.Repository{
+	rc.mocks.stores.RepoMock().EXPECT().BatchGet(ctx, int64(0), batchSize, (*types.BatchGetFilter)(nil)).Return([]database.Repository{
 		repo1, repo2,
 	}, nil)
 	// loop 2
-	rc.mocks.stores.RepoMock().EXPECT().FindWithBatch(ctx, batchSize, 1).Return([]database.Repository{
+	rc.mocks.stores.RepoMock().EXPECT().BatchGet(ctx, int64(2), batchSize, (*types.BatchGetFilter)(nil)).Return([]database.Repository{
 		repo3,
 	}, nil)
 

--- a/component/repo_file.go
+++ b/component/repo_file.go
@@ -54,7 +54,12 @@ func (c *repoFileComponentImpl) GenRepoFileRecordsBatch(ctx context.Context, rep
 	//TODO: load last repo id from redis cache
 	batch := 10
 	for {
-		repos, err := c.repoStore.BatchGet(ctx, repoType, lastRepoID, batch)
+		pendingStatus := types.SensitiveCheckPending
+		filter := &types.BatchGetFilter{
+			RepoType:             repoType,
+			SensitiveCheckStatus: &pendingStatus,
+		}
+		repos, err := c.repoStore.BatchGet(ctx, lastRepoID, batch, filter)
 		if err != nil {
 			return fmt.Errorf("failed to get repos in batch, error: %w", err)
 		}

--- a/component/repo_file_test.go
+++ b/component/repo_file_test.go
@@ -45,7 +45,12 @@ func TestRepoFileComponent_GenRepoFileRecordsBatch(t *testing.T) {
 	ctx := context.TODO()
 	rc := initializeTestRepoFileComponent(ctx, t)
 
-	rc.mocks.stores.RepoMock().EXPECT().BatchGet(ctx, types.ModelRepo, int64(1), 10).Return(
+	pendingStatus := types.SensitiveCheckPending
+	filter := &types.BatchGetFilter{
+		RepoType:             types.ModelRepo,
+		SensitiveCheckStatus: &pendingStatus,
+	}
+	rc.mocks.stores.RepoMock().EXPECT().BatchGet(ctx, int64(1), 10, filter).Return(
 		[]database.Repository{{ID: 1, Path: "foo/bar"}}, nil,
 	)
 

--- a/moderation/component/repo_file.go
+++ b/moderation/component/repo_file.go
@@ -55,7 +55,12 @@ func (c *repoFileComponentImpl) GenRepoFileRecordsBatch(ctx context.Context, rep
 	//TODO: load last repo id from redis cache
 	batch := 10
 	for {
-		repos, err := c.rs.BatchGet(ctx, repoType, lastRepoID, batch)
+		pendingStatus := types.SensitiveCheckPending
+		filter := &types.BatchGetFilter{
+			RepoType:             repoType,
+			SensitiveCheckStatus: &pendingStatus,
+		}
+		repos, err := c.rs.BatchGet(ctx, lastRepoID, batch, filter)
 		if err != nil {
 			return fmt.Errorf("failed to get repos in batch, error: %w", err)
 		}


### PR DESCRIPTION
## Issue 1

### Background

The SQL query used for the daily scheduled calculation of repository recommendation weights is performing a full table scan instead of using an index, leading to numerous slow queries.

### Solution

Change the repository traversal method to traverse by repository ID order. Since the ID is an auto-incrementing value, sequential lookups are very fast.

## Issue 2

### Background

Queries using `LOWER(path) = LOWER('AIWizards/whisper-base-mlx-2bit')` bypass the index, resulting in many slow SQL queries.

### Solution

Change the unique index of the `repositories` table from `(repository_type, path)` to `(repository_type, lower(path))`. This allows queries using `LOWER(path)` to hit the index.

### Testing

Database migration scripts

**Migration**

```
init logger, level: INFO, format: json
{"time":"2025-08-19T12:11:17.17196+08:00","level":"INFO","msg":"migrated to group #140 (20250819034735_idx_repositories_repository_type_lower_path)"}
```

**Rollback**

```
{"time":"2025-08-19T12:11:58.424687+08:00","level":"INFO","msg":"rolled back group #140 (20250819034735_idx_repositories_repository_type_lower_path)"}
```