### PR TITLE
update modal pricing with sku resolution and description in aigateway

### DIFF
--- a/aigateway/types/openai.go
+++ b/aigateway/types/openai.go
@@ -308,11 +308,13 @@ type ModelTokenPrice struct {
 
 // ModelModalPrice is a unit-based media generation price.
 type ModelModalPrice struct {
-	Currency     string  `json:"currency,omitempty"`
-	PricePerUnit float64 `json:"price_per_unit,omitempty"`
-	SkuUnit      int64   `json:"sku_unit,omitempty"`
-	SkuUnitType  string  `json:"sku_unit_type,omitempty"`
-	Resolution   string  `json:"resolution,omitempty"`
+	Currency      string  `json:"currency,omitempty"`
+	PricePerUnit  float64 `json:"price_per_unit,omitempty"`
+	SkuUnit       int64   `json:"sku_unit,omitempty"`
+	SkuUnitType   string  `json:"sku_unit_type,omitempty"`
+	Resolution    string  `json:"resolution,omitempty"`
+	SkuResolution string  `json:"sku_resolution,omitempty"`
+	SkuDesc       string  `json:"sku_desc,omitempty"`
 }
 
 // ModelScenePrice is Metadata["pricing"]: serverless and external_llm use token and modal generation prices.


### PR DESCRIPTION
Summary:
- Added `sku_resolution` field to `ModelModalPrice` to expose the original resolution value for billing matching.
- Mapped `ModelModalPrice.resolution` to `p.SkuDesc` to provide the SKU description required by the frontend.