### PR TITLE
fix(aigateway): add backend upstream test endpoint to avoid frontend CORS

### DIFF
--- a/_mocks/opencsg.com/csghub-server/component/mock_LLMServiceComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_LLMServiceComponent.go
@@ -654,6 +654,65 @@ func (_c *MockLLMServiceComponent_ShowPromptConfig_Call) RunAndReturn(run func(c
 	return _c
 }
 
+// TestUpstream provides a mock function with given fields: ctx, req
+func (_m *MockLLMServiceComponent) TestUpstream(ctx context.Context, req *types.TestUpstreamReq) (*types.TestUpstreamResult, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TestUpstream")
+	}
+
+	var r0 *types.TestUpstreamResult
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *types.TestUpstreamReq) (*types.TestUpstreamResult, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *types.TestUpstreamReq) *types.TestUpstreamResult); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.TestUpstreamResult)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *types.TestUpstreamReq) error); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockLLMServiceComponent_TestUpstream_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TestUpstream'
+type MockLLMServiceComponent_TestUpstream_Call struct {
+	*mock.Call
+}
+
+// TestUpstream is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *types.TestUpstreamReq
+func (_e *MockLLMServiceComponent_Expecter) TestUpstream(ctx interface{}, req interface{}) *MockLLMServiceComponent_TestUpstream_Call {
+	return &MockLLMServiceComponent_TestUpstream_Call{Call: _e.mock.On("TestUpstream", ctx, req)}
+}
+
+func (_c *MockLLMServiceComponent_TestUpstream_Call) Run(run func(ctx context.Context, req *types.TestUpstreamReq)) *MockLLMServiceComponent_TestUpstream_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*types.TestUpstreamReq))
+	})
+	return _c
+}
+
+func (_c *MockLLMServiceComponent_TestUpstream_Call) Return(_a0 *types.TestUpstreamResult, _a1 error) *MockLLMServiceComponent_TestUpstream_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockLLMServiceComponent_TestUpstream_Call) RunAndReturn(run func(context.Context, *types.TestUpstreamReq) (*types.TestUpstreamResult, error)) *MockLLMServiceComponent_TestUpstream_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateLLMConfig provides a mock function with given fields: ctx, req
 func (_m *MockLLMServiceComponent) UpdateLLMConfig(ctx context.Context, req *types.UpdateLLMConfigReq) (*types.LLMConfig, error) {
 	ret := _m.Called(ctx, req)

--- a/common/types/llm_service.go
+++ b/common/types/llm_service.go
@@ -169,3 +169,31 @@ type UpdateUpstreamReq struct {
 	LimitPolicy           **UsageLimitPolicy `json:"limit_policy"`
 	Tags                  *map[string]string `json:"tags"`
 }
+
+// TestUpstreamReq is the request to test connectivity to an upstream endpoint.
+// The upstream is identified by its database ID; the backend fetches the
+// upstream's URL, model name and auth header from the database so that the
+// frontend never needs to send credentials or perform cross-origin requests.
+type TestUpstreamReq struct {
+	ID int64 `json:"id" binding:"required"`
+}
+
+// TestUpstreamResult is the result of an upstream connectivity test.
+// The request summary is masked so that sensitive header values (such as
+// API keys) are never leaked to the frontend.
+type TestUpstreamResult struct {
+	// Request is the masked request summary (url, method, headers, body).
+	Request string `json:"request"`
+	// OK indicates whether the upstream returned a 2xx status code.
+	OK bool `json:"ok"`
+	// Status is the HTTP status code returned by the upstream.
+	Status int `json:"status"`
+	// StatusText is the HTTP status text returned by the upstream.
+	StatusText string `json:"status_text"`
+	// Content is the extracted text content from the upstream response.
+	Content string `json:"content"`
+	// ResponseBody is the raw response body from the upstream.
+	ResponseBody string `json:"response_body"`
+	// Error is the error message when the test fails (e.g. timeout, network error).
+	Error string `json:"error,omitempty"`
+}

--- a/component/llm_service.go
+++ b/component/llm_service.go
@@ -36,6 +36,11 @@ type LLMServiceComponent interface {
 	UpdateUpstream(ctx context.Context, req *types.UpdateUpstreamReq) (*types.UpstreamConfig, error)
 	// DeleteUpstream deletes an upstream by ID.
 	DeleteUpstream(ctx context.Context, id int64) error
+	// TestUpstream tests connectivity to an upstream endpoint by ID. It fetches
+	// the upstream config from the database, sends a simple "hi" prompt to the
+	// upstream URL (supporting /chat/completions and /responses endpoints), and
+	// returns the masked request summary, response status, body and content.
+	TestUpstream(ctx context.Context, req *types.TestUpstreamReq) (*types.TestUpstreamResult, error)
 }
 
 type llmServiceComponentImpl struct {

--- a/component/llm_service_upstream.go
+++ b/component/llm_service_upstream.go
@@ -1,0 +1,269 @@
+
+package component
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"opencsg.com/csghub-server/common/errorx"
+	"opencsg.com/csghub-server/common/types"
+)
+
+// upstreamTestTimeout is the maximum duration allowed for an upstream
+// connectivity test request.
+const upstreamTestTimeout = 30 * time.Second
+
+// maskedAuthSecret is the placeholder used to redact sensitive header values
+// in the request summary returned to the frontend.
+const maskedAuthSecret = "................."
+
+// endpointChatCompletions and endpointResponses are the two supported
+// upstream endpoint path suffixes.
+const (
+	endpointChatCompletions = "/chat/completions"
+	endpointResponses       = "/responses"
+)
+
+// testEndpointKind describes which protocol the upstream URL speaks.
+type testEndpointKind int
+
+const (
+	endpointKindUnsupported testEndpointKind = iota
+	endpointKindChatCompletions
+	endpointKindResponses
+)
+
+// detectEndpointKind inspects the upstream URL path and returns the
+// supported endpoint kind. Only /chat/completions and /responses are
+// supported; anything else returns endpointKindUnsupported.
+func detectEndpointKind(rawURL string) testEndpointKind {
+	// Trim query string and fragment before checking the path suffix.
+	u := rawURL
+	if idx := strings.IndexAny(u, "?#"); idx >= 0 {
+		u = u[:idx]
+	}
+	u = strings.TrimRight(u, "/")
+	switch {
+	case strings.HasSuffix(u, endpointChatCompletions):
+		return endpointKindChatCompletions
+	case strings.HasSuffix(u, endpointResponses):
+		return endpointKindResponses
+	default:
+		return endpointKindUnsupported
+	}
+}
+
+// parseAuthHeader parses the upstream auth_header field into a map of
+// HTTP headers. The auth_header is either a plain "Bearer xxx" string or
+// a JSON object string like {"Authorization":"Bearer xxx"}.
+func parseAuthHeader(authHeader string) (map[string]string, error) {
+	trimmed := strings.TrimSpace(authHeader)
+	if trimmed == "" {
+		return map[string]string{}, nil
+	}
+
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		// Not a JSON object; treat as a bare Authorization value.
+		return map[string]string{
+			"Authorization": trimmed,
+		}, nil
+	}
+
+	headers := make(map[string]string, len(parsed))
+	for k, v := range parsed {
+		key := strings.TrimSpace(k)
+		if key == "" {
+			continue
+		}
+		headers[key] = v
+	}
+	return headers, nil
+}
+
+// maskRequestHeaders returns a copy of the headers with sensitive values
+// redacted. Only Content-Type is preserved verbatim; all other values
+// (including Authorization / apikey) are masked.
+func maskRequestHeaders(headers map[string]string) map[string]string {
+	masked := make(map[string]string, len(headers))
+	for k, v := range headers {
+		switch strings.ToLower(k) {
+		case "content-type":
+			masked[k] = v
+		default:
+			masked[k] = maskedAuthSecret
+		}
+	}
+	return masked
+}
+
+// buildTestRequestBody constructs the request body for the given endpoint
+// kind. A simple "hi" prompt is used for both protocols.
+func buildTestRequestBody(kind testEndpointKind, modelName string) (map[string]any, error) {
+	switch kind {
+	case endpointKindChatCompletions:
+		return map[string]any{
+			"model":    modelName,
+			"messages": []map[string]string{{"role": "user", "content": "hi"}},
+			"stream":   false,
+		}, nil
+	case endpointKindResponses:
+		return map[string]any{
+			"model":  modelName,
+			"input":  "hi",
+			"stream": false,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported upstream endpoint, only %s and %s are supported", endpointChatCompletions, endpointResponses)
+	}
+}
+
+// requestSummary is the masked request representation sent to the frontend.
+type requestSummary struct {
+	URL     string            `json:"url"`
+	Method  string            `json:"method"`
+	Headers map[string]string `json:"headers"`
+	Body    map[string]any    `json:"body"`
+}
+
+// doUpstreamTest performs the HTTP request against the upstream and returns
+// the test result. It is split from TestUpstream so it can be unit tested
+// with an injectable http.Client.
+func doUpstreamTest(ctx context.Context, client *http.Client, url string, kind testEndpointKind, modelName string, authHeaders map[string]string) (*types.TestUpstreamResult, error) {
+	body, err := buildTestRequestBody(kind, modelName)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	requestHeaders := map[string]string{
+		"Content-Type": "application/json",
+	}
+	for k, v := range authHeaders {
+		requestHeaders[k] = v
+	}
+
+	summary := requestSummary{
+		URL:     url,
+		Method:  http.MethodPost,
+		Headers: maskRequestHeaders(requestHeaders),
+		Body:    body,
+	}
+	summaryBytes, _ := json.MarshalIndent(summary, "", "  ")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return &types.TestUpstreamResult{
+			Request: string(summaryBytes),
+			Error:   err.Error(),
+		}, nil
+	}
+	for k, v := range requestHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return &types.TestUpstreamResult{
+			Request: string(summaryBytes),
+			Error:   err.Error(),
+		}, nil
+	}
+	defer resp.Body.Close()
+
+	rawBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &types.TestUpstreamResult{
+			Request:     string(summaryBytes),
+			OK:          false,
+			Status:      resp.StatusCode,
+			StatusText:  resp.Status,
+			ResponseBody: "",
+			Error:       fmt.Sprintf("failed to read response body: %v", err),
+		}, nil
+	}
+	rawText := string(rawBytes)
+
+	var prettyBody string
+	var jsonObj map[string]any
+	if json.Unmarshal(rawBytes, &jsonObj) == nil {
+		pretty, _ := json.MarshalIndent(jsonObj, "", "  ")
+		prettyBody = string(pretty)
+	} else {
+		prettyBody = rawText
+	}
+
+	return &types.TestUpstreamResult{
+		Request:      string(summaryBytes),
+		OK:           resp.StatusCode >= 200 && resp.StatusCode < 300,
+		Status:       resp.StatusCode,
+		StatusText:   resp.Status,
+		Content:      rawText,
+		ResponseBody: prettyBody,
+	}, nil
+}
+
+// TestUpstream tests connectivity to an upstream endpoint by ID.
+func (s *llmServiceComponentImpl) TestUpstream(ctx context.Context, req *types.TestUpstreamReq) (*types.TestUpstreamResult, error) {
+	dbUp, err := s.upstreamStore.GetByID(ctx, req.ID)
+	if err != nil {
+		return nil, fmt.Errorf("upstream not found: %w", err)
+	}
+
+	url := strings.TrimSpace(dbUp.URL)
+	if url == "" {
+		return nil, fmt.Errorf("upstream url is empty")
+	}
+	modelName := strings.TrimSpace(dbUp.ModelName)
+	if modelName == "" {
+		return nil, fmt.Errorf("upstream model_name is empty")
+	}
+
+	kind := detectEndpointKind(url)
+	if kind == endpointKindUnsupported {
+		return nil, errorx.ReqParamInvalid(
+			fmt.Errorf("unsupported upstream endpoint, only %s and %s are supported", endpointChatCompletions, endpointResponses),
+			nil,
+		)
+	}
+
+	authHeaders, err := parseAuthHeader(dbUp.AuthHeader)
+	if err != nil {
+		return nil, fmt.Errorf("invalid auth_header: %w", err)
+	}
+
+	testCtx, cancel := context.WithTimeout(ctx, upstreamTestTimeout)
+	defer cancel()
+
+	client := &http.Client{Timeout: upstreamTestTimeout}
+
+	slog.InfoContext(ctx, "testing upstream connection",
+		slog.Int64("upstream_id", dbUp.ID),
+		slog.String("url", url),
+		slog.String("endpoint_kind", endpointKindString(kind)),
+	)
+
+	return doUpstreamTest(testCtx, client, url, kind, modelName, authHeaders)
+}
+
+func endpointKindString(k testEndpointKind) string {
+	switch k {
+	case endpointKindChatCompletions:
+		return endpointChatCompletions
+	case endpointKindResponses:
+		return endpointResponses
+	default:
+		return "unsupported"
+	}
+}

--- a/component/llm_service_upstream_test.go
+++ b/component/llm_service_upstream_test.go
@@ -1,0 +1,299 @@
+package component
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	mockdatabase "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/errorx"
+	"opencsg.com/csghub-server/common/types"
+)
+
+func TestDetectEndpointKind(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    testEndpointKind
+	}{
+		{"chat completions", "https://api.example.com/v1/chat/completions", endpointKindChatCompletions},
+		{"chat completions trailing slash", "https://api.example.com/v1/chat/completions/", endpointKindChatCompletions},
+		{"chat completions with query", "https://api.example.com/v1/chat/completions?foo=bar", endpointKindChatCompletions},
+		{"responses", "https://api.example.com/v1/responses", endpointKindResponses},
+		{"responses trailing slash", "https://api.example.com/v1/responses/", endpointKindResponses},
+		{"responses with fragment", "https://api.example.com/v1/responses#frag", endpointKindResponses},
+		{"unsupported root", "https://api.example.com/v1", endpointKindUnsupported},
+		{"unsupported embeddings", "https://api.example.com/v1/embeddings", endpointKindUnsupported},
+		{"empty", "", endpointKindUnsupported},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, detectEndpointKind(tt.url))
+		})
+	}
+}
+
+func TestParseAuthHeader(t *testing.T) {
+	t.Run("empty returns empty map", func(t *testing.T) {
+		headers, err := parseAuthHeader("")
+		require.NoError(t, err)
+		require.Empty(t, headers)
+	})
+	t.Run("json object", func(t *testing.T) {
+		headers, err := parseAuthHeader(`{"Authorization":"Bearer secret","X-Api-Key":"key123"}`)
+		require.NoError(t, err)
+		require.Equal(t, "Bearer secret", headers["Authorization"])
+		require.Equal(t, "key123", headers["X-Api-Key"])
+	})
+	t.Run("bare bearer string", func(t *testing.T) {
+		headers, err := parseAuthHeader("Bearer mytoken")
+		require.NoError(t, err)
+		require.Equal(t, "Bearer mytoken", headers["Authorization"])
+	})
+	t.Run("whitespace only", func(t *testing.T) {
+		headers, err := parseAuthHeader("   ")
+		require.NoError(t, err)
+		require.Empty(t, headers)
+	})
+}
+
+func TestMaskRequestHeaders(t *testing.T) {
+	headers := map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "Bearer secret",
+		"X-Api-Key":     "key123",
+	}
+	masked := maskRequestHeaders(headers)
+	require.Equal(t, "application/json", masked["Content-Type"])
+	require.Equal(t, maskedAuthSecret, masked["Authorization"])
+	require.Equal(t, maskedAuthSecret, masked["X-Api-Key"])
+}
+
+func TestBuildTestRequestBody(t *testing.T) {
+	t.Run("chat completions", func(t *testing.T) {
+		body, err := buildTestRequestBody(endpointKindChatCompletions, "gpt-4")
+		require.NoError(t, err)
+		require.Equal(t, "gpt-4", body["model"])
+		require.Equal(t, false, body["stream"])
+		require.NotContains(t, body, "max_tokens")
+		messages, ok := body["messages"].([]map[string]string)
+		require.True(t, ok)
+		require.Len(t, messages, 1)
+		require.Equal(t, "hi", messages[0]["content"])
+	})
+	t.Run("responses", func(t *testing.T) {
+		body, err := buildTestRequestBody(endpointKindResponses, "gpt-4o")
+		require.NoError(t, err)
+		require.Equal(t, "gpt-4o", body["model"])
+		require.Equal(t, "hi", body["input"])
+		require.Equal(t, false, body["stream"])
+		require.NotContains(t, body, "max_output_tokens")
+	})
+	t.Run("unsupported returns error", func(t *testing.T) {
+		_, err := buildTestRequestBody(endpointKindUnsupported, "model")
+		require.Error(t, err)
+	})
+}
+
+func TestDoUpstreamTest_ChatCompletionsSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"hello"}}]}`))
+	}))
+	defer srv.Close()
+
+	url := srv.URL + "/v1/chat/completions"
+	client := &http.Client{}
+	result, err := doUpstreamTest(context.Background(), client, url, endpointKindChatCompletions, "gpt-4", map[string]string{"Authorization": "Bearer secret"})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.OK)
+	require.Equal(t, http.StatusOK, result.Status)
+	// Content is the raw upstream response, not parsed
+	require.Contains(t, result.Content, "hello")
+
+	// Verify the request summary is masked
+	var summary requestSummary
+	require.NoError(t, json.Unmarshal([]byte(result.Request), &summary))
+	require.Equal(t, url, summary.URL)
+	require.Equal(t, http.MethodPost, summary.Method)
+	require.Equal(t, maskedAuthSecret, summary.Headers["Authorization"])
+	require.Equal(t, "application/json", summary.Headers["Content-Type"])
+}
+
+func TestDoUpstreamTest_ResponsesSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"output":[{"content":[{"type":"output_text","text":"resp"}]}]}`))
+	}))
+	defer srv.Close()
+
+	url := srv.URL + "/v1/responses"
+	client := &http.Client{}
+	result, err := doUpstreamTest(context.Background(), client, url, endpointKindResponses, "gpt-4o", map[string]string{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.OK)
+	require.Contains(t, result.Content, "resp")
+}
+
+func TestDoUpstreamTest_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key"}}`))
+	}))
+	defer srv.Close()
+
+	url := srv.URL + "/v1/chat/completions"
+	client := &http.Client{}
+	result, err := doUpstreamTest(context.Background(), client, url, endpointKindChatCompletions, "gpt-4", map[string]string{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.OK)
+	require.Equal(t, http.StatusUnauthorized, result.Status)
+	// Content is the raw upstream response including errors
+	require.Contains(t, result.Content, "invalid api key")
+}
+
+func TestDoUpstreamTest_NetworkError(t *testing.T) {
+	// Use a closed server to simulate a connection error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	url := srv.URL + "/v1/chat/completions"
+	client := &http.Client{}
+	result, err := doUpstreamTest(context.Background(), client, url, endpointKindChatCompletions, "gpt-4", map[string]string{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.OK)
+	require.NotEmpty(t, result.Error)
+}
+
+func TestLLMServiceComponent_TestUpstream_ChatCompletions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer srv.Close()
+
+	ctx := context.TODO()
+	upstreamStore := mockdatabase.NewMockUpstreamStore(t)
+	upstreamStore.EXPECT().GetByID(ctx, int64(42)).Return(&database.Upstream{
+		ID:        42,
+		URL:       srv.URL + "/v1/chat/completions",
+		ModelName: "gpt-4",
+		AuthHeader: `{"Authorization":"Bearer secret"}`,
+	}, nil)
+
+	mc := &llmServiceComponentImpl{
+		upstreamStore: upstreamStore,
+	}
+	result, err := mc.TestUpstream(ctx, &types.TestUpstreamReq{ID: 42})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.OK)
+	require.Contains(t, result.Content, "ok")
+}
+
+func TestLLMServiceComponent_TestUpstream_Responses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"output":[{"content":[{"type":"output_text","text":"resp"}]}]}`))
+	}))
+	defer srv.Close()
+
+	ctx := context.TODO()
+	upstreamStore := mockdatabase.NewMockUpstreamStore(t)
+	upstreamStore.EXPECT().GetByID(ctx, int64(43)).Return(&database.Upstream{
+		ID:        43,
+		URL:       srv.URL + "/v1/responses",
+		ModelName: "gpt-4o",
+		AuthHeader: "",
+	}, nil)
+
+	mc := &llmServiceComponentImpl{
+		upstreamStore: upstreamStore,
+	}
+	result, err := mc.TestUpstream(ctx, &types.TestUpstreamReq{ID: 43})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.OK)
+	require.Contains(t, result.Content, "resp")
+}
+
+func TestLLMServiceComponent_TestUpstream_UnsupportedEndpoint(t *testing.T) {
+	ctx := context.TODO()
+	upstreamStore := mockdatabase.NewMockUpstreamStore(t)
+	upstreamStore.EXPECT().GetByID(ctx, int64(44)).Return(&database.Upstream{
+		ID:        44,
+		URL:       "https://api.example.com/v1/embeddings",
+		ModelName: "text-embedding",
+	}, nil)
+
+	mc := &llmServiceComponentImpl{
+		upstreamStore: upstreamStore,
+	}
+	_, err := mc.TestUpstream(ctx, &types.TestUpstreamReq{ID: 44})
+	require.Error(t, err)
+	// The unsupported endpoint error must be an errorx custom error so the
+	// handler can map it to a 422 response instead of 500.
+	customErr, ok := errorx.GetFirstCustomError(err)
+	require.True(t, ok, "expected an errorx custom error for unsupported endpoint")
+	require.ErrorIs(t, customErr, errorx.ErrReqParamInvalid)
+}
+
+func TestLLMServiceComponent_TestUpstream_EmptyURL(t *testing.T) {
+	ctx := context.TODO()
+	upstreamStore := mockdatabase.NewMockUpstreamStore(t)
+	upstreamStore.EXPECT().GetByID(ctx, int64(45)).Return(&database.Upstream{
+		ID:        45,
+		URL:       "  ",
+		ModelName: "gpt-4",
+	}, nil)
+
+	mc := &llmServiceComponentImpl{
+		upstreamStore: upstreamStore,
+	}
+	_, err := mc.TestUpstream(ctx, &types.TestUpstreamReq{ID: 45})
+	require.Error(t, err)
+}
+
+func TestLLMServiceComponent_TestUpstream_EmptyModelName(t *testing.T) {
+	ctx := context.TODO()
+	upstreamStore := mockdatabase.NewMockUpstreamStore(t)
+	upstreamStore.EXPECT().GetByID(ctx, int64(46)).Return(&database.Upstream{
+		ID:        46,
+		URL:       "https://api.example.com/v1/chat/completions",
+		ModelName: "",
+	}, nil)
+
+	mc := &llmServiceComponentImpl{
+		upstreamStore: upstreamStore,
+	}
+	_, err := mc.TestUpstream(ctx, &types.TestUpstreamReq{ID: 46})
+	require.Error(t, err)
+}
+
+func TestLLMServiceComponent_TestUpstream_NotFound(t *testing.T) {
+	ctx := context.TODO()
+	upstreamStore := mockdatabase.NewMockUpstreamStore(t)
+	upstreamStore.EXPECT().GetByID(ctx, int64(99)).Return(nil, fmt.Errorf("record not found"))
+
+	mc := &llmServiceComponentImpl{
+		upstreamStore: upstreamStore,
+	}
+	_, err := mc.TestUpstream(ctx, &types.TestUpstreamReq{ID: 99})
+	require.Error(t, err)
+}


### PR DESCRIPTION
Summary:
- Adds a new `POST /config/upstreams/:id/test` backend endpoint to resolve frontend CORS errors when testing commercial API upstreams.
- The backend securely fetches upstream configurations, sends a test request with a 30s timeout, and returns a sanitized summary including status codes and extracted content.
- Resolves issue #2310 by enabling reliable connection testing for both `/chat/completions` and `/responses` endpoint formats without exposing sensitive credentials.