### PR TITLE
> [rproxy] Wrong way to set svc host name in header for v1.12 release

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/proxy/mock_ReverseProxy.go
+++ b/_mocks/opencsg.com/csghub-server/builder/proxy/mock_ReverseProxy.go
@@ -21,9 +21,9 @@ func (_m *MockReverseProxy) EXPECT() *MockReverseProxy_Expecter {
 	return &MockReverseProxy_Expecter{mock: &_m.Mock}
 }
 
-// ServeHTTP provides a mock function with given fields: w, r, api, host
-func (_m *MockReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request, api string, host string) {
-	_m.Called(w, r, api, host)
+// ServeHTTP provides a mock function with given fields: w, r, api, svcHost
+func (_m *MockReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request, api string, svcHost string) {
+	_m.Called(w, r, api, svcHost)
 }
 
 // MockReverseProxy_ServeHTTP_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ServeHTTP'
@@ -35,12 +35,12 @@ type MockReverseProxy_ServeHTTP_Call struct {
 //   - w http.ResponseWriter
 //   - r *http.Request
 //   - api string
-//   - host string
-func (_e *MockReverseProxy_Expecter) ServeHTTP(w interface{}, r interface{}, api interface{}, host interface{}) *MockReverseProxy_ServeHTTP_Call {
-	return &MockReverseProxy_ServeHTTP_Call{Call: _e.mock.On("ServeHTTP", w, r, api, host)}
+//   - svcHost string
+func (_e *MockReverseProxy_Expecter) ServeHTTP(w interface{}, r interface{}, api interface{}, svcHost interface{}) *MockReverseProxy_ServeHTTP_Call {
+	return &MockReverseProxy_ServeHTTP_Call{Call: _e.mock.On("ServeHTTP", w, r, api, svcHost)}
 }
 
-func (_c *MockReverseProxy_ServeHTTP_Call) Run(run func(w http.ResponseWriter, r *http.Request, api string, host string)) *MockReverseProxy_ServeHTTP_Call {
+func (_c *MockReverseProxy_ServeHTTP_Call) Run(run func(w http.ResponseWriter, r *http.Request, api string, svcHost string)) *MockReverseProxy_ServeHTTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(http.ResponseWriter), args[1].(*http.Request), args[2].(string), args[3].(string))
 	})

--- a/api/handler/rproxy.go
+++ b/api/handler/rproxy.go
@@ -96,7 +96,7 @@ func (r *RProxyHandler) Proxy(ctx *gin.Context) {
 			return
 		}
 		slog.Info("proxy target", slog.Any("appSvcName", appSvcName), slog.Any("target", target),
-			slog.Any("host", host), slog.Any("apiname", apiname))
+			slog.Any("set-header-host", host), slog.Any("apiname", apiname))
 		rp, _ := proxy.NewReverseProxy(target)
 		if deploy.Type == types.InferenceType || deploy.Type == types.ServerlessType {
 			// no need context path for inference
@@ -129,8 +129,8 @@ func (r *RProxyHandler) checkAccessPermission(ctx *gin.Context, deploy *database
 		}
 		// check space
 		allow, err = r.repoComp.AllowAccessByRepoID(ctx.Request.Context(), deploy.RepoID, username)
-	} else if deploy.ModelID > 0 {
-		// check model inference
+	} else {
+		// check endpoint
 		allow, err = r.repoComp.AllowAccessEndpoint(ctx.Request.Context(), username, deploy)
 	}
 	return allow, err


### PR DESCRIPTION
Fix rproxy bug
