### PR TITLE
Update error handling in discussion API

### DIFF
--- a/api/handler/discussion.go
+++ b/api/handler/discussion.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -9,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/common/utils/common"
 	"opencsg.com/csghub-server/component"
@@ -185,8 +187,14 @@ func (h *DiscussionHandler) ShowDiscussion(ctx *gin.Context) {
 	}
 	d, err := h.discussion.GetDiscussion(ctx.Request.Context(), idInt)
 	if err != nil {
-		slog.Error("Failed to get discussion", "error", err, "id", id)
-		httpbase.ServerError(ctx, fmt.Errorf("failed to get discussion: %w", err))
+		if errors.Is(err, errorx.ErrForbidden) {
+			httpbase.ForbiddenError(ctx, err)
+		} else if errors.Is(err, errorx.ErrDatabaseNoRows) {
+			httpbase.NotFoundError(ctx, err)
+		} else {
+			slog.Error("Failed to get discussion", "error", err, "id", id)
+			httpbase.ServerError(ctx, fmt.Errorf("failed to get discussion: %w", err))
+		}
 		return
 	}
 	httpbase.OK(ctx, d)
@@ -223,8 +231,14 @@ func (h *DiscussionHandler) ListRepoDiscussions(ctx *gin.Context) {
 	req.Name = name
 	resp, err := h.discussion.ListRepoDiscussions(ctx.Request.Context(), req)
 	if err != nil {
-		slog.Error("Failed to list repo discussions", "error", err, "request", req)
-		httpbase.ServerError(ctx, fmt.Errorf("failed to list repo discussions: %w", err))
+		if errors.Is(err, errorx.ErrForbidden) {
+			httpbase.ForbiddenError(ctx, err)
+		} else if errors.Is(err, errorx.ErrDatabaseNoRows) {
+			httpbase.NotFoundError(ctx, err)
+		} else {
+			slog.Error("Failed to list repo discussions", "error", err, "request", req)
+			httpbase.ServerError(ctx, fmt.Errorf("failed to list repo discussions: %w", err))
+		}
 		return
 	}
 	httpbase.OK(ctx, resp)
@@ -370,8 +384,14 @@ func (h *DiscussionHandler) ListDiscussionComments(ctx *gin.Context) {
 	}
 	comments, err := h.discussion.ListDiscussionComments(ctx.Request.Context(), idInt)
 	if err != nil {
-		slog.Error("Failed to list discussion comments", "error", err, "id", id)
-		httpbase.ServerError(ctx, fmt.Errorf("failed to list discussion comments: %w", err))
+		if errors.Is(err, errorx.ErrForbidden) {
+			httpbase.ForbiddenError(ctx, err)
+		} else if errors.Is(err, errorx.ErrDatabaseNoRows) {
+			httpbase.NotFoundError(ctx, err)
+		} else {
+			slog.Error("Failed to list discussion comments", "error", err, "id", id)
+			httpbase.ServerError(ctx, fmt.Errorf("failed to list discussion comments: %w", err))
+		}
 		return
 	}
 	httpbase.OK(ctx, comments)

--- a/builder/store/database/discussion.go
+++ b/builder/store/database/discussion.go
@@ -1,6 +1,10 @@
 package database
 
-import "context"
+import (
+	"context"
+
+	"opencsg.com/csghub-server/common/errorx"
+)
 
 type Discussion struct {
 	ID                 int64  `bun:"id,pk,autoincrement"`
@@ -65,6 +69,7 @@ func NewDiscussionStoreWithDB(db *DB) DiscussionStore {
 func (s *discussionStoreImpl) Create(ctx context.Context, discussion Discussion) (*Discussion, error) {
 	_, err := s.db.Core.NewInsert().Model(&discussion).Exec(ctx)
 	if err != nil {
+		err := errorx.HandleDBError(err, nil)
 		return nil, err
 	}
 	return &discussion, nil
@@ -77,6 +82,8 @@ func (s *discussionStoreImpl) FindByID(ctx context.Context, id int64) (*Discussi
 		Relation("User").
 		Scan(ctx)
 	if err != nil {
+		err := errorx.HandleDBError(err, errorx.Ctx().
+			Set("id", id))
 		return nil, err
 	}
 	return &discussion, nil
@@ -89,6 +96,9 @@ func (s *discussionStoreImpl) FindByDiscussionableID(ctx context.Context, discus
 		Relation("User").
 		Scan(ctx)
 	if err != nil {
+		err := errorx.HandleDBError(err, errorx.Ctx().
+			Set("id", discussionableID).
+			Set("type", discussionableType))
 		return nil, err
 	}
 	return discussions, nil
@@ -97,6 +107,8 @@ func (s *discussionStoreImpl) FindByDiscussionableID(ctx context.Context, discus
 func (s *discussionStoreImpl) UpdateByID(ctx context.Context, id int64, title string) error {
 	_, err := s.db.Core.NewUpdate().Model(&Discussion{}).Set("title = ?", title).Where("id = ?", id).Exec(ctx)
 	if err != nil {
+		err := errorx.HandleDBError(err, errorx.Ctx().
+			Set("id", id))
 		return err
 	}
 	return nil
@@ -105,6 +117,8 @@ func (s *discussionStoreImpl) UpdateByID(ctx context.Context, id int64, title st
 func (s *discussionStoreImpl) DeleteByID(ctx context.Context, id int64) error {
 	_, err := s.db.Core.NewDelete().Model(&Discussion{}).Where("id = ?", id).Exec(ctx)
 	if err != nil {
+		err := errorx.HandleDBError(err, errorx.Ctx().
+			Set("id", id))
 		return err
 	}
 	return nil
@@ -117,6 +131,8 @@ func (s *discussionStoreImpl) FindDiscussionComments(ctx context.Context, discus
 		Where("commentable_type=? AND	commentable_id = ?", CommentableTypeDiscussion, discussionID).
 		Scan(ctx)
 	if err != nil {
+		err := errorx.HandleDBError(err, errorx.Ctx().
+			Set("id", discussionID))
 		return nil, err
 	}
 	return comments, nil
@@ -125,6 +141,7 @@ func (s *discussionStoreImpl) FindDiscussionComments(ctx context.Context, discus
 func (s *discussionStoreImpl) CreateComment(ctx context.Context, comment Comment) (*Comment, error) {
 	_, err := s.db.Core.NewInsert().Model(&comment).Exec(ctx)
 	if err != nil {
+		err := errorx.HandleDBError(err, nil)
 		return nil, err
 	}
 	return &comment, nil
@@ -133,6 +150,7 @@ func (s *discussionStoreImpl) CreateComment(ctx context.Context, comment Comment
 func (s *discussionStoreImpl) UpdateComment(ctx context.Context, id int64, content string) error {
 	_, err := s.db.Core.NewUpdate().Model(&Comment{}).Set("content = ?", content).Where("id = ?", id).Exec(ctx)
 	if err != nil {
+		err := errorx.HandleDBError(err, nil)
 		return err
 	}
 	return nil
@@ -145,6 +163,7 @@ func (s *discussionStoreImpl) FindCommentByID(ctx context.Context, id int64) (*C
 		Relation("User").
 		Scan(ctx)
 	if err != nil {
+		err := errorx.HandleDBError(err, nil)
 		return nil, err
 	}
 	return &comment, nil
@@ -153,6 +172,7 @@ func (s *discussionStoreImpl) FindCommentByID(ctx context.Context, id int64) (*C
 func (s *discussionStoreImpl) DeleteComment(ctx context.Context, id int64) error {
 	_, err := s.db.Core.NewDelete().Model(&Comment{}).Where("id = ?", id).Exec(ctx)
 	if err != nil {
+		err := errorx.HandleDBError(err, nil)
 		return err
 	}
 	return nil

--- a/builder/store/database/discussion_test.go
+++ b/builder/store/database/discussion_test.go
@@ -2,10 +2,12 @@ package database_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/tests"
 )
 
@@ -47,6 +49,7 @@ func TestDiscussionStore_CRUD(t *testing.T) {
 	require.Nil(t, err)
 	_, err = store.FindByID(ctx, ds.ID)
 	require.NotNil(t, err)
+	require.True(t, errors.Is(err, errorx.ErrDatabaseNoRows))
 
 	_, err = store.CreateComment(ctx, database.Comment{
 		Content: "foobar",
@@ -71,4 +74,5 @@ func TestDiscussionStore_CRUD(t *testing.T) {
 	require.Nil(t, err)
 	_, err = store.FindCommentByID(ctx, cm.ID)
 	require.NotNil(t, err)
+	require.True(t, errors.Is(err, errorx.ErrDatabaseNoRows))
 }


### PR DESCRIPTION
Enhance error handling in the discussion API to provide more specific responses for forbidden and not found errors, improving the clarity of error messages returned to the client. Additionally, update tests to verify the new error handling behavior.