### PR TITLE
Namespace exists use downcase check

### DIFF
--- a/builder/store/database/namespace.go
+++ b/builder/store/database/namespace.go
@@ -60,7 +60,7 @@ func (s *NamespaceStoreImpl) Exists(ctx context.Context, path string) (exists bo
 	return s.db.Operator.Core.
 		NewSelect().
 		Model(&namespace).
-		Where("path =?", path).
+		Where("LOWER(path) = LOWER(?)", path).
 		Exists(ctx)
 }
 


### PR DESCRIPTION
Summary:
- Fixes an issue where organizations with different casing (e.g., "qwen" vs "Qwen") were treated as distinct entities.
- Implements case-insensitive namespace validation by converting paths to lowercase before existence checks to prevent duplicate organization creation.