### PR TITLE
Support query metering data without instance_name and update filtering logic

### DIFF
--- a/builder/store/database/account_metering_test.go
+++ b/builder/store/database/account_metering_test.go
@@ -91,7 +91,7 @@ func TestAccountMeteringStore_ListByUserIDAndTime(t *testing.T) {
 		},
 		{
 			UserUUID: "foo", Value: 12.34, ValueType: 1,
-			ResourceName: "r10", Scene: types.ScenePayOrder, CustomerID: "barz",
+			ResourceName: "r10", Scene: types.ScenePayOrder, CustomerID: "",
 			RecordedAt: dt.Add(-1 * time.Hour), EventUUID: uuid.New(),
 		},
 	}
@@ -115,6 +115,21 @@ func TestAccountMeteringStore_ListByUserIDAndTime(t *testing.T) {
 		names = append(names, am.ResourceName)
 	}
 	require.Equal(t, []string{"r5", "r4", "r3", "r2", "r1"}, names)
+
+	ams, total, err = store.ListByUserIDAndTime(ctx, types.ActStatementsReq{
+		UserUUID:     "foo",
+		Scene:        2,
+		InstanceName: "",
+		StartTime:    dt.Add(-5 * time.Hour).Format(time.RFC3339),
+		EndTime:      dt.Add(5 * time.Hour).Format(time.RFC3339),
+	})
+	require.Nil(t, err)
+	require.Equal(t, 6, total)
+	names = []string{}
+	for _, am := range ams {
+		names = append(names, am.ResourceName)
+	}
+	require.Equal(t, []string{"r10", "r5", "r4", "r3", "r2", "r1"}, names)
 }
 
 func TestAccountMeteringStore_GetStatByDate(t *testing.T) {

--- a/builder/store/database/migrations/20251225065249_add_index_user_scene_record_to_account_metering.down.sql
+++ b/builder/store/database/migrations/20251225065249_add_index_user_scene_record_to_account_metering.down.sql
@@ -1,0 +1,5 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+DROP INDEX IF EXISTS idx_account_meter_user_scene_recordat;

--- a/builder/store/database/migrations/20251225065249_add_index_user_scene_record_to_account_metering.up.sql
+++ b/builder/store/database/migrations/20251225065249_add_index_user_scene_record_to_account_metering.up.sql
@@ -1,0 +1,5 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+CREATE INDEX IF NOT EXISTS idx_account_meter_user_scene_recordat ON account_meterings (user_uuid, scene, recorded_at);


### PR DESCRIPTION
Automated sync of commit a4c955f. Depends on #651