### PR TITLE
feat: add tpu hardware

### DIFF
--- a/builder/deploy/cluster/cluster_manager.go
+++ b/builder/deploy/cluster/cluster_manager.go
@@ -643,6 +643,10 @@ func getXPULabel(labels map[string]string, config *config.Config) (string, strin
 		//for amd gpu
 		return "amd.com/gpu", "amd.com/gpu.product-name", []string{"amd.com/gpu.vram"}
 	}
+	if _, found := labels["chipltech.com/tpu.product"]; found {
+		//for chipltech tpu
+		return "chipltech.com/dlc-lyp", "chipltech.com/tpu.product", []string{"chipltech.com/tpu.mem"}
+	}
 	//check custom gpu model label
 	if config.Space.GPUModelLabel != "" {
 		var gpuLabels []types.GPUModel

--- a/builder/deploy/cluster/cluster_manager_test.go
+++ b/builder/deploy/cluster/cluster_manager_test.go
@@ -244,6 +244,15 @@ func TestGetXPULabel(t *testing.T) {
 			wantTypeLabel: "nvidia.com/nvidia_name",
 		},
 		{
+			name: "chipltech TPU label",
+			labels: map[string]string{
+				"chipltech.com/tpu.product": "TPU-X1",
+			},
+			config:        &config.Config{},
+			wantCapacity:  "chipltech.com/dlc-lyp",
+			wantTypeLabel: "chipltech.com/tpu.product",
+		},
+		{
 			name:          "no matching label",
 			labels:        map[string]string{},
 			config:        &config.Config{},

--- a/builder/deploy/common/utils.go
+++ b/builder/deploy/common/utils.go
@@ -64,6 +64,9 @@ func UpdateEvaluationEnvHardware(env map[string]string, hardware types.HardWare)
 	} else if hardware.GPGpu.Num != "" {
 		env["GPGPU_NUM"] = hardware.GPGpu.Num
 		xpuNum = hardware.GPGpu.Num
+	} else if hardware.Tpu.Num != "" {
+		env["TPU_NUM"] = hardware.Tpu.Num
+		xpuNum = hardware.Tpu.Num
 	}
 	if xpuNum != "0" {
 		env["GPU_NUM"] = xpuNum
@@ -84,6 +87,8 @@ func ResourceType(hardware types.HardWare) types.ResourceType {
 		resourceType = types.ResourceTypeDCU
 	} else if hardware.GPGpu.Num != "" {
 		resourceType = types.ResourceTypeGPGPU
+	} else if hardware.Tpu.Num != "" {
+		resourceType = types.ResourceTypeTPU
 	}
 	return resourceType
 }
@@ -106,6 +111,9 @@ func GetResourceAndType(hardware types.HardWare) (string, string) {
 	} else if hardware.Dcu.Num != "" {
 		resourceType = hardware.Dcu.Type
 		resource += "·" + hardware.Dcu.Num + "Dcu"
+	} else if hardware.Tpu.Num != "" {
+		resourceType = hardware.Tpu.Type
+		resource += "·" + hardware.Tpu.Num + "Tpu"
 	} else {
 		resourceType = hardware.Cpu.Type
 	}
@@ -115,7 +123,8 @@ func GetResourceAndType(hardware types.HardWare) (string, string) {
 func ContainsGraphicResource(hardware types.HardWare) bool {
 	if hardware.Gpu.Num != "" || hardware.Npu.Num != "" ||
 		hardware.Gcu.Num != "" || hardware.Mlu.Num != "" ||
-		hardware.Dcu.Num != "" || hardware.GPGpu.Num != "" {
+		hardware.Dcu.Num != "" || hardware.GPGpu.Num != "" ||
+		hardware.Tpu.Num != "" {
 		return true
 	}
 	return false
@@ -135,6 +144,8 @@ func GetXPUNumber(hardware types.HardWare) (int, error) {
 		xpuNumStr = hardware.Dcu.Num
 	} else if hardware.GPGpu.Num != "" {
 		xpuNumStr = hardware.GPGpu.Num
+	} else if hardware.Tpu.Num != "" {
+		xpuNumStr = hardware.Tpu.Num
 	}
 	xpuNum, err := strconv.Atoi(xpuNumStr)
 	return xpuNum, err

--- a/builder/deploy/common/utils_test.go
+++ b/builder/deploy/common/utils_test.go
@@ -101,6 +101,22 @@ func TestUpdateEvaluationEnvHardware(t *testing.T) {
 			},
 		},
 		{
+			name: "TPU set when others are empty",
+			env:  make(map[string]string),
+			hardware: types.HardWare{
+				Gpu: types.Processor{Num: ""},
+				Npu: types.Processor{Num: ""},
+				Gcu: types.Processor{Num: ""},
+				Mlu: types.Processor{Num: ""},
+				Dcu: types.Processor{Num: ""},
+				Tpu: types.Processor{Num: "1"},
+			},
+			expected: map[string]string{
+				"TPU_NUM": "1",
+				"GPU_NUM": "1",
+			},
+		},
+		{
 			name: "No hardware set",
 			env:  make(map[string]string),
 			hardware: types.HardWare{
@@ -208,6 +224,14 @@ func TestGetXPUNumber(t *testing.T) {
 				Mlu: types.Processor{Num: "1"},
 			},
 			want:    1,
+			wantErr: false,
+		},
+		{
+			name: "Only Tpu specified",
+			hardware: types.HardWare{
+				Tpu: types.Processor{Num: "3"},
+			},
+			want:    3,
 			wantErr: false,
 		},
 		{
@@ -434,6 +458,18 @@ func TestResourceType(t *testing.T) {
 			},
 			expected: types.ResourceTypeGPU,
 		},
+		{
+			name: "TPU when TPU Num is not empty and others are empty",
+			hardware: types.HardWare{
+				Gpu: types.Processor{Num: ""},
+				Npu: types.Processor{Num: ""},
+				Mlu: types.Processor{Num: ""},
+				Gcu: types.Processor{Num: ""},
+				Dcu: types.Processor{Num: ""},
+				Tpu: types.Processor{Num: "1"},
+			},
+			expected: types.ResourceTypeTPU,
+		},
 	}
 
 	for _, tt := range tests {
@@ -442,6 +478,33 @@ func TestResourceType(t *testing.T) {
 			if actual != tt.expected {
 				t.Errorf("ResourceType() = %v, want %v", actual, tt.expected)
 			}
+		})
+	}
+}
+
+func TestContainsGraphicResource(t *testing.T) {
+	tests := []struct {
+		name     string
+		hardware types.HardWare
+		want     bool
+	}{
+		{
+			name:     "cpu only",
+			hardware: types.HardWare{Cpu: types.CPU{Num: "2"}, Memory: "4Gi"},
+			want:     false,
+		},
+		{
+			name: "tpu is graphic resource",
+			hardware: types.HardWare{
+				Tpu: types.Processor{Num: "1"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ContainsGraphicResource(tt.hardware))
 		})
 	}
 }

--- a/builder/deploy/deployer_resource.go
+++ b/builder/deploy/deployer_resource.go
@@ -174,7 +174,8 @@ func isCPUOnlyWorkload(hardware *types.HardWare) bool {
 		hardware.Gcu.Num == "" &&
 		hardware.Mlu.Num == "" &&
 		hardware.Dcu.Num == "" &&
-		hardware.GPGpu.Num == ""
+		hardware.GPGpu.Num == "" &&
+		hardware.Tpu.Num == ""
 }
 
 func isXPUNode(node types.NodeResourceInfo) bool {

--- a/common/types/hardware.go
+++ b/common/types/hardware.go
@@ -50,6 +50,7 @@ type (
 		Mlu              Processor `json:"mlu,omitempty"`   // cambricon
 		Dcu              Processor `json:"dcu,omitempty"`   // hygon
 		GPGpu            Processor `json:"gpgpu,omitempty"` // iluvatar,metax
+		Tpu              Processor `json:"tpu,omitempty"`   // chipltech
 		Cpu              CPU       `json:"cpu,omitempty"`
 		Memory           string    `json:"memory,omitempty"`
 		EphemeralStorage string    `json:"ephemeral_storage,omitempty"`
@@ -79,6 +80,8 @@ func (h *HardWare) GetResXPUMode() string {
 		xpuProc = h.Dcu
 	case strings.TrimSpace(h.GPGpu.Num) != "":
 		xpuProc = h.GPGpu
+	case strings.TrimSpace(h.Tpu.Num) != "":
+		xpuProc = h.Tpu
 	}
 
 	xpuModel := strings.TrimSpace(xpuProc.Type)

--- a/common/types/space_resource.go
+++ b/common/types/space_resource.go
@@ -15,6 +15,7 @@ const (
 	ResourceTypeGPGPU ResourceType = "gpgpu"
 	ResourceTypeMLU   ResourceType = "mlu"
 	ResourceTypeDCU   ResourceType = "dcu"
+	ResourceTypeTPU   ResourceType = "tpu"
 	PayModeFree       PayMode      = "free"
 	PayModeMinute     PayMode      = "minute"
 	PayModeMonth      PayMode      = "month"
@@ -28,7 +29,8 @@ func ResourceTypeValid(resourceType ResourceType) bool {
 		resourceType == ResourceTypeGCU ||
 		resourceType == ResourceTypeGPGPU ||
 		resourceType == ResourceTypeMLU ||
-		resourceType == ResourceTypeDCU
+		resourceType == ResourceTypeDCU ||
+		resourceType == ResourceTypeTPU
 }
 
 var ResourceTypeValidator validator.Func = func(fl validator.FieldLevel) bool {

--- a/runner/common/resource.go
+++ b/runner/common/resource.go
@@ -38,6 +38,7 @@ func GenerateResources(params rtypes.ResourceGeneratorParams) *rtypes.GeneratedR
 		{hardware.Dcu.Labels},
 		{hardware.GPGpu.Labels},
 		{hardware.Cpu.Labels},
+		{hardware.Tpu.Labels},
 	}
 
 	for _, hw := range hardwareTypes {

--- a/runner/common/resource_ce.go
+++ b/runner/common/resource_ce.go
@@ -21,6 +21,7 @@ func handleAccelerator(hardware types.HardWare, resReq map[corev1.ResourceName]r
 		{hardware.Mlu.ResourceName, hardware.Mlu.Num},
 		{hardware.Dcu.ResourceName, hardware.Dcu.Num},
 		{hardware.GPGpu.ResourceName, hardware.GPGpu.Num},
+		{hardware.Tpu.ResourceName, hardware.Tpu.Num},
 	}
 
 	for _, acc := range accelerators {

--- a/runner/common/resource_ce_test.go
+++ b/runner/common/resource_ce_test.go
@@ -44,6 +44,18 @@ func Test_handleAccelerator_CE(t *testing.T) {
 			},
 		},
 		{
+			name: "tpu with resource name",
+			hardware: types.HardWare{
+				Tpu: types.Processor{
+					Num:          "1",
+					ResourceName: "chipltech.com/dlc-lyp",
+				},
+			},
+			wantReq: map[corev1.ResourceName]resource.Quantity{
+				"chipltech.com/dlc-lyp": resource.MustParse("1"),
+			},
+		},
+		{
 			name: "no resource name",
 			hardware: types.HardWare{
 				Gpu: types.Processor{
@@ -87,6 +99,26 @@ func Test_GenerateResources_CE(t *testing.T) {
 			want: &rtypes.GeneratedResources{
 				ResourceRequirements: map[corev1.ResourceName]resource.Quantity{
 					"nvidia.com/gpu": resource.MustParse("1"),
+				},
+				NodeSelector: map[string]string{},
+				NodeAffinity: nil,
+				Tolerations:  nil,
+			},
+		},
+		{
+			name: "tpu resources with resource name (CE)",
+			hardware: types.HardWare{
+				Tpu: types.Processor{
+					Num:          "2",
+					ResourceName: "chipltech.com/dlc-lyp",
+				},
+			},
+			nodes:     []types.Node{},
+			deployExt: types.DeployExtend{},
+			config:    &config.Config{},
+			want: &rtypes.GeneratedResources{
+				ResourceRequirements: map[corev1.ResourceName]resource.Quantity{
+					"chipltech.com/dlc-lyp": resource.MustParse("2"),
 				},
 				NodeSelector: map[string]string{},
 				NodeAffinity: nil,


### PR DESCRIPTION
**What is this feature?**

本次更新为系统新增了 TPU 设备类型在核心资源链路中的支持与回归测试，主要包括：

新增/完善 TPU 在硬件结构与资源类型中的识别（如 HardWare.Tpu、ResourceTypeTPU 校验）
完善部署与运行时公共逻辑对 TPU 的处理（资源类型推断、资源数量提取、图形资源判断、资源请求生成）
增加 cluster 对 chipltech TPU 节点标签的识别测试
增加 TPU 相关回归测试，覆盖 builder/deploy/common、runner/common、common/types 关键路径

**Special notes for your reviewer:**

保留了 CE 侧“仅 GPU 检测”的现有策略，未改 deployer_ce 的该逻辑
PD 加速器参数相关逻辑本 PR 未扩展到 TPU（当前 TPU 适配 vLLM 不依赖该参数）
新增了 TPU 回归测试文件与用例，重点覆盖：
builder/deploy/common/utils_test.go
runner/common/resource_ce_test.go
builder/deploy/cluster/cluster_manager_test.go