### PR TITLE
[Fix] drop type_content_id constraint and add unique index for type, content_id in agent_instances table.

### DIFF
--- a/builder/store/database/migrations/20251211065927_update_constraint_for_agent_instances_table.down.sql
+++ b/builder/store/database/migrations/20251211065927_update_constraint_for_agent_instances_table.down.sql
@@ -1,0 +1,7 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+DROP INDEX IF EXISTS idx_agent_instances_type_content_id_unique_active;
+
+ALTER TABLE agent_instances ADD CONSTRAINT unique_agent_instances_type_content_id UNIQUE (type, content_id);

--- a/builder/store/database/migrations/20251211065927_update_constraint_for_agent_instances_table.up.sql
+++ b/builder/store/database/migrations/20251211065927_update_constraint_for_agent_instances_table.up.sql
@@ -1,0 +1,7 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE agent_instances DROP CONSTRAINT IF EXISTS unique_agent_instances_type_content_id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_instances_type_content_id_unique_active ON agent_instances(type, content_id) WHERE deleted_at IS NULL;


### PR DESCRIPTION
Automated sync of commit 865fb01. Depends on PR #597