### PR TITLE
enable muti-host inference for  nvidia vllm and sgalng

### DIFF
--- a/component/model.go
+++ b/component/model.go
@@ -1066,7 +1066,8 @@ func (c *modelComponentImpl) Deploy(ctx context.Context, deployReq types.DeployA
 
 	// only vllm and sglang support multi-host inference
 	if hardware.Replicas > 1 {
-		if frame.FrameName != "vllm" && frame.FrameName != "sglang" {
+		frameNameLower := strings.ToLower(frame.FrameName)
+		if !strings.Contains(frameNameLower, "vllm") && !strings.Contains(frameNameLower, "sglang") {
 			return -1, errorx.ErrMultiHostInferenceNotSupported
 		}
 		if req.MinReplica < 1 {


### PR DESCRIPTION
Automated sync of commit d868cb1. Depends on #729