### PR TITLE
feat: add scenarios field to space resources and support auto allocate sandbox resource

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_SpaceResourceStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_SpaceResourceStore.go
@@ -424,6 +424,65 @@ func (_c *MockSpaceResourceStore_FindByName_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// FindByScenarios provides a mock function with given fields: ctx, scenarios
+func (_m *MockSpaceResourceStore) FindByScenarios(ctx context.Context, scenarios []string) ([]database.SpaceResource, error) {
+	ret := _m.Called(ctx, scenarios)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindByScenarios")
+	}
+
+	var r0 []database.SpaceResource
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []string) ([]database.SpaceResource, error)); ok {
+		return rf(ctx, scenarios)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []string) []database.SpaceResource); ok {
+		r0 = rf(ctx, scenarios)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.SpaceResource)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = rf(ctx, scenarios)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockSpaceResourceStore_FindByScenarios_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindByScenarios'
+type MockSpaceResourceStore_FindByScenarios_Call struct {
+	*mock.Call
+}
+
+// FindByScenarios is a helper method to define mock.On call
+//   - ctx context.Context
+//   - scenarios []string
+func (_e *MockSpaceResourceStore_Expecter) FindByScenarios(ctx interface{}, scenarios interface{}) *MockSpaceResourceStore_FindByScenarios_Call {
+	return &MockSpaceResourceStore_FindByScenarios_Call{Call: _e.mock.On("FindByScenarios", ctx, scenarios)}
+}
+
+func (_c *MockSpaceResourceStore_FindByScenarios_Call) Run(run func(ctx context.Context, scenarios []string)) *MockSpaceResourceStore_FindByScenarios_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]string))
+	})
+	return _c
+}
+
+func (_c *MockSpaceResourceStore_FindByScenarios_Call) Return(_a0 []database.SpaceResource, _a1 error) *MockSpaceResourceStore_FindByScenarios_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockSpaceResourceStore_FindByScenarios_Call) RunAndReturn(run func(context.Context, []string) ([]database.SpaceResource, error)) *MockSpaceResourceStore_FindByScenarios_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Index provides a mock function with given fields: ctx, filter, per, page
 func (_m *MockSpaceResourceStore) Index(ctx context.Context, filter types.SpaceResourceFilter, per int, page int) ([]database.SpaceResource, int, error) {
 	ret := _m.Called(ctx, filter, per, page)

--- a/builder/store/database/migrations/20260703120000_add_scenarios_to_space_resources.down.sql
+++ b/builder/store/database/migrations/20260703120000_add_scenarios_to_space_resources.down.sql
@@ -1,0 +1,5 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE space_resources DROP COLUMN IF EXISTS scenarios;

--- a/builder/store/database/migrations/20260703120000_add_scenarios_to_space_resources.up.sql
+++ b/builder/store/database/migrations/20260703120000_add_scenarios_to_space_resources.up.sql
@@ -1,0 +1,5 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE space_resources ADD COLUMN IF NOT EXISTS scenarios text[] DEFAULT '{}';

--- a/builder/store/database/space_resource.go
+++ b/builder/store/database/space_resource.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/uptrace/bun/dialect/pgdialect"
+
 	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 )
@@ -23,6 +25,7 @@ type SpaceResourceStore interface {
 	FindAll(ctx context.Context) ([]SpaceResource, error)
 	FindAllResourceTypes(ctx context.Context, clusterId string) ([]string, error)
 	FindByHardwareType(ctx context.Context, hardwareType string) ([]SpaceResource, error)
+	FindByScenarios(ctx context.Context, scenarios []string) ([]SpaceResource, error)
 }
 
 func NewSpaceResourceStore() SpaceResourceStore {
@@ -34,10 +37,11 @@ func NewSpaceResourceStoreWithDB(db *DB) SpaceResourceStore {
 }
 
 type SpaceResource struct {
-	ID        int64  `bun:",pk,autoincrement" json:"id"`
-	Name      string `bun:",notnull" json:"name"`
-	Resources string `bun:",notnull" json:"resources"`
-	ClusterID string `bun:",notnull" json:"cluster_id"`
+	ID        int64    `bun:",pk,autoincrement" json:"id"`
+	Name      string   `bun:",notnull" json:"name"`
+	Resources string   `bun:",notnull" json:"resources"`
+	ClusterID string   `bun:",notnull" json:"cluster_id"`
+	Scenarios []string `bun:",array" json:"scenarios"`
 	times
 }
 
@@ -67,6 +71,9 @@ func (s *spaceResourceStoreImpl) Index(ctx context.Context, filter types.SpaceRe
 }
 
 func (s *spaceResourceStoreImpl) Create(ctx context.Context, input SpaceResource) (*SpaceResource, error) {
+	if input.Scenarios == nil {
+		input.Scenarios = []string{}
+	}
 	res, err := s.db.Core.NewInsert().Model(&input).Exec(ctx, &input)
 	if err := assertAffectedOneRow(res, err); err != nil {
 		err = errorx.HandleDBError(err, errorx.Ctx().
@@ -174,6 +181,17 @@ func (s *spaceResourceStoreImpl) FindByHardwareType(ctx context.Context, hardwar
 	var result []SpaceResource
 	err := s.db.Operator.Core.NewSelect().Model(&result).
 		Where("EXISTS (SELECT 1 FROM jsonb_each(resources::jsonb) WHERE value->>'type' = ?)", hardwareType).
+		Scan(ctx)
+	if err != nil {
+		return nil, errorx.HandleDBError(err, nil)
+	}
+	return result, nil
+}
+
+func (s *spaceResourceStoreImpl) FindByScenarios(ctx context.Context, scenarios []string) ([]SpaceResource, error) {
+	var result []SpaceResource
+	err := s.db.Operator.Core.NewSelect().Model(&result).
+		Where("scenarios && ?", pgdialect.Array(scenarios)).
 		Scan(ctx)
 	if err != nil {
 		return nil, errorx.HandleDBError(err, nil)

--- a/common/types/sandbox.go
+++ b/common/types/sandbox.go
@@ -18,18 +18,20 @@ type SandboxVolume struct {
 type SandboxCreateRequest struct {
 	UUID         string            `json:"-"`
 	Image        string            `json:"image" binding:"required"`
-	ResourceID   int64             `json:"resource_id" binding:"required"`
+	ResourceID   int64             `json:"resource_id"`
 	SandboxName  string            `json:"sandbox_name" binding:"required"`
 	Environments map[string]string `json:"environments,omitempty"`
 	Volumes      []SandboxVolume   `json:"volumes,omitempty"`
 	Port         int               `json:"port,omitempty"`
 	Timeout      int               `json:"timeout,omitempty"`
+	MinCPU       string            `json:"min_cpu"`
+	MinMemory    string            `json:"min_memory"`
 }
 
 type SandboxUpdateRequest struct {
 	UUID         string            `json:"-"`
 	Image        string            `json:"image" binding:"required"`
-	ResourceID   int64             `json:"resource_id" binding:"required"`
+	ResourceID   int64             `json:"resource_id"`
 	Environments map[string]string `json:"environments,omitempty"`
 	Volumes      []SandboxVolume   `json:"volumes,omitempty"`
 	Port         int               `json:"port,omitempty"`

--- a/common/types/space_resource.go
+++ b/common/types/space_resource.go
@@ -6,6 +6,7 @@ import (
 
 type ResourceType string
 type PayMode string
+type ScenarioType string
 
 const (
 	ResourceTypeCPU   ResourceType = "cpu"
@@ -20,6 +21,8 @@ const (
 	PayModeMinute     PayMode      = "minute"
 	PayModeMonth      PayMode      = "month"
 	PayModeYear       PayMode      = "year"
+
+	ScenarioSandbox ScenarioType = "sandbox"
 )
 
 func ResourceTypeValid(resourceType ResourceType) bool {
@@ -53,18 +56,21 @@ type SpaceResource struct {
 	OrderDetailId       int64                     `json:"order_detail_id"`
 	AvailableStatusList []ResourceAvailableStatus `json:"available_status_list"`
 	PriceUndefined      bool                      `json:"price_undefined"`
+	Scenarios           []string                  `json:"scenarios"`
 }
 
 type CreateSpaceResourceReq struct {
-	Name      string `json:"name" binding:"required"`
-	Resources string `json:"resources" binding:"required"`
-	ClusterID string `json:"cluster_id" binding:"required"`
+	Name      string   `json:"name" binding:"required"`
+	Resources string   `json:"resources" binding:"required"`
+	ClusterID string   `json:"cluster_id" binding:"required"`
+	Scenarios []string `json:"scenarios"`
 }
 
 type UpdateSpaceResourceReq struct {
-	ID        int64  `json:"-"`
-	Name      string `json:"name"`
-	Resources string `json:"resources"`
+	ID        int64    `json:"-"`
+	Name      string   `json:"name"`
+	Resources string   `json:"resources"`
+	Scenarios []string `json:"scenarios"`
 }
 
 type SpaceResourceIndexReq struct {

--- a/component/space_resource.go
+++ b/component/space_resource.go
@@ -49,6 +49,23 @@ func validateResources(resources string) error {
 	return nil
 }
 
+func sanitizeScenarios(scenarios []string) []string {
+	if scenarios == nil {
+		return []string{}
+	}
+	seen := make(map[string]bool)
+	result := make([]string, 0, len(scenarios))
+	for _, s := range scenarios {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		result = append(result, s)
+	}
+	return result
+}
+
 func (c *spaceResourceComponentImpl) Index(ctx context.Context, req *types.SpaceResourceIndexReq) ([]types.SpaceResource, int, error) {
 	var result []types.SpaceResource
 	var total int
@@ -100,6 +117,10 @@ func (c *spaceResourceComponentImpl) Index(ctx context.Context, req *types.Space
 				}
 			}
 			resourceType := common.ResourceType(hardware)
+			scenarios := r.Scenarios
+			if scenarios == nil {
+				scenarios = []string{}
+			}
 			singleClusterResult = append(singleClusterResult, types.SpaceResource{
 				ID:                  r.ID,
 				ClusterID:           r.ClusterID,
@@ -108,6 +129,7 @@ func (c *spaceResourceComponentImpl) Index(ctx context.Context, req *types.Space
 				Resources:           r.Resources,
 				IsAvailable:         isAvailable,
 				Type:                resourceType,
+				Scenarios:           scenarios,
 				AvailableStatusList: availableStatusList,
 			})
 			resourceCount++
@@ -144,16 +166,25 @@ func (c *spaceResourceComponentImpl) Update(ctx context.Context, req *types.Upda
 	sr.Name = req.Name
 	sr.Resources = req.Resources
 
+	if req.Scenarios != nil {
+		sr.Scenarios = sanitizeScenarios(req.Scenarios)
+	}
+
 	sr, err = c.spaceResourceStore.Update(ctx, *sr)
 	if err != nil {
 		slog.Error("error updating space resource", slog.Any("error", err))
 		return nil, err
 	}
 
+	scenarios := sr.Scenarios
+	if scenarios == nil {
+		scenarios = []string{}
+	}
 	result := &types.SpaceResource{
 		ID:        sr.ID,
 		Name:      sr.Name,
 		Resources: sr.Resources,
+		Scenarios: scenarios,
 	}
 
 	return result, nil
@@ -167,6 +198,7 @@ func (c *spaceResourceComponentImpl) Create(ctx context.Context, req *types.Crea
 		Name:      req.Name,
 		Resources: req.Resources,
 		ClusterID: req.ClusterID,
+		Scenarios: sanitizeScenarios(req.Scenarios),
 	}
 	res, err := c.spaceResourceStore.Create(ctx, sr)
 	if err != nil {
@@ -174,10 +206,15 @@ func (c *spaceResourceComponentImpl) Create(ctx context.Context, req *types.Crea
 		return nil, err
 	}
 
+	scenariosResult := res.Scenarios
+	if scenariosResult == nil {
+		scenariosResult = []string{}
+	}
 	result := &types.SpaceResource{
 		ID:        res.ID,
 		Name:      res.Name,
 		Resources: res.Resources,
+		Scenarios: scenariosResult,
 	}
 
 	return result, nil
@@ -216,11 +253,16 @@ func (c *spaceResourceComponentImpl) ListAll(ctx context.Context) ([]types.Space
 
 	result := make([]types.SpaceResource, 0, len(dbResources))
 	for _, r := range dbResources {
+		scenarios := r.Scenarios
+		if scenarios == nil {
+			scenarios = []string{}
+		}
 		result = append(result, types.SpaceResource{
 			ID:        r.ID,
 			Name:      r.Name,
 			ClusterID: r.ClusterID,
 			Resources: r.Resources,
+			Scenarios: scenarios,
 		})
 	}
 

--- a/component/space_resource_ce_test.go
+++ b/component/space_resource_ce_test.go
@@ -35,7 +35,7 @@ func TestSpaceResourceComponent_Index(t *testing.T) {
 	require.Equal(t, []types.SpaceResource{
 		{
 			ID: 1, Name: "sr", Resources: `{"memory": "1000", "gpu": {"num": "5"}}`,
-			IsAvailable: false, Type: "gpu",
+			IsAvailable: false, Type: "gpu", Scenarios: []string{},
 		},
 	}, data)
 

--- a/component/space_resource_test.go
+++ b/component/space_resource_test.go
@@ -70,6 +70,7 @@ func TestSpaceResourceComponent_Update(t *testing.T) {
 		ID:        1,
 		Name:      "n",
 		Resources: validResourcesJSON,
+		Scenarios: []string{},
 	}, data)
 }
 
@@ -93,7 +94,8 @@ func TestSpaceResourceComponent_Create(t *testing.T) {
 		Name:      "n",
 		Resources: validResourcesJSON,
 		ClusterID: "c",
-	}).Return(&database.SpaceResource{ID: 1, Name: "n", Resources: validResourcesJSON}, nil)
+		Scenarios: []string{},
+	}).Return(&database.SpaceResource{ID: 1, Name: "n", Resources: validResourcesJSON, Scenarios: []string{}}, nil)
 
 	data, err := sc.Create(ctx, &types.CreateSpaceResourceReq{
 		Name:      "n",
@@ -105,6 +107,7 @@ func TestSpaceResourceComponent_Create(t *testing.T) {
 		ID:        1,
 		Name:      "n",
 		Resources: validResourcesJSON,
+		Scenarios: []string{},
 	}, data)
 }
 
@@ -187,8 +190,8 @@ func TestSpaceResourceComponent_ListAll(t *testing.T) {
 		resources, err := sc.ListAll(ctx)
 		require.Nil(t, err)
 		require.Equal(t, []types.SpaceResource{
-			{ID: 1, Name: "resource1", ClusterID: "c1", Resources: "{}"},
-			{ID: 2, Name: "resource2", ClusterID: "c2", Resources: "{}"},
+			{ID: 1, Name: "resource1", ClusterID: "c1", Resources: "{}", Scenarios: []string{}},
+			{ID: 2, Name: "resource2", ClusterID: "c2", Resources: "{}", Scenarios: []string{}},
 		}, resources)
 	})
 	t.Run("error listing all resources", func(t *testing.T) {


### PR DESCRIPTION
Summary:
- Added a `scenarios` field to `space_resources` and updated related types to enable marking resources with specific use cases like "sandbox".
- Implemented automatic sandbox resource allocation that selects the optimal resource based on minimum CPU/memory requirements when `resource_id` is not specified.
- Ensures backward compatibility by maintaining existing logic when a specific `resource_id` is provided during sandbox creation.