### PR TITLE
Add namespace exists check before create namespace mapping

### DIFF
--- a/api/handler/mirror_namespace_mapping.go
+++ b/api/handler/mirror_namespace_mapping.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -8,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	"opencsg.com/csghub-server/component"
 )
@@ -48,7 +50,11 @@ func (h *MirrorNamespaceMappingHandler) Create(ctx *gin.Context) {
 	ms, err := h.mirrorNamespaceMapping.Create(ctx.Request.Context(), msReq)
 	if err != nil {
 		slog.ErrorContext(ctx.Request.Context(), "Failed to create mirror namespace mapping", "error", err)
-		httpbase.ServerError(ctx, err)
+		if errors.Is(err, errorx.ErrTargetNamespaceNotFound) {
+			httpbase.BadRequestWithExt(ctx, err)
+		} else {
+			httpbase.ServerError(ctx, err)
+		}
 		return
 	}
 	httpbase.OK(ctx, ms)
@@ -110,8 +116,12 @@ func (h *MirrorNamespaceMappingHandler) Update(ctx *gin.Context) {
 	msReq.ID = msId
 	ms, err := h.mirrorNamespaceMapping.Update(ctx.Request.Context(), msReq)
 	if err != nil {
-		slog.ErrorContext(ctx.Request.Context(), "Failed to get mirror namespace mappings", "error", err)
-		httpbase.ServerError(ctx, err)
+		slog.ErrorContext(ctx.Request.Context(), "Failed to update mirror namespace mapping", "error", err)
+		if errors.Is(err, errorx.ErrTargetNamespaceNotFound) {
+			httpbase.BadRequestWithExt(ctx, err)
+		} else {
+			httpbase.ServerError(ctx, err)
+		}
 		return
 	}
 	httpbase.OK(ctx, ms)

--- a/common/errorx/error_req.go
+++ b/common/errorx/error_req.go
@@ -1,5 +1,7 @@
 package errorx
 
+import "fmt"
+
 const errReqPrefix = "REQ-ERR"
 
 const (
@@ -17,6 +19,9 @@ const (
 
 	errReqContentTypeUnsupported
 	errRateLimitExceeded
+	errLimitedIPLocation
+	errCaptchaIncorrect
+	errTargetNamespaceNotFound
 )
 
 var (
@@ -118,6 +123,45 @@ var (
 	//
 	// zh-HK: 請求過於頻繁，需要驗證碼
 	ErrRateLimitExceeded = CustomError{prefix: errReqPrefix, code: errRateLimitExceeded}
+
+	// requests from this IP location are restricted, captcha is required
+	//
+	// Description: Requests originating from this IP location are restricted. To proceed, please complete a captcha verification.
+	//
+	// Description_ZH: 来自此IP位置的请求受到限制。要继续操作，请完成验证码验证。
+	//
+	// en-US: Requests from this IP location are restricted, captcha is required
+	//
+	// zh-CN: 来自该IP位置的请求受限，需要验证码
+	//
+	// zh-HK: 來自該IP位置的請求受限，需要驗證碼
+	ErrLimitedIPLocation = CustomError{prefix: errReqPrefix, code: errLimitedIPLocation}
+
+	// captcha verification failed
+	//
+	// Description: The provided captcha verification failed. Please try again with a valid captcha.
+	//
+	// Description_ZH: 提供的验证码验证失败。请使用有效的验证码重试。
+	//
+	// en-US: Captcha verification failed
+	//
+	// zh-CN: 验证码验证失败
+	//
+	// zh-HK: 驗證碼驗證失敗
+	ErrCaptchaIncorrect = CustomError{prefix: errReqPrefix, code: errCaptchaIncorrect}
+
+	// the target namespace does not exist
+	//
+	// Description: The specified target namespace was not found in the system. Please verify the namespace exists before creating or updating the mapping.
+	//
+	// Description_ZH: 指定的目标命名空间在系统中不存在。请在创建或更新映射之前确认命名空间存在。
+	//
+	// en-US: Target namespace not found
+	//
+	// zh-CN: 目标命名空间不存在
+	//
+	// zh-HK: 目標命名空間不存在
+	ErrTargetNamespaceNotFound = CustomError{prefix: errReqPrefix, code: errTargetNamespaceNotFound}
 )
 
 func BadRequest(originErr error, ext context) error {
@@ -144,5 +188,14 @@ func ReqParamInvalid(err error, ext context) error {
 		code:    errReqParamInvalid,
 		err:     err,
 		context: ext,
+	}
+}
+
+func TargetNamespaceNotFound(namespace string) error {
+	return CustomError{
+		prefix:  errReqPrefix,
+		code:    errTargetNamespaceNotFound,
+		err:     fmt.Errorf("target namespace not found: %s", namespace),
+		context: Ctx().Set("target_namespace", namespace),
 	}
 }

--- a/common/i18n/en-US/err_req.json
+++ b/common/i18n/en-US/err_req.json
@@ -8,6 +8,15 @@
     "error.REQ-ERR-10": {
         "other": "Too many requests, captcha is required"
     },
+    "error.REQ-ERR-11": {
+        "other": "Requests from this IP location are restricted, captcha is required"
+    },
+    "error.REQ-ERR-12": {
+        "other": "Captcha verification failed"
+    },
+    "error.REQ-ERR-13": {
+        "other": "Target namespace not found"
+    },
     "error.REQ-ERR-2": {
         "other": "Request body cannot be empty"
     },

--- a/common/i18n/zh-CN/err_req.json
+++ b/common/i18n/zh-CN/err_req.json
@@ -8,6 +8,15 @@
     "error.REQ-ERR-10": {
         "other": "请求过于频繁，需要验证码"
     },
+    "error.REQ-ERR-11": {
+        "other": "来自该IP位置的请求受限，需要验证码"
+    },
+    "error.REQ-ERR-12": {
+        "other": "验证码验证失败"
+    },
+    "error.REQ-ERR-13": {
+        "other": "目标命名空间不存在"
+    },
     "error.REQ-ERR-2": {
         "other": "请求体不能为空"
     },

--- a/common/i18n/zh-HK/err_req.json
+++ b/common/i18n/zh-HK/err_req.json
@@ -8,6 +8,15 @@
     "error.REQ-ERR-10": {
         "other": "請求過於頻繁，需要驗證碼"
     },
+    "error.REQ-ERR-11": {
+        "other": "來自該IP位置的請求受限，需要驗證碼"
+    },
+    "error.REQ-ERR-12": {
+        "other": "驗證碼驗證失敗"
+    },
+    "error.REQ-ERR-13": {
+        "other": "目標命名空間不存在"
+    },
     "error.REQ-ERR-2": {
         "other": "請求體不能為空"
     },

--- a/component/mirror_namespace_mapping.go
+++ b/component/mirror_namespace_mapping.go
@@ -6,12 +6,14 @@ import (
 
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 )
 
 type mirrorNamespaceMappingComponentImpl struct {
 	mirrorNamespaceMappingStore database.MirrorNamespaceMappingStore
 	userStore                   database.UserStore
+	namespaceStore              database.NamespaceStore
 }
 
 type MirrorNamespaceMappingComponent interface {
@@ -26,10 +28,19 @@ func NewMirrorNamespaceMappingComponent(config *config.Config) (MirrorNamespaceM
 	return &mirrorNamespaceMappingComponentImpl{
 		mirrorNamespaceMappingStore: database.NewMirrorNamespaceMappingStore(),
 		userStore:                   database.NewUserStore(),
+		namespaceStore:              database.NewNamespaceStore(),
 	}, nil
 }
 
 func (c *mirrorNamespaceMappingComponentImpl) Create(ctx context.Context, req types.CreateMirrorNamespaceMappingReq) (*database.MirrorNamespaceMapping, error) {
+	exists, err := c.namespaceStore.Exists(ctx, req.TargetNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check target namespace existence, error: %w", err)
+	}
+	if !exists {
+		return nil, errorx.TargetNamespaceNotFound(req.TargetNamespace)
+	}
+
 	var mnm database.MirrorNamespaceMapping
 	mnm.SourceNamespace = req.SourceNamespace
 	mnm.TargetNamespace = req.TargetNamespace
@@ -59,6 +70,16 @@ func (c *mirrorNamespaceMappingComponentImpl) Index(ctx context.Context) ([]data
 	return mnm, nil
 }
 func (c *mirrorNamespaceMappingComponentImpl) Update(ctx context.Context, req types.UpdateMirrorNamespaceMappingReq) (*database.MirrorNamespaceMapping, error) {
+	if req.TargetNamespace != nil {
+		exists, err := c.namespaceStore.Exists(ctx, *req.TargetNamespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check target namespace existence, error: %w", err)
+		}
+		if !exists {
+			return nil, errorx.TargetNamespaceNotFound(*req.TargetNamespace)
+		}
+	}
+
 	var mnm database.MirrorNamespaceMapping
 	mnm.ID = req.ID
 	if req.SourceNamespace != nil {

--- a/component/mirror_namespace_mapping_test.go
+++ b/component/mirror_namespace_mapping_test.go
@@ -12,6 +12,7 @@ import (
 func TestMirrorNamespaceMappingComponent_Create(t *testing.T) {
 	ctx := context.TODO()
 	mc := initializeTestMirrorNamespaceMappingComponent(ctx, t)
+	mc.mocks.stores.NamespaceMock().EXPECT().Exists(ctx, "u").Return(true, nil)
 	mc.mocks.stores.MirrorNamespaceMappingMock().EXPECT().Create(ctx, &database.MirrorNamespaceMapping{
 		SourceNamespace: "sn",
 		TargetNamespace: "u",
@@ -52,6 +53,7 @@ func TestMirrorNamespaceMappingComponent_Index(t *testing.T) {
 func TestMirrorNamespaceMappingComponent_Update(t *testing.T) {
 	ctx := context.TODO()
 	mc := initializeTestMirrorNamespaceMappingComponent(ctx, t)
+	mc.mocks.stores.NamespaceMock().EXPECT().Exists(ctx, "u").Return(true, nil)
 	mc.mocks.stores.MirrorNamespaceMappingMock().EXPECT().Update(ctx, &database.MirrorNamespaceMapping{
 		ID:              1,
 		SourceNamespace: "sn",

--- a/component/wireset_ce.go
+++ b/component/wireset_ce.go
@@ -102,6 +102,7 @@ func NewTestSpaceResourceComponent(config *config.Config, stores *tests.MockStor
 func NewTestMirrorNamespaceMappingComponent(config *config.Config, stores *tests.MockStores) *mirrorNamespaceMappingComponentImpl {
 	return &mirrorNamespaceMappingComponentImpl{
 		mirrorNamespaceMappingStore: stores.MirrorNamespaceMapping,
+		namespaceStore:              stores.Namespace,
 	}
 }
 


### PR DESCRIPTION
Summary:
- Added a pre-creation validation check to verify the existence of the target namespace before creating a namespace mapping.
- Prevents mirror creation failures and error messages caused by attempting to map non-existent namespaces.