### PR TITLE
fix: fix potential bugs that may cause program panic

### DIFF
--- a/runner/component/service.go
+++ b/runner/component/service.go
@@ -561,19 +561,19 @@ func (s *serviceComponentImpl) runInformer() {
 			slog.Error("cluster is unavailable", slog.Any("cluster config", cls.CID), slog.Any("error", err))
 			continue
 		}
-		wg.Add(2)
-		go func(cluster *cluster.Cluster) {
-			defer wg.Done()
-			s.runServiceInformer(stopCh, cluster)
-		}(cls)
-		go func(cluster *cluster.Cluster) {
-			defer wg.Done()
-			s.runPodInformer(stopCh, cluster)
-		}(cls)
-		go func(cluster *cluster.Cluster) {
-			defer wg.Done()
-			s.runRevisionInformer(stopCh, cluster)
-		}(cls)
+
+		// Using the wg.Go(func()) function (Go 1.25+) avoids panics caused by mismatched counts of manual wg.Add(n) and wg.Done() calls.
+		// In Go 1.22, there is no need to additionally create or pass the cls variable,
+		// see https://github.com/golang/go/issues/60078 (@rsc)
+		wg.Go(func() {
+			s.runServiceInformer(stopCh, cls)
+		})
+		wg.Go(func() {
+			s.runPodInformer(stopCh, cls)
+		})
+		wg.Go(func() {
+			s.runRevisionInformer(stopCh, cls)
+		})
 	}
 	wg.Wait()
 }

--- a/runner/component/workflow.go
+++ b/runner/component/workflow.go
@@ -412,22 +412,16 @@ func (wc *workFlowComponentImpl) RunInformer(c *config.Config) {
 			continue
 		}
 		if wc.config.Cluster.ResourceQuotaNamespace != wc.config.Cluster.SpaceNamespace {
-			wg.Add(2)
-			go func(cluster *cluster.Cluster) {
-				defer wg.Done()
-				go wc.RunArgoInformer(stopCh, wc.config.Cluster.SpaceNamespace, cls)
-			}(cls)
-			go func(cluster *cluster.Cluster) {
-				defer wg.Done()
-				go wc.RunArgoInformer(stopCh, wc.config.Cluster.ResourceQuotaNamespace, cls)
-			}(cls)
-
+			wg.Go(func() {
+				wc.RunArgoInformer(stopCh, wc.config.Cluster.SpaceNamespace, cls)
+			})
+			wg.Go(func() {
+				wc.RunArgoInformer(stopCh, wc.config.Cluster.ResourceQuotaNamespace, cls)
+			})
 		} else {
-			wg.Add(1)
-			go func(cluster *cluster.Cluster) {
-				defer wg.Done()
-				go wc.RunArgoInformer(stopCh, wc.config.Cluster.SpaceNamespace, cls)
-			}(cls)
+			wg.Go(func() {
+				wc.RunArgoInformer(stopCh, wc.config.Cluster.SpaceNamespace, cls)
+			})
 		}
 	}
 	wg.Wait()

--- a/runner/handler/service.go
+++ b/runner/handler/service.go
@@ -99,6 +99,7 @@ func (s *K8sHandler) UpdateService(c *gin.Context) {
 	if err != nil {
 		slog.ErrorContext(c.Request.Context(), "failed to update service", slog.Any("error", err), slog.Any("req", request))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
 	}
 	slog.Info("service updated", slog.String("svc_name", svcName))
 	resp.Code = 0


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

1. Fix repeated calls to c.JSON(), which may cause a panic in the Gin framework.
2. Resolve mismatch between wg.Add(n) and wg.Done() in WaitGroup usage by refactoring to Go 1.25(go.mod 1.25.7) wg.Go(func) pattern.
3. Fix improper nested goroutine creation in runner/component/workflow.go, which breaks WaitGroup synchronization.
