### PR TITLE
fix(service): handle errors for delete/stop non-existent services

### DIFF
--- a/runner/component/service.go
+++ b/runner/component/service.go
@@ -1202,6 +1202,12 @@ func (s *serviceComponentImpl) StopService(ctx context.Context, req types.StopRe
 		k8serr := new(k8serrors.StatusError)
 		if errors.As(err, &k8serr) {
 			if k8serr.Status().Code == http.StatusNotFound {
+				// force delete db record for not exist ksvc
+				dberr := s.serviceStore.Delete(ctx, cluster.ID, req.SvcName)
+				if dberr != nil && !errors.Is(dberr, sql.ErrNoRows) {
+					slog.ErrorContext(ctx, "clean db record %s failed, error: %v", req.SvcName, dberr)
+				}
+				
 				slog.Info("stop service skip,service not exist", slog.String("svc_name", req.SvcName), slog.Any("k8s_err", k8serr))
 				resp.Code = 0
 				resp.Message = "skip,service not exist"

--- a/runner/component/service_test.go
+++ b/runner/component/service_test.go
@@ -142,6 +142,42 @@ func TestServiceComponent_StopService(t *testing.T) {
 	require.Equal(t, resp.Code, 0)
 }
 
+func TestServiceComponent_StopService_NotExistInK8s(t *testing.T) {
+	kss := mockdb.NewMockKnativeServiceStore(t)
+	ctx := context.TODO()
+	pool := mockCluster.NewMockPool(t)
+	kubeClient := fake.NewSimpleClientset()
+	knativeClient := knativefake.NewSimpleClientset()
+	cluster := cluster.Cluster{
+		CID:           "config",
+		ID:            "test",
+		Client:        kubeClient,
+		KnativeClient: knativeClient,
+	}
+	pool.EXPECT().GetClusterByID(mock.Anything, "test").Return(&cluster, nil)
+	sc := &serviceComponentImpl{
+		k8sNameSpace:       "test",
+		env:                &config.Config{},
+		spaceDockerRegBase: "http://test.com",
+		modelDockerRegBase: "http://test.com",
+		imagePullSecret:    "test",
+		serviceStore:       kss,
+		clusterPool:        pool,
+		logReporter:        mockReporter.NewMockLogCollector(t),
+	}
+
+	kss.EXPECT().Delete(ctx, "test", "nonexistent").Return(nil)
+
+	resp, err := sc.StopService(ctx, types.StopRequest{
+		SvcName:   "nonexistent",
+		ClusterID: "test",
+	})
+	require.Nil(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, resp.Code, 0)
+	require.Equal(t, "skip,service not exist", resp.Message)
+}
+
 func TestServiceComponent_PurgeService(t *testing.T) {
 	kss := mockdb.NewMockKnativeServiceStore(t)
 	ctx := context.TODO()


### PR DESCRIPTION
## 改动说明
- 应用 GitLab MR #2277 的代码改动
- 修复 remote runner 中 ksvc 不存在但数据库记录仍然存在的问题
- 更新 runner stop action 来清理不存在的 ksvc 的数据库记录

## 具体改动
1. **runner/component/service.go**: 在 StopService 函数中添加数据库清理逻辑，当 k8s 服务不存在时强制删除数据库记录
2. **runner/component/service_test.go**: 添加新的测试用例 TestServiceComponent_StopService_NotExistInK8s

## 相关 Issue
- GitLab Issue #1087

## 测试
- 添加了完整的测试用例验证功能
- 测试当 k8s 服务不存在时的正确处理流程