### PR TITLE
fix(runner): resolve nil pointer panic and channel close panic in ser…

### DIFF
--- a/runner/common/pod.go
+++ b/runner/common/pod.go
@@ -3,8 +3,8 @@ package common
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,8 +29,7 @@ func GetPod(ctx context.Context, client kubernetes.Interface, podName string, na
 	return pod, nil
 }
 
-func GetPodLogStream(ctx context.Context, client kubernetes.Interface, podName string, namespace string, container string) (chan []byte, string, error) {
-
+func GetPodLogStream(ctx context.Context, client kubernetes.Interface, podName string, namespace string, container string) (stream io.ReadCloser, message string, err error) {
 	pod, err := GetPod(ctx, client, podName, namespace)
 	if err != nil {
 		return nil, "", err
@@ -45,46 +44,13 @@ func GetPodLogStream(ctx context.Context, client kubernetes.Interface, podName s
 	if pod.Status.Phase == "Pending" {
 		for _, condition := range pod.Status.Conditions {
 			if condition.Type == "PodScheduled" && condition.Status == "False" {
-				message := fmt.Sprintf("Pod is pending due to reason: %s, message: %s", condition.Reason, condition.Message)
+				message = fmt.Sprintf("Pod is pending due to reason: %s, message: %s", condition.Reason, condition.Message)
 				return nil, message, nil
 			}
 		}
 	}
-
-	ch := make(chan []byte)
-	buf := make([]byte, 32*1024)
-
-	stream, err := logs.Stream(context.Background())
-	if err != nil {
-		return nil, "", err
-	}
-
-	go func() {
-		defer close(ch)
-		defer stream.Close()
-		for {
-			select {
-			case <-ctx.Done():
-				slog.Info("logs request context done", slog.Any("error", ctx.Err()))
-				return
-			default:
-				n, err := stream.Read(buf)
-				if err != nil {
-					slog.Error("read pod logs failed", slog.Any("error", err))
-					return
-				}
-				if n == 0 {
-					time.Sleep(5 * time.Second)
-				}
-
-				if n > 0 {
-					ch <- buf[:n]
-				}
-			}
-		}
-	}()
-
-	return ch, "", nil
+	stream, err = logs.Stream(ctx)
+	return stream, message, err
 }
 
 // get container name

--- a/runner/handler/service.go
+++ b/runner/handler/service.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"database/sql"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 
@@ -18,6 +19,7 @@ import (
 	rcommon "opencsg.com/csghub-server/runner/common"
 	"opencsg.com/csghub-server/runner/component"
 	rTypes "opencsg.com/csghub-server/runner/types"
+	"opencsg.com/csghub-server/runner/utils"
 )
 
 type K8sHandler struct {
@@ -228,47 +230,36 @@ func (s *K8sHandler) readPodLogsFromDB(c *gin.Context, cluster *cluster.Cluster,
 func (s *K8sHandler) readPodLogsFromCluster(c *gin.Context, cluster *cluster.Cluster, podName, svcName string) {
 	slog.Debug("read pod logs from cluster", slog.Any("namespace", s.k8sNameSpace), slog.Any("pod-name", podName),
 		slog.Any("svcname", svcName), slog.Any("clusterID", cluster.ID))
-	ch, message, err := rcommon.GetPodLogStream(c, cluster.Client, podName, s.k8sNameSpace, rTypes.UserContainerName)
+
+	stream, message, err := rcommon.GetPodLogStream(c.Request.Context(), cluster.Client, podName, s.k8sNameSpace, rTypes.UserContainerName)
 	if err != nil {
 		slog.ErrorContext(c.Request.Context(), "Failed to open stream", slog.Any("error", err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to open stream"})
 		return
 	}
 	defer func() {
-		if ch != nil {
-			select {
-			case _, ok := <-ch:
-				if ok {
-					close(ch)
-				}
-			default:
-				close(ch)
-			}
+		if stream != nil {
+			_ = stream.Close()
 		}
 	}()
 
-	setResponseHeaderForLogs(c)
-
 	if message != "" {
-		_, err = c.Writer.Write([]byte(message))
-		if err != nil {
-			slog.ErrorContext(c.Request.Context(), "write pod message data failed", slog.Any("svcName", svcName),
-				slog.Any("namespace", s.k8sNameSpace), slog.Any("pod-name", podName),
-				slog.Any("clusterID", cluster.ID), slog.Any("error", err))
-		}
-		c.Writer.Flush()
 		c.JSON(http.StatusBadRequest, gin.H{"error": message})
 		return
 	}
 
-	for log := range ch {
-		_, err := c.Writer.Write(log)
-		if err != nil {
-			slog.ErrorContext(c.Request.Context(), "write pod log data failed", slog.Any("svcName", svcName),
-				slog.Any("namespace", s.k8sNameSpace), slog.Any("pod-name", podName),
-				slog.Any("clusterID", cluster.ID), slog.Any("error", err))
-		}
-		c.Writer.Flush()
+	// TODO miss web socket
+
+	setResponseHeaderForLogs(c)
+
+	// Flush the header by calling http.Flusher if supported.
+	if flusher, ok := c.Writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+
+	w := utils.Wrap(c.Writer)
+	if _, err := io.Copy(w, stream); err != nil {
+		slog.ErrorContext(c.Request.Context(), "failed to copy stream", slog.Any("error", err))
 	}
 }
 

--- a/runner/handler/service_test.go
+++ b/runner/handler/service_test.go
@@ -3,17 +3,26 @@ package handler
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	mockcomponent "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/runner/component"
+	"opencsg.com/csghub-server/builder/deploy/cluster"
+	"opencsg.com/csghub-server/common/errorx"
+	"opencsg.com/csghub-server/common/types"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	mockcomponent "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/runner/component"
-	"opencsg.com/csghub-server/common/errorx"
-	"opencsg.com/csghub-server/common/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	testcore "k8s.io/client-go/testing"
+	knativefake "knative.dev/serving/pkg/client/clientset/versioned/fake"
 )
 
 func TestK8sHandler_CreateRevisions_Success(t *testing.T) {
@@ -272,4 +281,131 @@ func TestK8sHandler_DeleteKsvcVersion_ServiceComponentError(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusConflict, w.Code)
+}
+
+//type fakeRespWrapper struct {
+//	reader io.ReadCloser
+//}
+//
+//func (f *fakeRespWrapper) Stream(ctx context.Context) (io.ReadCloser, error) {
+//	return f.reader, nil
+//}
+//
+//func (f *fakeRespWrapper) DoRaw(ctx context.Context) ([]byte, error) {
+//	return io.ReadAll(f.reader)
+//}
+//
+//type streamReadCloser struct {
+//	buffs [][]byte // test, miss lock
+//	err   error    // set error
+//}
+//
+//func (s *streamReadCloser) Read(p []byte) (n int, err error) {
+//	if s.err != nil {
+//		return 0, s.err
+//	}
+//
+//	if len(s.buffs) == 0 {
+//		return 0, io.EOF
+//	}
+//
+//	buff := s.buffs[0]
+//	if len(p) >= len(buff) {
+//		n = copy(p, buff)
+//		copy(s.buffs, s.buffs[1:])
+//		s.buffs = s.buffs[:len(s.buffs)-1]
+//	} else {
+//		n = copy(p, buff)
+//		copy(buff, buff[n:])
+//		buff = buff[:len(buff)-n]
+//		s.buffs[0] = buff
+//	}
+//
+//	return n, nil
+//}
+//func (s *streamReadCloser) Close() error {
+//	s.err = io.EOF
+//	return nil
+//}
+
+func Test_readPodLogsFromCluster(t *testing.T) {
+	client := fake.NewClientset()
+
+	status := corev1.PodStatus{
+		Phase: corev1.PodRunning,
+		Conditions: []corev1.PodCondition{
+			{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			},
+		},
+	}
+	var setErr error = nil
+	client.PrependReactor("get", "pods", func(action testcore.Action) (handled bool, ret runtime.Object, err error) {
+		if action.GetSubresource() == "log" {
+			// TODO Based on the code submitted in https://github.com/kubernetes/kubernetes/pull/91485,
+			// the GetLogs() method does not support custom objects; instead, it creates an internal fakerest.RESTClient.
+			// Tests for this functionality will be added once Kubernetes provides native support.
+			return false, nil, nil
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fake-pod",
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "app",
+						Image: "image-test",
+					},
+				},
+			},
+			Status: status,
+		}
+		return true, pod, setErr
+	})
+
+	gin.SetMode(gin.TestMode)
+
+	hfn := func() (*httptest.ResponseRecorder, *gin.Context) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = &http.Request{}
+		return w, c
+	}
+
+	w, c := hfn()
+	h := &K8sHandler{
+		k8sNameSpace: "test-ns",
+	}
+	testCluster := &cluster.Cluster{
+		CID:           "stream-log",
+		ID:            "test",
+		Client:        client,
+		KnativeClient: knativefake.NewSimpleClientset(),
+	}
+
+	h.readPodLogsFromCluster(c, testCluster, "pod-test", "svc-test")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// test pod PodPending
+	status = corev1.PodStatus{
+		Phase: corev1.PodPending,
+		Conditions: []corev1.PodCondition{
+			{
+				Type:   corev1.PodScheduled,
+				Status: corev1.ConditionFalse,
+			},
+		},
+	}
+	w, c = hfn()
+	h.readPodLogsFromCluster(c, testCluster, "pod-test", "svc-test")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	// set error
+	setErr = errors.New("test error")
+	w, c = hfn()
+	h.readPodLogsFromCluster(c, testCluster, "pod-test", "svc-test")
+	require.Equal(t, http.StatusInternalServerError, w.Code)
 }

--- a/runner/utils/flushwriter.go
+++ b/runner/utils/flushwriter.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"io"
+	"net/http"
+)
+
+// Wrap wraps an io.Writer into a writer that flushes after every write if
+// the writer implements the Flusher interface.
+func Wrap(w io.Writer) io.Writer {
+	fw := &flushWriter{
+		writer: w,
+	}
+	if flusher, ok := w.(http.Flusher); ok {
+		fw.flusher = flusher
+	}
+	return fw
+}
+
+// flushWriter provides wrapper for responseWriter with HTTP streaming capabilities
+type flushWriter struct {
+	flusher http.Flusher
+	writer  io.Writer
+}
+
+// Write is a FlushWriter implementation of the io.Writer that sends any buffered
+// data to the client.
+func (fw *flushWriter) Write(p []byte) (n int, err error) {
+	n, err = fw.writer.Write(p)
+	if err != nil {
+		return
+	}
+	if fw.flusher != nil {
+		fw.flusher.Flush()
+	}
+	return
+}


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

- Fix close(nil channel) panic in readPodLogsFromCluster when pod is in Pending state (defer attempted to close a nil channel returned by GetPodLogStream)
 - Fix incorrect HTTP 200 status returned for pending pods; the old code called setResponseHeaderForLogs before the message check, causing the 400 status to be silently overwritten by gin
 - Fix goroutine and k8s connection leak by passing request context to logs.Stream instead of context.Background

 **Improvements**:
 - Replace manual goroutine + channel + 5s polling loop with direct io.ReadCloser stream from k8s client-go, reducing log forwarding latency from 5s to near-zero
 - Simplify defer channel close logic to a single stream.Close() call
 - Replace per-chunk Write/Flush loop with io.Copy + flushWriter wrapper for more efficient streaming

**Special notes for your reviewer:**

- Normal logs streaming should be compatible with WebSocket in general scenarios. Since the frontend working mode is unclear, this part is not implemented for now and marked with TODO in the code.
- The idea of using flushwriter to replace channel logic is referenced from Kubernetes source code. The implementation is copied directly from k8s.io/apiserver/pkg/util/flushwriter. As the code is lightweight and self-contained, we adopt copy migration instead of importing the dependency directly.
- Context lifecycle is managed by http.Request.Context(). Per Go official documentation, there is no explicit guarantee that this context will always be closed properly, and related abnormal cases have been reported (e.g. https://github.com/golang/go/issues/70834). However, mainstream implementations like Kubernetes still rely on this context behavior without obvious runtime issues. We follow the same practice as Kubernetes here.