### PR TITLE
Allow disabling vLLM enforce-eager for serverless deployments.

### DIFF
--- a/api/workflow/activity/deploy_activity.go
+++ b/api/workflow/activity/deploy_activity.go
@@ -819,7 +819,9 @@ func (a *DeployActivity) makeDeployEnv(ctx context.Context, hardware types.HardW
 		envMap["HF_ENDPOINT"] = a.cfg.ModelDownloadEndpoint // "https://hub.opencsg-stg.com/"
 		envMap["HF_HUB_OFFLINE"] = "1"
 		envMap["HF_TASK"] = string(deployInfo.Task)
-		envMap["VLLM_ENFORCE_EAGER"] = "1"
+		if vllmEnforceEagerEnabled(deployInfo.EngineArgs) {
+			envMap["VLLM_ENFORCE_EAGER"] = "1"
+		}
 	}
 
 	if deployInfo.Type == types.FinetuneType {
@@ -847,6 +849,28 @@ func (a *DeployActivity) makeDeployEnv(ctx context.Context, hardware types.HardW
 	}
 
 	return envMap, nil
+}
+
+// vllmEnforceEagerEnabled reports whether single-node vLLM should run with --enforce-eager.
+// Disabled by default; set engine_args "enforce-eager" to enable/true/1 to turn it on.
+func vllmEnforceEagerEnabled(engineArgs string) bool {
+	if engineArgs == "" {
+		return false
+	}
+	argValuesMap, err := utilcommon.JsonStrToMap(engineArgs)
+	if err != nil {
+		return false
+	}
+	value, ok := argValuesMap["enforce-eager"]
+	if !ok {
+		return false
+	}
+	switch value {
+	case "enable", "true", "1":
+		return true
+	default:
+		return false
+	}
 }
 
 // getModelArchitecture reads the model architecture from metadata

--- a/api/workflow/activity/deploy_activity_test.go
+++ b/api/workflow/activity/deploy_activity_test.go
@@ -583,3 +583,28 @@ func TestDeploy(t *testing.T) {
 	require.NoError(t, err)
 
 }
+
+func TestVLLMEnforceEagerEnabled(t *testing.T) {
+	tests := []struct {
+		name       string
+		engineArgs string
+		want       bool
+	}{
+		{name: "empty engine args defaults to disabled", engineArgs: "", want: false},
+		{name: "missing enforce-eager key defaults to disabled", engineArgs: `{"max-model-len":"8192"}`, want: false},
+		{name: "disable turns off enforce-eager", engineArgs: `{"enforce-eager":"disable"}`, want: false},
+		{name: "false turns off enforce-eager", engineArgs: `{"enforce-eager":"false"}`, want: false},
+		{name: "zero turns off enforce-eager", engineArgs: `{"enforce-eager":"0"}`, want: false},
+		{name: "empty value turns off enforce-eager", engineArgs: `{"enforce-eager":""}`, want: false},
+		{name: "enable keeps enforce-eager on", engineArgs: `{"enforce-eager":"enable"}`, want: true},
+		{name: "true keeps enforce-eager on", engineArgs: `{"enforce-eager":"true"}`, want: true},
+		{name: "one keeps enforce-eager on", engineArgs: `{"enforce-eager":"1"}`, want: true},
+		{name: "invalid json defaults to disabled", engineArgs: "not-json", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, vllmEnforceEagerEnabled(tt.engineArgs))
+		})
+	}
+}

--- a/configs/inference/amd-vllm.json
+++ b/configs/inference/amd-vllm.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "enforce-eager",
-      "value": "enable",
+      "value": "disable",
       "format": "--enforce-eager"
     },
     {
@@ -382,6 +382,7 @@
     "DeepseekV32ForCausalLM": "deepseek_v32",
     "DeepseekV4ForCausalLM": "deepseek_v4",
     "Ernie4_5ForCausalLM": "ernie45",
+    "GlmMoeDsaForCausalLM": "glm47",
     "Glm4ForCausalLM": "glm47",
     "Glm4MoeForCausalLM": "glm45",
     "GptOssForCausalLM": "openai",

--- a/configs/inference/nvidia-vllm.json
+++ b/configs/inference/nvidia-vllm.json
@@ -53,6 +53,11 @@
       "format": "--cpu-offload-gb %s"
     },
     {
+      "name": "data-parallel-size",
+      "value": "1",
+      "format": "--data-parallel-size %s"
+    },
+    {
       "name": "pipeline-parallel-size",
       "value": "1",
       "format": "--pipeline-parallel-size %s"
@@ -89,7 +94,7 @@
     },
     {
       "name": "enforce-eager",
-      "value": "enable",
+      "value": "disable",
       "format": "--enforce-eager"
     },
     {
@@ -101,6 +106,11 @@
       "name": "enable-tool-calling",
       "value": "disable",
       "format": "--enable-auto-tool-choice"
+    },
+    {
+      "name": "enable-expert-parallel",
+      "value": "disable",
+      "format": "--enable-expert-parallel"
     },
     {
       "name": "limit-mm-per-prompt",
@@ -214,6 +224,7 @@
     "DeepseekV3ForCausalLM": "deepseek_v3",
     "DeepseekV31ForCausalLM": "deepseek_v31",
     "DeepseekR1ForCausalLM": "deepseek_r1",
+    "GlmMoeDsaForCausalLM": "glm47",
     "GraniteForCausalLM": "granite",
     "HermesForCausalLM": "hermes",
     "InternLMForCausalLM": "internlm",

--- a/configs/inference/vllm.json
+++ b/configs/inference/vllm.json
@@ -295,7 +295,7 @@
     },
     {
       "name": "enforce-eager",
-      "value": "enable",
+      "value": "disable",
       "format": "--enforce-eager"
     },
     {
@@ -410,6 +410,7 @@
     "DeepseekV32ForCausalLM": "deepseek_v32",
     "DeepseekV4ForCausalLM": "deepseek_v4",
     "Ernie4_5ForCausalLM": "ernie45",
+    "GlmMoeDsaForCausalLM": "glm47",
     "Glm4ForCausalLM": "glm47",
     "Glm4MoeForCausalLM": "glm45",
     "GptOssForCausalLM": "openai",


### PR DESCRIPTION
Summary:
- Enables disabling vLLM's `enforce-eager` mode specifically for serverless deployments to optimize inference performance.
- Introduces a new configuration option to allow flexible control over eager execution behavior without affecting other deployment types.