### PR TITLE
Rename openai_compatible_embedder to openai_compatible_model

### DIFF
--- a/data/memmachine/configuration.yml
+++ b/data/memmachine/configuration.yml
@@ -58,7 +58,7 @@ resources:
         dimensions: 1536
 
   language_models:
-    openai_compatible_embedder:
+    openai_compatible_model:
       provider: openai-chat-completions
       config:
         model: "gpt-5-mini"


### PR DESCRIPTION
**What is this feature?**

[修复data/memmachine/configuration.yml文件.]


**Which issue(s) does this PR fix?**:
#813 
Fixes #

**Rename openai_compatible_embedder to openai_compatible_model
:**
