### PR TITLE
fix: skip metadata scan failures in push callback

### DIFF
--- a/component/callback/git_callback.go
+++ b/component/callback/git_callback.go
@@ -565,13 +565,13 @@ func (c *gitCallbackComponentImpl) updateModelMetadata(ctx context.Context, file
 	modelInfo, err := c.runtimeArchComponent.UpdateModelMetadata(ctx, repo)
 	if err != nil {
 		slog.Warn("fail to update model metadata", slog.Any("error", err), slog.Any("repo path", repo.Path))
-		return err
+		return nil
 	}
 	err = c.runtimeArchComponent.UpdateRuntimeFrameworkTag(ctx, modelInfo, repo)
 	if err != nil {
 		slog.Warn("fail to update runtime framework tag", slog.Any("error", err), slog.Any("repo path", repo.Path))
 	}
-	return err
+	return nil
 }
 
 // check if the repo is valid for runtime framework

--- a/component/callback/git_callback_test.go
+++ b/component/callback/git_callback_test.go
@@ -2,6 +2,7 @@ package callback
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -207,6 +208,30 @@ func TestGitCallbackComponentImpl_UpdateRepoInfos(t *testing.T) {
 		gc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "namespace", "repo").Return(repo, nil)
 		gc.mocks.runtimeArchComponent.EXPECT().UpdateModelMetadata(ctx, repo).Return(modelInfo, nil)
 		gc.mocks.runtimeArchComponent.EXPECT().UpdateRuntimeFrameworkTag(ctx, modelInfo, repo).Return(nil)
+
+		err := gc.UpdateRepoInfos(context.Background(), req)
+		assert.NoError(t, err)
+	})
+
+	t.Run("should skip model metadata update failure", func(t *testing.T) {
+		gc := initializeTestGitCallbackComponent(context.Background(), t)
+		req := &types.GiteaCallbackPushReq{
+			Ref: "refs/heads/main",
+			Repository: types.GiteaCallbackPushReq_Repository{
+				FullName: "models_namespace/repo",
+			},
+			Commits: []types.GiteaCallbackPushReq_Commit{
+				{
+					Modified: []string{"config.json"},
+					Removed:  []string{"old_file.txt"},
+				},
+			},
+		}
+
+		gc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "namespace", "repo").Return(repo, nil)
+		gc.mocks.runtimeArchComponent.EXPECT().UpdateModelMetadata(ctx, repo).Return(nil, errors.New("unsupported model format unknown"))
+		gc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "namespace", "repo").Return(repo, nil)
+		gc.mocks.tagComponent.EXPECT().UpdateLibraryTags(ctx, types.ModelTagScope, "namespace", "repo", "old_file.txt", "").Return(nil)
 
 		err := gc.UpdateRepoInfos(context.Background(), req)
 		assert.NoError(t, err)


### PR DESCRIPTION
Summary:
- Skips metadata scan failures in the push callback to prevent unnecessary errors when metadata is unavailable.
- Resolves issue #1303 by ensuring the push process continues smoothly even when metadata scanning encounters issues.