### PR TITLE
Fix client delete remote branch bug

### DIFF
--- a/api/handler/internal.go
+++ b/api/handler/internal.go
@@ -103,14 +103,16 @@ func (h *InternalHandler) SSHAllowed(ctx *gin.Context) {
 			return
 		}
 		rawReq.GitEnv = gitEnv
-		valid, err := h.internal.CheckGitCallback(ctx.Request.Context(), rawReq)
+		if len(gitEnv.GitAlternateObjectDirectoriesRelative) != 0 || gitEnv.GitObjectDirectoryRelative != "" {
+			valid, err := h.internal.CheckGitCallback(ctx.Request.Context(), rawReq)
 
-		if !valid {
-			ctx.PureJSON(http.StatusOK, gin.H{
-				"status":  false,
-				"message": err.Error(),
-			})
-			return
+			if !valid {
+				ctx.PureJSON(http.StatusOK, gin.H{
+					"status":  false,
+					"message": err.Error(),
+				})
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
**What is this feature?**

When user run the following command to delete a remote branch,it will return 500 error.

```shell
git push origin --delete v1
```
Fix this issue.



**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**
