### PR TITLE
Sort by create_ed or submit_time for query bills

### DIFF
--- a/accounting/component/metering_test.go
+++ b/accounting/component/metering_test.go
@@ -64,7 +64,7 @@ func TestMeteringComponent_ListMeteringByUserIDAndDate(t *testing.T) {
 
 	req := types.ActStatementsReq{
 		UserUUID:  "test-user-uuid",
-		Scene:     int(types.SceneModelInference),
+		Scene:     types.SceneModelInference,
 		StartTime: "2024-01-01",
 		EndTime:   "2024-12-31",
 		Per:       10,

--- a/accounting/handler/metering.go
+++ b/accounting/handler/metering.go
@@ -51,7 +51,7 @@ func (mh *MeteringHandler) QueryMeteringStatementByUserID(ctx *gin.Context) {
 
 	req := types.ActStatementsReq{
 		UserUUID:     userID,
-		Scene:        scene,
+		Scene:        types.SceneType(scene),
 		InstanceName: instance_name,
 		StartTime:    startTime,
 		EndTime:      endTime,
@@ -89,7 +89,7 @@ func (mh *MeteringHandler) QueryMeteringStatByDate(ctx *gin.Context) {
 	}
 
 	req := types.ActStatementsReq{
-		Scene:     scene,
+		Scene:     types.SceneType(scene),
 		StartTime: startDate + " 00:00:00",
 		EndTime:   endDate + " 23:59:59",
 	}

--- a/api/handler/accounting.go
+++ b/api/handler/accounting.go
@@ -95,7 +95,7 @@ func (ah *AccountingHandler) QueryMeteringStatementByUserID(ctx *gin.Context) {
 	req := types.ActStatementsReq{
 		CurrentUser:  currentUser,
 		UserUUID:     userUUID,
-		Scene:        scene,
+		Scene:        types.SceneType(scene),
 		InstanceName: instance_name,
 		StartTime:    startTime,
 		EndTime:      endTime,

--- a/builder/store/database/account_bill.go
+++ b/builder/store/database/account_bill.go
@@ -100,17 +100,32 @@ func (s *accountBillStoreImpl) ListByUserIDAndDate(ctx context.Context, req type
 		ColumnExpr("sum(voucher_value) as voucher_value").
 		ColumnExpr("sum(cash_value) as cash_value").
 		ColumnExpr("sum(duration) as duration").
-		ColumnExpr("sum(count) as count").
-		ColumnExpr("MIN(bill_date) as bill_date").
-		Where("bill_date >= ? and bill_date <= ?", req.StartDate, req.EndDate).
-		Where("user_uuid = ?", req.TargetUUID).
-		Where("scene = ?", req.Scene)
+		ColumnExpr("sum(count) as count")
+
+	switch req.Scene {
+	case types.SceneEvaluation:
+		q = q.ColumnExpr("d.submit_time as created_at")
+		q = q.Join("LEFT JOIN argo_workflows d ON customer_id = d.task_id")
+	case types.SceneSpace, types.SceneModelInference, types.SceneModelFinetune:
+		q = q.ColumnExpr("d.created_at as created_at")
+		q = q.Join("LEFT JOIN deploys d ON customer_id = d.svc_name")
+	}
+
+	q = q.Where("account_bill.bill_date >= ? and account_bill.bill_date <= ?", req.StartDate, req.EndDate).
+		Where("account_bill.user_uuid = ?", req.TargetUUID).
+		Where("account_bill.scene = ?", req.Scene)
 
 	if len(req.InstanceName) > 0 {
 		q = q.Where("LOWER(customer_id) LIKE ?", "%"+strings.ToLower(req.InstanceName)+"%")
 	}
-
-	q = q.Group("customer_id", "data_type", "resolution", "unit_type")
+	switch req.Scene {
+	case types.SceneEvaluation:
+		q = q.Group("customer_id", "data_type", "resolution", "unit_type", "d.submit_time")
+	case types.SceneSpace, types.SceneModelInference, types.SceneModelFinetune:
+		q = q.Group("customer_id", "data_type", "resolution", "unit_type", "d.created_at")
+	default:
+		q = q.Group("customer_id", "data_type", "resolution", "unit_type")
+	}
 
 	count, err := q.Count(ctx)
 	if err != nil {
@@ -132,8 +147,14 @@ func (s *accountBillStoreImpl) ListByUserIDAndDate(ctx context.Context, req type
 	if err != nil {
 		return AccountBillRes{}, errorx.HandleDBError(err, nil)
 	}
-
-	err = q.Order("bill_date DESC").Order("customer_id").Limit(req.Per).Offset((req.Page-1)*req.Per).Scan(ctx, &res)
+	switch req.Scene {
+	case types.SceneEvaluation:
+		q = q.Order("d.submit_time DESC NULLS LAST")
+	case types.SceneSpace, types.SceneModelInference, types.SceneModelFinetune:
+		q = q.Order("d.created_at DESC NULLS LAST")
+	}
+	q = q.Order("customer_id")
+	err = q.Limit(req.Per).Offset((req.Page-1)*req.Per).Scan(ctx, &res)
 	if err != nil {
 		return AccountBillRes{}, errorx.HandleDBError(err, nil)
 	}

--- a/builder/store/database/account_bill_test.go
+++ b/builder/store/database/account_bill_test.go
@@ -17,6 +17,7 @@ func TestAccountBillStore_List(t *testing.T) {
 	ctx := context.TODO()
 
 	dt := time.Date(2022, 11, 22, 3, 0, 0, 0, time.UTC)
+
 	bills := []database.AccountBill{
 		{
 			// included
@@ -88,10 +89,102 @@ func TestAccountBillStore_List(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 2, len(res.Data))
 	expectedData := []types.ITEM{
-		{Consumption: 21, InstanceName: "c2", Value: 20, PromptToken: 0, CompletionToken: 0},
 		{Consumption: 31, InstanceName: "c1", Value: 28, PromptToken: 0, CompletionToken: 0},
+		{Consumption: 21, InstanceName: "c2", Value: 20, PromptToken: 0, CompletionToken: 0},
 	}
 	require.Equal(t, expectedData, res.Data)
+
+}
+
+func TestAccountBillStore_ListWithDeployJoin(t *testing.T) {
+	db := tests.InitTestDB()
+	defer db.Close()
+	ctx := context.TODO()
+
+	dt := time.Date(2022, 11, 22, 3, 0, 0, 0, time.UTC)
+
+	deploys := []database.Deploy{
+		{
+			SvcName:   "c2",
+			SpaceID:   1,
+			Status:    1,
+			GitPath:   "path",
+			GitBranch: "main",
+			Template:  "tpl",
+			Hardware:  "hw",
+			UserID:    1,
+		},
+		{
+			SvcName:   "c1",
+			SpaceID:   2,
+			Status:    1,
+			GitPath:   "path",
+			GitBranch: "main",
+			Template:  "tpl",
+			Hardware:  "hw",
+			UserID:    2,
+		},
+	}
+	_, err := db.Operator.Core.NewInsert().Model(&deploys).Exec(ctx)
+	require.Nil(t, err)
+
+	// Give deploys distinct created_at values so d.created_at DESC is deterministic
+	_, err = db.Operator.Core.NewUpdate().
+		Model((*database.Deploy)(nil)).
+		Set("created_at = ?", dt.Add(2*24*time.Hour)).
+		Where("svc_name = 'c2'").
+		Exec(ctx)
+	require.Nil(t, err)
+	_, err = db.Operator.Core.NewUpdate().
+		Model((*database.Deploy)(nil)).
+		Set("created_at = ?", dt.Add(1*24*time.Hour)).
+		Where("svc_name = 'c1'").
+		Exec(ctx)
+	require.Nil(t, err)
+
+	bills := []database.AccountBill{
+		{
+			UserUUID: "foo", Value: 3, Consumption: 4,
+			BillDate: dt.Add(-3 * 24 * time.Hour), CustomerID: "c1",
+			Scene: types.SceneSpace,
+		},
+		{
+			UserUUID: "foo", Value: 5, Consumption: 6,
+			BillDate: dt.Add(-1 * 24 * time.Hour), CustomerID: "c1",
+			Scene: types.SceneSpace,
+		},
+		{
+			UserUUID: "foo", Value: 20, Consumption: 21,
+			BillDate: dt.Add(2 * 24 * time.Hour), CustomerID: "c1",
+			Scene: types.SceneSpace,
+		},
+		{
+			UserUUID: "foo", Value: 20, Consumption: 21,
+			BillDate: dt.Add(3 * 24 * time.Hour), CustomerID: "c2",
+			Scene: types.SceneSpace,
+		},
+	}
+	_, err = db.Operator.Core.NewInsert().Model(&bills).Exec(ctx)
+	require.Nil(t, err)
+
+	store := database.NewAccountBillStoreWithDB(db)
+	res, err := store.ListByUserIDAndDate(ctx, types.AcctBillsReq{
+		TargetUUID: "foo",
+		Scene:      types.SceneSpace,
+		StartDate:  dt.Add(-5 * 24 * time.Hour).Format(time.RFC3339),
+		EndDate:    dt.Add(5 * 24 * time.Hour).Format(time.RFC3339),
+		Per:        20,
+		Page:       1,
+	})
+	require.Nil(t, err)
+	require.Equal(t, 2, len(res.Data))
+	// c2 deploy has later created_at, so d.created_at DESC puts c2 first
+	require.Equal(t, "c2", res.Data[0].InstanceName)
+	require.Equal(t, float64(21), res.Data[0].Consumption)
+	require.Equal(t, float64(20), res.Data[0].Value)
+	require.Equal(t, "c1", res.Data[1].InstanceName)
+	require.Equal(t, float64(31), res.Data[1].Consumption)
+	require.Equal(t, float64(28), res.Data[1].Value)
 
 }
 

--- a/builder/store/database/account_statement_test.go
+++ b/builder/store/database/account_statement_test.go
@@ -426,7 +426,7 @@ func TestAccountStatementStore_ListGroupedByUserAndSku(t *testing.T) {
 
 	res, total, err := store.ListStatementByUserAndSku(ctx, types.ActStatementsReq{
 		UserUUID:     "user1",
-		Scene:        int(types.SceneCashCharge),
+		Scene:        types.SceneCashCharge,
 		InstanceName: "cust1",
 		StartTime:    dt.Add(-time.Hour).Format(time.RFC3339),
 		EndTime:      dt.Add(time.Hour).Format(time.RFC3339),

--- a/common/types/accounting.go
+++ b/common/types/accounting.go
@@ -248,15 +248,15 @@ type AcctSubscriptionNotify struct {
 }
 
 type ActStatementsReq struct {
-	CurrentUser  string `json:"current_user"`
-	UserUUID     string `json:"user_uuid"`
-	Scene        int    `json:"scene"`
-	InstanceName string `json:"instance_name"`
-	StartTime    string `json:"start_time"`
-	EndTime      string `json:"end_time"`
-	Per          int    `json:"per"`
-	Page         int    `json:"page"`
-	UserName     string `json:"user_name"`
+	CurrentUser  string    `json:"current_user"`
+	UserUUID     string    `json:"user_uuid"`
+	Scene        SceneType `json:"scene"`
+	InstanceName string    `json:"instance_name"`
+	StartTime    string    `json:"start_time"`
+	EndTime      string    `json:"end_time"`
+	Per          int       `json:"per"`
+	Page         int       `json:"page"`
+	UserName     string    `json:"user_name"`
 }
 
 type AcctBillsReq struct {

--- a/component/cluster.go
+++ b/component/cluster.go
@@ -180,7 +180,7 @@ func (c *clusterComponentImpl) GetDeploys(ctx context.Context, req types.DeployR
 			continue
 		}
 		req2 := types.ActStatementsReq{
-			Scene:        int(scene),
+			Scene:        scene,
 			UserUUID:     deploy.UserUUID,
 			StartTime:    deploy.CreatedAt.Format(time.DateTime),
 			EndTime:      time.Now().Format(time.DateTime),


### PR DESCRIPTION
Summary:
- Modified `ListByUserIDAndDate` to sort bills by actual instance creation time (`deploy.created_at` or `argo_workflows.submit_time`) instead of bill date, ensuring the list order matches the chronological creation of instances.
- Updated the `Scene` field type from `int` to `SceneType` across handlers and components, and refactored the query to use LEFT JOINs for direct retrieval of creation timestamps without secondary lookups.