### PR TITLE
Optimize avatar validation logic

### DIFF
--- a/user/component/user.go
+++ b/user/component/user.go
@@ -308,6 +308,13 @@ func (c *userComponentImpl) UpdateByUUID(ctx context.Context, req *types.UpdateU
 		return errorx.ErrUserNotFound
 	}
 	var oldUser = *user
+
+	if req.Avatar != nil && *req.Avatar != "" && *req.Avatar != user.Avatar {
+		if err := common.ValidateImageURL(*req.Avatar); err != nil {
+			return errorx.ReqParamInvalid(err, errorx.Ctx().Set("param", "avatar"))
+		}
+	}
+
 	opUserName := req.OpUser
 	var opUser database.User
 	if user.Username != opUserName {

--- a/user/component/user_test.go
+++ b/user/component/user_test.go
@@ -479,6 +479,7 @@ func TestUserComponent_UpdateByUUID_NoSyncWhenOnlyOtherFieldsChanged(t *testing.
 		Username:    "user1",
 		Email:       "user1@example.com",
 		RegProvider: "casdoor",
+		Avatar:      "https://example.com/avatar.jpg",
 	}
 	mockUserStore.EXPECT().FindByUUID(mock.Anything, "user1").Return(user, nil)
 	mockUserStore.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -591,6 +592,7 @@ func TestUserComponent_UpdateByUUID_NoRollbackWhenNoSync(t *testing.T) {
 		Username:    "user1",
 		Email:       "user1@example.com",
 		RegProvider: "casdoor",
+		Avatar:      "https://example.com/avatar.jpg",
 	}
 	mockUserStore.EXPECT().FindByUUID(mock.Anything, "user1").Return(user, nil)
 	mockUserStore.EXPECT().Update(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("database error"))

--- a/user/handler/user.go
+++ b/user/handler/user.go
@@ -143,14 +143,6 @@ func (h *UserHandler) Update(ctx *gin.Context) {
 		return
 	}
 
-	if req.Avatar != nil && *req.Avatar != "" {
-		if err := common.ValidateImageURL(*req.Avatar); err != nil {
-			slog.ErrorContext(ctx.Request.Context(), "invalid avatar url", slog.Any("error", err))
-			httpbase.BadRequestWithExt(ctx, errorx.ReqParamInvalid(err, errorx.Ctx().Set("param", "avatar")))
-			return
-		}
-	}
-
 	id := ctx.Param("id")
 	req.UUID = &id
 	req.OpUser = currentUser
@@ -163,6 +155,10 @@ func (h *UserHandler) Update(ctx *gin.Context) {
 		}
 		if errors.Is(err, errorx.ErrUserNotFound) {
 			httpbase.NotFoundError(ctx, err)
+			return
+		}
+		if errors.Is(err, errorx.ErrReqParamInvalid) {
+			httpbase.BadRequestWithExt(ctx, err)
 			return
 		}
 		httpbase.ServerError(ctx, err)


### PR DESCRIPTION
Summary:
- Fixes an issue where users with non-compliant default avatars were blocked from updating their profile information.
- Optimizes validation logic to only verify avatar links when the new URL differs from the existing one.