### PR TITLE
Add model metadata to multi-sync data

### DIFF
--- a/component/multi_sync.go
+++ b/component/multi_sync.go
@@ -36,6 +36,7 @@ type multiSyncComponentImpl struct {
 	tagStore         database.TagStore
 	fileStore        database.FileStore
 	skillStore       database.SkillStore
+	metadataStore    database.MetadataStore
 	gitServer        gitserver.GitServer
 }
 
@@ -64,6 +65,7 @@ func NewMultiSyncComponent(config *config.Config) (MultiSyncComponent, error) {
 		promptStore:      database.NewPromptStore(),
 		mcpStore:         database.NewMCPServerStore(),
 		skillStore:       database.NewSkillStore(),
+		metadataStore:    database.NewMetadataStore(),
 		gitServer:        git,
 	}, nil
 }
@@ -557,6 +559,23 @@ func (c *multiSyncComponentImpl) createLocalModel(ctx context.Context, m *types.
 	_, err = c.modelStore.CreateIfNotExist(ctx, dbModel)
 	if err != nil {
 		return fmt.Errorf("failed to create database model, cause: %w", err)
+	}
+
+	// sync metadata
+	err = c.metadataStore.Upsert(ctx, &database.Metadata{
+		RepositoryID:      newDBRepo.ID,
+		ModelParams:       m.Metadata.ModelParams,
+		TensorType:        m.Metadata.TensorType,
+		MiniGPUMemoryGB:   m.Metadata.MiniGPUMemoryGB,
+		MiniGPUFinetuneGB: m.Metadata.MiniGPUFinetuneGB,
+		Architecture:      m.Metadata.Architecture,
+		ModelType:         m.Metadata.ModelType,
+		ClassName:         m.Metadata.ClassName,
+		Quantizations:     m.Metadata.Quantizations,
+		PDRecommendation:  m.Metadata.PDRecommendation,
+	})
+	if err != nil {
+		slog.Error("failed to sync metadata", slog.Any("error", err), slog.Int64("repo_id", newDBRepo.ID))
 	}
 
 	// create new trending scores related to repo

--- a/component/multi_sync_test.go
+++ b/component/multi_sync_test.go
@@ -163,6 +163,9 @@ func TestMultiSyncComponent_SyncAsClient(t *testing.T) {
 		RepositoryID: 1,
 		Repository:   dbrepo,
 	}).Return(nil, nil)
+	mc.mocks.stores.MetadataMock().EXPECT().Upsert(ctx, &database.Metadata{
+		RepositoryID: 1,
+	}).Return(nil)
 	mc.mocks.stores.RecomMock().EXPECT().UpsertScore(ctx, []*database.RecomRepoScore{
 		{RepositoryID: 1, WeightName: database.RecomWeightOp, Score: 40},
 		{RepositoryID: 1, WeightName: database.RecomWeightQuality, Score: 50},

--- a/component/wireset.go
+++ b/component/wireset.go
@@ -459,6 +459,7 @@ func NewTestMultiSyncComponent(config *config.Config, stores *tests.MockStores, 
 		promptStore:      stores.Prompt,
 		mcpStore:         stores.MCPServerStore,
 		skillStore:       stores.Skill,
+		metadataStore:    stores.Metadata,
 		gitServer:        gitServer,
 	}
 }


### PR DESCRIPTION
Summary:
- Enables filtering of unsynced models by parameter count in multi-source synchronization by fetching model metadata during data pull.
- Resolves the limitation where the model list could not be filtered based on parameter size for repositories that had not yet been synchronized.