### PR TITLE
Fix worker panic without sensitivecheck enable

### DIFF
--- a/cmd/csghub-server/cmd/temporal-worker/launch.go
+++ b/cmd/csghub-server/cmd/temporal-worker/launch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"opencsg.com/csghub-server/moderation/checker"
 
 	"opencsg.com/csghub-server/builder/deploy"
 	"opencsg.com/csghub-server/builder/deploy/common"
@@ -23,7 +24,6 @@ import (
 	"opencsg.com/csghub-server/builder/temporal"
 	"opencsg.com/csghub-server/common/config"
 	"opencsg.com/csghub-server/common/types"
-	"opencsg.com/csghub-server/moderation/checker"
 	moderationworkflow "opencsg.com/csghub-server/moderation/workflow"
 	notificationworkflow "opencsg.com/csghub-server/notification/workflow"
 	userworkflow "opencsg.com/csghub-server/user/workflow"
@@ -55,8 +55,11 @@ var cmdLaunch = &cobra.Command{
 			return fmt.Errorf("failed to init database, error: %w", err)
 		}
 
-		slog.Info("init sensitive checker")
-		checker.Init(cfg)
+		if cfg.SensitiveCheck.Enable {
+			slog.Info("init sensitive checker")
+			checker.Init(cfg)
+		}
+
 		slog.Info("init event publisher")
 		err = event.InitEventPublisher(cfg)
 		if err != nil {


### PR DESCRIPTION
## What is this feature?

This PR fixes a startup panic caused by initializing and registering the `SensitiveCheck` worker when sensitive check is disabled in the configuration.  
It ensures that the worker is only initialized when `cfg.SensitiveCheck.Enable` is explicitly enabled.

## Why do we need this feature?

Currently, the worker is initialized unconditionally, regardless of whether the sensitive check is enabled.  
When the check is disabled, the initialization logic triggers a panic during worker startup.  
This prevents the system from booting normally and affects service availability.

This fix ensures stable startup behavior and allows sensitive check to remain configurable.

## Who is this feature for?

- Developers and operators who deploy workers in environments where sensitive checks may be disabled.  
- Any deployment that relies on feature toggles for security or performance reasons.

## Which issue(s) does this PR fix?

Fixes #

## Special notes for your reviewer

- The main change is adding a conditional guard to avoid initializing or registering the sensitive check worker when the feature is disabled.  
- Verified that worker startup no longer panics when `SensitiveCheck.Enable = false`.  
- No behavior change when the feature is enabled.
