### PR TITLE
fix(space): replace hardcoded engine version with constant and use FindSpaceLatestVersion

### DIFF
--- a/component/space.go
+++ b/component/space.go
@@ -1000,16 +1000,16 @@ func (c *spaceComponentImpl) Deploy(ctx context.Context, namespace, name, curren
 		var err error
 		if (space.Sdk == types.GRADIO.Name && space.SdkVersion != types.GRADIO.Version) ||
 			(space.Sdk == types.STREAMLIT.Name && space.SdkVersion != types.STREAMLIT.Version) {
-			// Using old base image 1.0.3 for old spaces, will be removed in the future
-			frame, err = c.rfs.FindByFrameNameAndDriverVersion(ctx, "space", "1.0.3", space.DriverVersion)
+			slog.InfoContext(ctx, "Using old base image 1.0.3 for old spaces")
+			frame, err = c.rfs.FindByFrameNameAndDriverVersion(ctx, "space", EngineVersion103, space.DriverVersion)
 			if err != nil {
-				return -1, fmt.Errorf("cannot find available (1.0.3) runtime framework, %w", err)
+				return -1, fmt.Errorf("cannot find available (%s) runtime framework, %w", EngineVersion103, err)
 			}
 		} else {
-			// 1.0.4
-			frame, err = c.rfs.FindByFrameNameAndDriverVersion(ctx, "space", "1.0.4", space.DriverVersion)
+			// use latest base space runtime image
+			frame, err = c.rfs.FindSpaceLatestVersion(ctx, "space", space.DriverVersion)
 			if err != nil {
-				return -1, fmt.Errorf("cannot find available (1.0.4) runtime framework, %w", err)
+				return -1, fmt.Errorf("cannot find available latest space runtime framework, %w", err)
 			}
 		}
 

--- a/component/space_ce_test.go
+++ b/component/space_ce_test.go
@@ -189,8 +189,7 @@ func TestSpaceComponent_Deploy(t *testing.T) {
 	sc.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "user").Return(database.User{
 		Username: "user1",
 	}, nil)
-	sc.mocks.stores.RuntimeFrameworkMock().EXPECT().FindByFrameNameAndDriverVersion(ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
-
+	sc.mocks.stores.RuntimeFrameworkMock().EXPECT().FindSpaceLatestVersion(ctx, mock.Anything, mock.Anything).Return(&database.RuntimeFramework{}, nil)
 	t.Run("Deploy", func(t *testing.T) {
 		sc.mocks.stores.SpaceMock().EXPECT().FindByPath(ctx, "ns1", "n1").Return(&database.Space{
 			ID:         1,


### PR DESCRIPTION
This PR addresses a maintainability issue in the space module by:
Replacing the hardcoded engine version string with the named constant EngineVersion103.
Updating the logic for retrieving the latest runtime framework version to use the new FindSpaceLatestVersion method instead of relying on a fixed version number.
These changes improve code clarity, reduce duplication, and make future version updates safer and easier.

Changes:
Use EngineVersion103 constant instead of magic string
Switch to FindSpaceLatestVersion() for latest runtime lookup
Testing:
Verified that space initialization behaves as expected with both known and latest engine versions
All existing unit tests pass