### PR TITLE
Add accounting bill data for custom dashboard

### DIFF
--- a/accounting/utils/scene.go
+++ b/accounting/utils/scene.go
@@ -22,8 +22,22 @@ func IsNeedCalculateBill(scene types.SceneType) bool {
 		types.SceneEvaluation,
 		types.SceneModelServerless,
 		types.SceneMultiModalServerless,
-		types.SceneStarship,
-		types.SceneGuiAgent:
+		// types.SceneStarship, deprecated
+		// types.SceneGuiAgent, deprecated
+		types.ScenePortalCharge,
+		types.SceneCashCharge:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsNeedExtractHardware(scene types.SceneType) bool {
+	switch scene {
+	case types.SceneModelInference,
+		types.SceneSpace,
+		types.SceneModelFinetune,
+		types.SceneEvaluation:
 		return true
 	default:
 		return false

--- a/accounting/utils/scene_test.go
+++ b/accounting/utils/scene_test.go
@@ -15,9 +15,9 @@ func TestScene_IsNeedCalculateBill(t *testing.T) {
 		types.SceneModelFinetune,
 		types.SceneEvaluation,
 		types.SceneModelServerless,
-		types.SceneStarship,
-		types.SceneGuiAgent,
-		// types.SceneAgenticHub,
+		types.SceneMultiModalServerless,
+		types.ScenePortalCharge,
+		types.SceneCashCharge,
 	}
 
 	for _, scene := range scenes {
@@ -27,10 +27,10 @@ func TestScene_IsNeedCalculateBill(t *testing.T) {
 
 	scenes = []types.SceneType{
 		types.SceneReserve,
-		types.ScenePortalCharge,
 		types.ScenePayOrder,
-		types.SceneCashCharge,
 		types.SceneMultiSync,
+		types.SceneStarship,
+		types.SceneGuiAgent,
 		types.SceneUnknow,
 	}
 

--- a/builder/store/database/account_bill.go
+++ b/builder/store/database/account_bill.go
@@ -54,6 +54,8 @@ type AccountBill struct {
 	VoucherValue    float64           `bun:",notnull,default:0" json:"voucher_value"`
 	CashValue       float64           `bun:",notnull,default:0" json:"cash_value"`
 	UnitType        types.SkuUnitType `bun:",notnull,default:''" json:"unit_type"`
+	ClusterID       string            `bun:",notnull,default:''" json:"cluster_id"`
+	HardwareType    string            `bun:",notnull,default:''" json:"hardware_type"`
 	times
 }
 
@@ -62,6 +64,11 @@ type BillValues struct {
 	VoucherValue float64 `bun:"voucher_value"`
 	CashValue    float64 `bun:"cash_value"`
 	Consumption  float64 `bun:"consumption"`
+}
+
+type BillResource struct {
+	ClusterID    string `bun:"cluster_id"`
+	HardwareType string `bun:"hardware_type"`
 }
 
 type TotalResult struct {

--- a/builder/store/database/account_statement.go
+++ b/builder/store/database/account_statement.go
@@ -172,8 +172,10 @@ func (as *accountStatementStoreImpl) chargeFeeStatement(ctx context.Context, inp
 			}
 		}
 
+		cashValue := 0.0
 		if input.Scene == types.SceneCashCharge {
 			input.BalanceValue = acctUser.CashBalance
+			cashValue = input.Value
 		} else {
 			input.BalanceValue = acctUser.Balance
 		}
@@ -181,6 +183,17 @@ func (as *accountStatementStoreImpl) chargeFeeStatement(ctx context.Context, inp
 		err = assertAffectedOneRow(tx.NewInsert().Model(&input).Exec(ctx))
 		if err != nil {
 			return fmt.Errorf("insert statement, error:%w", err)
+		}
+
+		err = updateFeeBill(ctx, tx, input, BillValues{
+			TotalValue:   input.Value,
+			VoucherValue: 0,
+			CashValue:    cashValue,
+			Consumption:  input.Consumption,
+		})
+
+		if err != nil {
+			return fmt.Errorf("update account bill for charge, error: %w", err)
 		}
 		return nil
 	})
@@ -235,7 +248,7 @@ func (as *accountStatementStoreImpl) deductFeeStatement(ctx context.Context, inp
 		})
 
 		if err != nil {
-			return fmt.Errorf("update account bill, error: %w", err)
+			return fmt.Errorf("update account bill for consume, error: %w", err)
 		}
 
 		isCSGUsage := utils.IsNeedCheckUserSubscription(input.Scene)
@@ -564,6 +577,10 @@ func updateFeeBill(ctx context.Context, tx bun.Tx, input AccountStatement, billV
 	if !utils.IsNeedCalculateBill(input.Scene) {
 		return nil
 	}
+	billRes, err := GetConsumeResource(ctx, tx, input)
+	if err != nil {
+		return fmt.Errorf("get consume resource for %s user %s, error:%w", input.EventUUID, input.UserUUID, err)
+	}
 	if billValues.TotalValue != 0 {
 		// calculate bill
 		bill := AccountBill{
@@ -583,6 +600,8 @@ func updateFeeBill(ctx context.Context, tx bun.Tx, input AccountStatement, billV
 			VoucherNo:       input.VoucherNo,
 			VoucherValue:    billValues.VoucherValue,
 			CashValue:       billValues.CashValue,
+			ClusterID:       billRes.ClusterID,
+			HardwareType:    billRes.HardwareType,
 		}
 		if input.Scene == types.SceneMultiModalServerless {
 			bill.UnitType = input.SkuUnitType
@@ -590,7 +609,7 @@ func updateFeeBill(ctx context.Context, tx bun.Tx, input AccountStatement, billV
 
 		// depend on unique index for update
 		_, err := tx.NewInsert().Model(&bill).
-			On("CONFLICT (bill_date, user_uuid, scene, customer_id, token_id, data_type, resolution, voucher_no, unit_type) DO UPDATE").
+			On("CONFLICT (bill_date, user_uuid, scene, customer_id, token_id, data_type, resolution, voucher_no, unit_type, cluster_id, hardware_type) DO UPDATE").
 			Set("value = account_bill.value + ?", billValues.TotalValue).
 			Set("consumption = account_bill.consumption + ?", billValues.Consumption).
 			Set("prompt_token = account_bill.prompt_token + ?", input.PromptToken).
@@ -614,6 +633,33 @@ func updateFeeBill(ctx context.Context, tx bun.Tx, input AccountStatement, billV
 	}
 
 	return nil
+}
+
+func GetConsumeResource(ctx context.Context, tx bun.Tx, input AccountStatement) (BillResource, error) {
+	var err error
+	var res SpaceResource
+	billResource := BillResource{}
+
+	if !utils.IsNeedExtractHardware(input.Scene) {
+		// skip extract hardware type for scene that not need it
+		return billResource, nil
+	}
+
+	res.ID, err = strconv.ParseInt(input.ResourceID, 10, 64)
+	if err != nil {
+		return billResource, fmt.Errorf("parse resource id %s to int64 for bill, error:%w", input.ResourceID, err)
+	}
+	_, err = tx.NewSelect().Model(&res).WherePK().Exec(ctx, &res)
+	if err != nil {
+		return billResource, fmt.Errorf("query space resource id %d for bill, error:%w", res.ID, err)
+	}
+	hwType, err := types.GetHardwareType(res.Resources)
+	if err != nil {
+		return billResource, fmt.Errorf("extract hardware type from resource id %d for bill, error:%w", res.ID, err)
+	}
+	billResource.ClusterID = res.ClusterID
+	billResource.HardwareType = hwType
+	return billResource, nil
 }
 
 func (as *accountStatementStoreImpl) ListByUserIDAndTime(ctx context.Context, req types.ActStatementsReq) (AccountStatementRes, error) {

--- a/builder/store/database/account_statement_test.go
+++ b/builder/store/database/account_statement_test.go
@@ -456,3 +456,111 @@ func TestAccountStatementStore_ListGroupedByUserAndSku(t *testing.T) {
 	require.Equal(t, float64(30), groupMap[1002].TotalValue)
 	require.Equal(t, float64(-4), groupMap[1002].TotalConsumption)
 }
+
+func TestGetConsumeResource(t *testing.T) {
+	cases := []struct {
+		name              string
+		scene             types.SceneType
+		spaceResource     *database.SpaceResource
+		expectClusterID   string
+		expectHardwareTyp string
+		expectErr         bool
+	}{
+		{
+			name:              "scene not need extract hardware",
+			scene:             types.SceneCashCharge,
+			spaceResource:     nil,
+			expectClusterID:   "",
+			expectHardwareTyp: "",
+			expectErr:         false,
+		},
+		{
+			name:  "scene need extract hardware with valid resource",
+			scene: types.SceneSpace,
+			spaceResource: &database.SpaceResource{
+				Name:      "test-resource",
+				Resources: `{"gpu": {"num": "1", "type": "A10"}}`,
+				ClusterID: "test-cluster",
+			},
+			expectClusterID:   "test-cluster",
+			expectHardwareTyp: "A10",
+			expectErr:         false,
+		},
+		{
+			name:  "scene need extract hardware with invalid resource id",
+			scene: types.SceneModelInference,
+			spaceResource: &database.SpaceResource{
+				Name:      "test-resource",
+				Resources: `{"gpu": {"num": "1", "type": "A10"}}`,
+				ClusterID: "test-cluster",
+			},
+			expectClusterID:   "",
+			expectHardwareTyp: "",
+			expectErr:         true,
+		},
+		{
+			name:  "scene need extract hardware with missing resource record",
+			scene: types.SceneEvaluation,
+			spaceResource: &database.SpaceResource{
+				Name:      "other-resource",
+				Resources: `{"gpu": {"num": "1", "type": "A10"}}`,
+				ClusterID: "other-cluster",
+			},
+			expectClusterID:   "",
+			expectHardwareTyp: "",
+			expectErr:         true,
+		},
+		{
+			name:  "scene need extract hardware with cpu only resource",
+			scene: types.SceneModelFinetune,
+			spaceResource: &database.SpaceResource{
+				Name:      "cpu-resource",
+				Resources: `{"cpu": {"num": "2", "type": "Intel"}}`,
+				ClusterID: "cpu-cluster",
+			},
+			expectClusterID:   "cpu-cluster",
+			expectHardwareTyp: "Intel",
+			expectErr:         false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			db := tests.InitTestDB()
+			defer db.Close()
+			ctx := context.TODO()
+
+			resourceID := "not-a-number"
+			if c.spaceResource != nil {
+				_, err := db.Core.NewInsert().Model(c.spaceResource).Exec(ctx, c.spaceResource)
+				require.Nil(t, err)
+				resourceID = fmt.Sprintf("%d", c.spaceResource.ID)
+			}
+
+			err := db.Core.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+				input := database.AccountStatement{
+					Scene:      c.scene,
+					ResourceID: resourceID,
+				}
+
+				if c.name == "scene need extract hardware with invalid resource id" {
+					input.ResourceID = "not-a-number"
+				}
+				if c.name == "scene need extract hardware with missing resource record" {
+					input.ResourceID = "99999"
+				}
+
+				result, err := database.GetConsumeResource(ctx, tx, input)
+				if c.expectErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, c.expectClusterID, result.ClusterID)
+					require.Equal(t, c.expectHardwareTyp, result.HardwareType)
+				}
+				return nil
+			})
+			require.Nil(t, err)
+		})
+	}
+}

--- a/builder/store/database/migrations/20260706064355_add_column_clusterid_hardware_to_account_bill.down.sql
+++ b/builder/store/database/migrations/20260706064355_add_column_clusterid_hardware_to_account_bill.down.sql
@@ -1,0 +1,29 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE account_bills DROP COLUMN IF EXISTS cluster_id;
+
+--bun:split
+
+ALTER TABLE account_bills DROP COLUMN IF EXISTS hardware_type;
+
+--bun:split
+
+DROP INDEX IF EXISTS idx_acct_billdate_clusterid;
+
+--bun:split
+
+DROP INDEX IF EXISTS idx_acct_billdate_hardware;
+
+--bun:split
+
+DROP INDEX IF EXISTS idx_acct_billdate_scene;
+
+--bun:split
+
+DROP INDEX IF EXISTS idx_unique_account_bill_date_user_scene_cusid_tokenid_type_res;
+
+--bun:split
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_account_bill_date_user_scene_cusid_tokenid_type_res ON account_bills (bill_date,user_uuid,scene,customer_id,token_id,data_type,resolution,voucher_no,unit_type);

--- a/builder/store/database/migrations/20260706064355_add_column_clusterid_hardware_to_account_bill.up.sql
+++ b/builder/store/database/migrations/20260706064355_add_column_clusterid_hardware_to_account_bill.up.sql
@@ -1,0 +1,30 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE account_bills ADD COLUMN IF NOT EXISTS cluster_id VARCHAR(100) DEFAULT '';
+
+--bun:split
+
+ALTER TABLE account_bills ADD COLUMN IF NOT EXISTS hardware_type VARCHAR(50) DEFAULT '';
+
+--bun:split
+
+CREATE INDEX IF NOT EXISTS idx_acct_billdate_clusterid ON account_bills (bill_date, cluster_id);
+
+--bun:split
+
+CREATE INDEX IF NOT EXISTS idx_acct_billdate_hardware ON account_bills (bill_date, hardware_type);
+
+--bun:split
+
+CREATE INDEX IF NOT EXISTS idx_acct_billdate_scene ON account_bills (bill_date, scene);
+
+--bun:split
+
+DROP INDEX IF EXISTS idx_unique_account_bill_date_user_scene_cusid_tokenid_type_res;
+
+--bun:split
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_account_bill_date_user_scene_cusid_tokenid_type_res ON account_bills (bill_date,user_uuid,scene,customer_id,token_id,data_type,resolution,voucher_no,unit_type,cluster_id,hardware_type);
+

--- a/common/types/hardware.go
+++ b/common/types/hardware.go
@@ -90,12 +90,34 @@ func (h *HardWare) GetResXPUMode() string {
 
 }
 
-func GetResXPUMode(res string) (string, error) {
+func parseHardWare(res string) (HardWare, error) {
 	var hardware HardWare
 	err := json.Unmarshal([]byte(res), &hardware)
+	if err != nil {
+		return HardWare{}, err
+	}
+
+	return hardware, nil
+}
+
+func GetResXPUMode(res string) (string, error) {
+	hardware, err := parseHardWare(res)
 	if err != nil {
 		return "", err
 	}
 
 	return hardware.GetResXPUMode(), nil
+}
+
+func GetHardwareType(res string) (string, error) {
+	hardware, err := parseHardWare(res)
+	if err != nil {
+		return "", err
+	}
+	xpuType := hardware.GetResXPUMode()
+	if len(xpuType) > 0 {
+		return xpuType, nil
+	}
+	cpuType := hardware.Cpu.Type
+	return cpuType, nil
 }


### PR DESCRIPTION
Summary:
- Extended the `account_bills` table with `cluster_id` and `hardware_type` fields to enable granular billing aggregation for custom BI dashboards.
- Enhanced billing logic to capture hardware details (GPU/XPU/CPU) for specific compute scenarios and included recharge events in bill records.
- Refactored hardware extraction and scene judgment functions to improve data accuracy and support Volcano VXPU annotation parsing.