### PR TITLE
Capture FunASR audio duration for AIGateway billing

### DIFF
--- a/aigateway/component/adapter/audio/adapter.go
+++ b/aigateway/component/adapter/audio/adapter.go
@@ -1,0 +1,38 @@
+package audio
+
+import (
+	"net/http"
+
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+type Adapter interface {
+	Name() string
+	CanHandle(model *types.Model) bool
+	DurationFromHeader(header http.Header) (float64, bool)
+}
+
+type Registry struct {
+	adapters []Adapter
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		adapters: []Adapter{
+			NewFunASRAdapter(),
+			NewOpenAICompatibleAdapter(),
+		},
+	}
+}
+
+func (r *Registry) GetAdapter(model *types.Model) Adapter {
+	if r == nil {
+		return nil
+	}
+	for _, adapter := range r.adapters {
+		if adapter.CanHandle(model) {
+			return adapter
+		}
+	}
+	return nil
+}

--- a/aigateway/component/adapter/audio/adapter_test.go
+++ b/aigateway/component/adapter/audio/adapter_test.go
@@ -1,0 +1,59 @@
+package audio
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+func TestRegistryGetAdapter(t *testing.T) {
+	registry := NewRegistry()
+
+	funasr := registry.GetAdapter(&types.Model{InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "FunASR"}})
+	require.Equal(t, "funasr", funasr.Name())
+
+	opencsg := registry.GetAdapter(&types.Model{ExternalModelInfo: types.ExternalModelInfo{Provider: " OpenCSG "}})
+	require.Equal(t, "funasr", opencsg.Name())
+
+	openaiCompatible := registry.GetAdapter(&types.Model{})
+	require.Equal(t, "openai-compatible", openaiCompatible.Name())
+}
+
+func TestFunASRAdapterDurationFromHeader(t *testing.T) {
+	adapter := NewFunASRAdapter()
+
+	tests := []struct {
+		name string
+		val  string
+		want float64
+		ok   bool
+	}{
+		{name: "valid", val: "9.2", want: 9.2, ok: true},
+		{name: "invalid", val: "nope"},
+		{name: "zero", val: "0"},
+		{name: "negative", val: "-1"},
+		{name: "missing"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := http.Header{}
+			if tt.val != "" {
+				header.Set(audioDurationHeader, tt.val)
+			}
+			got, ok := adapter.DurationFromHeader(header)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestOpenAICompatibleAdapterIgnoresDurationHeader(t *testing.T) {
+	header := http.Header{}
+	header.Set(audioDurationHeader, "9.2")
+
+	got, ok := NewOpenAICompatibleAdapter().DurationFromHeader(header)
+	require.False(t, ok)
+	require.Zero(t, got)
+}

--- a/aigateway/component/adapter/audio/funasr.go
+++ b/aigateway/component/adapter/audio/funasr.go
@@ -1,0 +1,48 @@
+package audio
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+const audioDurationHeader = "Audio-Duration-Seconds"
+
+type FunASRAdapter struct{}
+
+func NewFunASRAdapter() *FunASRAdapter {
+	return &FunASRAdapter{}
+}
+
+func (a *FunASRAdapter) Name() string {
+	return "funasr"
+}
+
+func (a *FunASRAdapter) CanHandle(model *types.Model) bool {
+	return model != nil && (isValue(model.RuntimeFramework, "funasr") || isValue(model.Provider, "opencsg"))
+}
+
+func (a *FunASRAdapter) DurationFromHeader(header http.Header) (float64, bool) {
+	return parseDurationHeader(header)
+}
+
+func parseDurationHeader(header http.Header) (float64, bool) {
+	if header == nil {
+		return 0, false
+	}
+	value := header.Get(audioDurationHeader)
+	if value == "" {
+		return 0, false
+	}
+	duration, err := strconv.ParseFloat(value, 64)
+	if err != nil || duration <= 0 {
+		return 0, false
+	}
+	return duration, true
+}
+
+func isValue(value, expected string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), expected)
+}

--- a/aigateway/component/adapter/audio/openai_compatible.go
+++ b/aigateway/component/adapter/audio/openai_compatible.go
@@ -1,0 +1,25 @@
+package audio
+
+import (
+	"net/http"
+
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+type OpenAICompatibleAdapter struct{}
+
+func NewOpenAICompatibleAdapter() *OpenAICompatibleAdapter {
+	return &OpenAICompatibleAdapter{}
+}
+
+func (a *OpenAICompatibleAdapter) Name() string {
+	return "openai-compatible"
+}
+
+func (a *OpenAICompatibleAdapter) CanHandle(model *types.Model) bool {
+	return model != nil
+}
+
+func (a *OpenAICompatibleAdapter) DurationFromHeader(header http.Header) (float64, bool) {
+	return 0, false
+}

--- a/aigateway/handler/openai.go
+++ b/aigateway/handler/openai.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
 	"opencsg.com/csghub-server/aigateway/component"
+	audioadapter "opencsg.com/csghub-server/aigateway/component/adapter/audio"
 	"opencsg.com/csghub-server/aigateway/component/adapter/text2image"
 	"opencsg.com/csghub-server/aigateway/component/adapter/text2video"
 	"opencsg.com/csghub-server/aigateway/component/availability"
@@ -98,7 +99,7 @@ func NewOpenAIHandlerFromConfig(config *config.Config) (OpenAIHandler, error) {
 	storage, _ := component.NewStorage(config)
 	whitelistRule := database.NewRepositoryFileCheckRuleStore()
 	aiGenerationStore := database.NewAIGenerationStore()
-	handler := newOpenAIHandler(modelService, repoComp, modComponent, clusterComp, token.NewCounterFactory(), text2image.NewRegistry(), text2video.NewRegistry(), config, storage, whitelistRule, aiGenerationStore)
+	handler := newOpenAIHandler(modelService, repoComp, modComponent, clusterComp, token.NewCounterFactory(), text2image.NewRegistry(), text2video.NewRegistry(), audioadapter.NewRegistry(), config, storage, whitelistRule, aiGenerationStore)
 
 	if config.AIGateway.EnableLLMTrace && config.Instrumentation.OTLPEndpoint != "" {
 		llmTracer, traceErr := llmtrace.NewSigilTracer(llmtrace.SigilConfig{
@@ -135,6 +136,7 @@ func newOpenAIHandler(
 	tokenCounterFactory token.CounterFactory,
 	t2iRegistry *text2image.Registry,
 	t2vRegistry *text2video.Registry,
+	audioRegistry *audioadapter.Registry,
 	config *config.Config,
 	storage types.Storage,
 	whitelistRule database.RepositoryFileCheckRuleStore,
@@ -148,6 +150,7 @@ func newOpenAIHandler(
 		tokenCounterFactory:        tokenCounterFactory,
 		t2iRegistry:                t2iRegistry,
 		t2vRegistry:                t2vRegistry,
+		audioRegistry:              audioRegistry,
 		config:                     config,
 		storage:                    storage,
 		whitelistRule:              whitelistRule,
@@ -244,6 +247,7 @@ type OpenAIHandlerImpl struct {
 	tokenCounterFactory        token.CounterFactory
 	t2iRegistry                *text2image.Registry
 	t2vRegistry                *text2video.Registry
+	audioRegistry              *audioadapter.Registry
 	config                     *config.Config
 	storage                    types.Storage
 	whitelistRule              database.RepositoryFileCheckRuleStore

--- a/aigateway/handler/openai_audio.go
+++ b/aigateway/handler/openai_audio.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	audioadapter "opencsg.com/csghub-server/aigateway/component/adapter/audio"
 	llmtrace "opencsg.com/csghub-server/aigateway/component/trace"
 	"opencsg.com/csghub-server/aigateway/token"
 	"opencsg.com/csghub-server/aigateway/types"
@@ -129,6 +130,7 @@ func (h *OpenAIHandlerImpl) Transcription(c *gin.Context) {
 			"stream": strconv.FormatBool(isStream),
 		},
 	}
+	adapter := h.audioAdapter(modelTarget.Model)
 	body, contentType, _ := rewriteMultipartModelStreamWithOptions(form, modelTarget.ModelName, options)
 	c.Request.Body = body
 	c.Request.ContentLength = -1
@@ -160,7 +162,7 @@ func (h *OpenAIHandlerImpl) Transcription(c *gin.Context) {
 	slog.InfoContext(ctx, "proxy audio transcription request to model endpoint", slog.Any("target", modelTarget.Target), slog.Any("host", modelTarget.Host), slog.Any("user", username), slog.Any("model_id", modelID), slog.Any("model_name", modelTarget.ModelName))
 
 	audioCounter := token.NewAudioUsageCounter(token.NewTokenizerImpl(modelTarget.Target, modelTarget.Host, modelTarget.ModelName, modelTarget.Model.ImageID, modelTarget.Model.Provider))
-	w := NewResponseWriterWrapperAudio(c.Writer, audioCounter, isStream)
+	w := NewResponseWriterWrapperAudio(c.Writer, audioCounter, isStream, adapter)
 	rp.ServeHTTP(w, c.Request, proxyToApi, modelTarget.Host)
 
 	go func() {
@@ -197,4 +199,13 @@ func (h *OpenAIHandlerImpl) Transcription(c *gin.Context) {
 			}
 		}
 	}()
+}
+
+func (h *OpenAIHandlerImpl) audioAdapter(model *types.Model) audioadapter.Adapter {
+	if h != nil && h.audioRegistry != nil {
+		if adapter := h.audioRegistry.GetAdapter(model); adapter != nil {
+			return adapter
+		}
+	}
+	return audioadapter.NewOpenAICompatibleAdapter()
 }

--- a/aigateway/handler/openai_test.go
+++ b/aigateway/handler/openai_test.go
@@ -30,6 +30,7 @@ import (
 	mockdatabase "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/store/database"
 	apicomp "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/component"
 	comp "opencsg.com/csghub-server/aigateway/component"
+	audioadapter "opencsg.com/csghub-server/aigateway/component/adapter/audio"
 	"opencsg.com/csghub-server/aigateway/component/adapter/text2image"
 	"opencsg.com/csghub-server/aigateway/component/adapter/text2video"
 	llmtrace "opencsg.com/csghub-server/aigateway/component/trace"
@@ -95,7 +96,7 @@ func setupTest(t *testing.T) (*testerOpenAIHandler, *gin.Context, *httptest.Resp
 	cfg := &config.Config{}
 	mockWhitelistRule := mockdatabase.NewMockRepositoryFileCheckRuleStore(t)
 	mockAIGenerationStore := mockdatabase.NewMockAIGenerationStore(t)
-	handler := newOpenAIHandler(mockOpenAI, mockRepo, mockModeration, mockClsComp, mockTokenCounterFactory, text2image.NewRegistry(), text2video.NewRegistry(), cfg, nil, mockWhitelistRule, mockAIGenerationStore)
+	handler := newOpenAIHandler(mockOpenAI, mockRepo, mockModeration, mockClsComp, mockTokenCounterFactory, text2image.NewRegistry(), text2video.NewRegistry(), audioadapter.NewRegistry(), cfg, nil, mockWhitelistRule, mockAIGenerationStore)
 
 	// Set test user
 	tester := &testerOpenAIHandler{
@@ -1561,6 +1562,60 @@ func TestOpenAIHandler_Transcription(t *testing.T) {
 		require.Equal(t, int64(423), usage.TotalTokens)
 		require.Empty(t, errorCode)
 		require.Equal(t, []string{"response", "usage", "end"}, events)
+	})
+
+	t.Run("funasr text response uses duration header for billing", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+
+		var downstreamResponseFormat string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/v1/audio/transcriptions", r.URL.Path)
+			require.NoError(t, r.ParseMultipartForm(32<<20))
+			downstreamResponseFormat = r.FormValue("response_format")
+			require.Equal(t, "backend-model", r.FormValue("model"))
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.Header().Set("Audio-Duration-Seconds", "9.2")
+			_, _ = w.Write([]byte("hello world"))
+		}))
+		defer server.Close()
+
+		c.Request = newMultipartTranscriptionRequest(t, "model1", "audio-bytes", map[string]string{
+			"response_format": "text",
+		})
+		model := &types.Model{
+			BaseModel: types.BaseModel{
+				ID:       "backend-model",
+				Object:   "model",
+				Metadata: map[string]any{},
+				Task:     "audio-transcription",
+			},
+			InternalModelInfo: types.InternalModelInfo{
+				RuntimeFramework: "funasr",
+			},
+			Endpoint: server.URL + "/v1/audio/transcriptions",
+			Upstreams: []commontypes.UpstreamConfig{
+				{URL: server.URL + "/v1/audio/transcriptions", Enabled: true, ModelName: "backend-model"},
+			},
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").Return(model, nil).Once()
+		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+		tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, mock.Anything, mock.MatchedBy(func(usage *token.Usage) bool {
+			return usage != nil && usage.Duration == 9.2 && usage.CompletionDesc == "hello world"
+		}), "").RunAndReturn(
+			func(ctx context.Context, userUUID string, model *types.Model, targetModelName string, usage *token.Usage, apikey string) error {
+				wg.Done()
+				return nil
+			}).Once()
+
+		tester.handler.Transcription(c)
+		wg.Wait()
+
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		require.Equal(t, "hello world", w.Body.String())
+		require.Equal(t, "text", downstreamResponseFormat)
 	})
 
 	t.Run("missing model", func(t *testing.T) {

--- a/aigateway/handler/response_writer_wrapper_audio.go
+++ b/aigateway/handler/response_writer_wrapper_audio.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	audioadapter "opencsg.com/csghub-server/aigateway/component/adapter/audio"
 	"opencsg.com/csghub-server/aigateway/handler/streamdecoder"
 	"opencsg.com/csghub-server/aigateway/token"
 	commontypes "opencsg.com/csghub-server/common/types"
@@ -23,11 +24,11 @@ type audioResponseWriter interface {
 	DurationSeconds() (float64, bool)
 }
 
-func NewResponseWriterWrapperAudio(internalWritter http.ResponseWriter, tokenCounter *token.AudioUsageCounter, useStream bool) audioResponseWriter {
+func NewResponseWriterWrapperAudio(internalWritter http.ResponseWriter, tokenCounter *token.AudioUsageCounter, useStream bool, adapter audioadapter.Adapter) audioResponseWriter {
 	if useStream {
-		return newStreamAudioResponseWriter(internalWritter, tokenCounter)
+		return newStreamAudioResponseWriter(internalWritter, tokenCounter, adapter)
 	}
-	return newNonStreamAudioResponseWriter(internalWritter, tokenCounter)
+	return newNonStreamAudioResponseWriter(internalWritter, tokenCounter, adapter)
 }
 
 type nonStreamAudioResponseWriter struct {
@@ -37,13 +38,15 @@ type nonStreamAudioResponseWriter struct {
 	statusCode      int
 	durationSeconds float64
 	hasDuration     bool
+	adapter         audioadapter.Adapter
 }
 
-func newNonStreamAudioResponseWriter(internalWritter http.ResponseWriter, tokenCounter *token.AudioUsageCounter) *nonStreamAudioResponseWriter {
+func newNonStreamAudioResponseWriter(internalWritter http.ResponseWriter, tokenCounter *token.AudioUsageCounter, adapter audioadapter.Adapter) *nonStreamAudioResponseWriter {
 	return &nonStreamAudioResponseWriter{
 		internalWritter: internalWritter,
 		tokenCounter:    tokenCounter,
 		statusCode:      http.StatusOK,
+		adapter:         adapter,
 	}
 }
 
@@ -53,6 +56,7 @@ func (rw *nonStreamAudioResponseWriter) Header() http.Header {
 
 func (rw *nonStreamAudioResponseWriter) WriteHeader(statusCode int) {
 	rw.statusCode = statusCode
+	rw.captureDurationFromHeader()
 	rw.internalWritter.WriteHeader(statusCode)
 }
 
@@ -129,6 +133,9 @@ func (rw *nonStreamAudioResponseWriter) captureText(data []byte) {
 }
 
 func (rw *nonStreamAudioResponseWriter) captureDuration(candidates ...*float64) {
+	if rw == nil || rw.hasDuration {
+		return
+	}
 	for _, candidate := range candidates {
 		if candidate != nil && *candidate > 0 {
 			rw.durationSeconds = *candidate
@@ -138,6 +145,15 @@ func (rw *nonStreamAudioResponseWriter) captureDuration(candidates ...*float64) 
 			}
 			return
 		}
+	}
+}
+
+func (rw *nonStreamAudioResponseWriter) captureDurationFromHeader() {
+	if rw == nil || rw.adapter == nil || rw.hasDuration {
+		return
+	}
+	if duration, ok := rw.adapter.DurationFromHeader(rw.Header()); ok {
+		rw.captureDuration(&duration)
 	}
 }
 
@@ -167,13 +183,15 @@ type streamAudioResponseWriter struct {
 	hasDuration     bool
 	streamStarted   bool
 	accumulatedText string
+	adapter         audioadapter.Adapter
 }
 
-func newStreamAudioResponseWriter(internalWritter http.ResponseWriter, tokenCounter *token.AudioUsageCounter) *streamAudioResponseWriter {
+func newStreamAudioResponseWriter(internalWritter http.ResponseWriter, tokenCounter *token.AudioUsageCounter, adapter audioadapter.Adapter) *streamAudioResponseWriter {
 	return &streamAudioResponseWriter{
 		internalWritter: internalWritter,
 		tokenCounter:    tokenCounter,
 		statusCode:      http.StatusOK,
+		adapter:         adapter,
 	}
 }
 
@@ -183,6 +201,7 @@ func (rw *streamAudioResponseWriter) Header() http.Header {
 
 func (rw *streamAudioResponseWriter) WriteHeader(statusCode int) {
 	rw.statusCode = statusCode
+	rw.captureDurationFromHeader()
 	rw.internalWritter.Header().Del("Content-Length")
 
 	ct := rw.internalWritter.Header().Get("Content-Type")
@@ -275,6 +294,9 @@ func (rw *streamAudioResponseWriter) handleStreamPayload(payload, raw []byte) er
 }
 
 func (rw *streamAudioResponseWriter) captureDuration(candidates ...*float64) {
+	if rw == nil || rw.hasDuration {
+		return
+	}
 	for _, candidate := range candidates {
 		if candidate != nil && *candidate > 0 {
 			rw.durationSeconds = *candidate
@@ -284,6 +306,15 @@ func (rw *streamAudioResponseWriter) captureDuration(candidates ...*float64) {
 			}
 			return
 		}
+	}
+}
+
+func (rw *streamAudioResponseWriter) captureDurationFromHeader() {
+	if rw == nil || rw.adapter == nil || rw.hasDuration {
+		return
+	}
+	if duration, ok := rw.adapter.DurationFromHeader(rw.Header()); ok {
+		rw.captureDuration(&duration)
 	}
 }
 

--- a/aigateway/handler/response_writer_wrapper_audio_test.go
+++ b/aigateway/handler/response_writer_wrapper_audio_test.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"net/http"
@@ -8,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	audioadapter "opencsg.com/csghub-server/aigateway/component/adapter/audio"
 	"opencsg.com/csghub-server/aigateway/token"
 )
 
@@ -32,7 +35,7 @@ func (w *failingAudioResponseWriter) Write([]byte) (int, error) {
 func TestResponseWriterWrapperAudio_UsesResponseUsage(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, false)
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, nil)
 
 	_, err := w.Write([]byte(`{"text":"hello","usage":{"prompt_tokens":371,"completion_tokens":52,"total_tokens":423,"seconds":9.2}}`))
 	require.NoError(t, err)
@@ -48,7 +51,7 @@ func TestResponseWriterWrapperAudio_UsesResponseUsage(t *testing.T) {
 func TestResponseWriterWrapperAudio_UsesResponseUsageFromChunkedJSON(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, false)
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, nil)
 
 	_, err := w.Write([]byte(`{"text":"hello","usage":`))
 	require.NoError(t, err)
@@ -84,7 +87,7 @@ func TestResponseWriterWrapperAudio_CapturesDurationFromUsage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			counter := token.NewAudioUsageCounter(nil)
 			recorder := httptest.NewRecorder()
-			w := NewResponseWriterWrapperAudio(recorder, counter, false)
+			w := NewResponseWriterWrapperAudio(recorder, counter, false, nil)
 
 			_, err := w.Write([]byte(tt.body))
 			require.NoError(t, err)
@@ -103,7 +106,7 @@ func TestResponseWriterWrapperAudio_CapturesDurationFromUsage(t *testing.T) {
 func TestResponseWriterWrapperAudio_CapturesFunASRVerboseJSONDuration(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, false)
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, nil)
 
 	_, err := w.Write([]byte(`{"text":"hello","segments":[{"start":0,"end":1.23,"text":"hello","speaker":null}],"language":"auto","duration":1.23,"model":"local"}`))
 	require.NoError(t, err)
@@ -121,7 +124,7 @@ func TestResponseWriterWrapperAudio_CapturesFunASRVerboseJSONDuration(t *testing
 func TestResponseWriterWrapperAudio_SkipsMissingDuration(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, false)
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, nil)
 
 	_, err := w.Write([]byte(`{"text":"hello","usage":{"prompt_tokens":1,"total_tokens":1}}`))
 	require.NoError(t, err)
@@ -130,12 +133,86 @@ func TestResponseWriterWrapperAudio_SkipsMissingDuration(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestAudioResponseWriter_NonStreamCapturesDurationFromHeader(t *testing.T) {
+	counter := token.NewAudioUsageCounter(nil)
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("Audio-Duration-Seconds", "9.2")
+	recorder.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, audioadapter.NewFunASRAdapter())
+	w.WriteHeader(http.StatusOK)
+
+	_, err := w.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	require.Equal(t, "hello", recorder.Body.String())
+	require.Equal(t, "text/plain; charset=utf-8", recorder.Header().Get("Content-Type"))
+	duration, ok := w.DurationSeconds()
+	require.True(t, ok)
+	require.Equal(t, 9.2, duration)
+	usage, err := counter.Usage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 9.2, usage.Duration)
+	require.Equal(t, "hello", usage.CompletionDesc)
+}
+
+func TestAudioResponseWriter_NonStreamHeaderDurationWinsOverBody(t *testing.T) {
+	counter := token.NewAudioUsageCounter(nil)
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("Audio-Duration-Seconds", "9.2")
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, audioadapter.NewFunASRAdapter())
+	w.WriteHeader(http.StatusOK)
+
+	_, err := w.Write([]byte(`{"text":"hello","segments":[{"start":0,"end":1.2,"text":"hello"}],"duration":12.5}`))
+	require.NoError(t, err)
+
+	require.JSONEq(t, `{"text":"hello","segments":[{"start":0,"end":1.2,"text":"hello"}],"duration":12.5}`, recorder.Body.String())
+	duration, ok := w.DurationSeconds()
+	require.True(t, ok)
+	require.Equal(t, 9.2, duration)
+}
+
+func TestFunASRAudioResponseWriter_NonStreamVerboseJSONPassthroughCapturesDuration(t *testing.T) {
+	counter := token.NewAudioUsageCounter(nil)
+	recorder := httptest.NewRecorder()
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, audioadapter.NewFunASRAdapter())
+	body := `{"text":"hello","segments":[],"duration":12.5}`
+	w.WriteHeader(http.StatusOK)
+
+	_, err := w.Write([]byte(body))
+	require.NoError(t, err)
+
+	require.JSONEq(t, body, recorder.Body.String())
+	duration, ok := w.DurationSeconds()
+	require.True(t, ok)
+	require.Equal(t, 12.5, duration)
+}
+
+func TestAudioResponseWriter_OpenAICompatibleAdapterPassesThroughGzipBody(t *testing.T) {
+	counter := token.NewAudioUsageCounter(nil)
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("Content-Encoding", "gzip")
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, audioadapter.NewOpenAICompatibleAdapter())
+	w.WriteHeader(http.StatusOK)
+
+	var body bytes.Buffer
+	gzipWriter := gzip.NewWriter(&body)
+	_, err := gzipWriter.Write([]byte(`{"text":"hello"}`))
+	require.NoError(t, err)
+	require.NoError(t, gzipWriter.Close())
+
+	_, err = w.Write(body.Bytes())
+	require.NoError(t, err)
+
+	require.Equal(t, body.Bytes(), recorder.Body.Bytes())
+	require.Equal(t, "gzip", recorder.Header().Get("Content-Encoding"))
+}
+
 func newTestNDJSONWriter(t *testing.T) (*token.AudioUsageCounter, *httptest.ResponseRecorder, audioResponseWriter) {
 	t.Helper()
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
 	recorder.Header().Set("Content-Type", "application/x-ndjson")
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 	w.WriteHeader(http.StatusOK)
 	return counter, recorder, w
 }
@@ -143,7 +220,7 @@ func newTestNDJSONWriter(t *testing.T) (*token.AudioUsageCounter, *httptest.Resp
 func TestNewResponseWriterWrapperAudio_FactoryStream(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 	_, ok := w.(*streamAudioResponseWriter)
 	require.True(t, ok, "expected *streamAudioResponseWriter when useStream=true")
 }
@@ -151,7 +228,7 @@ func TestNewResponseWriterWrapperAudio_FactoryStream(t *testing.T) {
 func TestNewResponseWriterWrapperAudio_FactoryNonStream(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, false)
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, nil)
 	_, ok := w.(*nonStreamAudioResponseWriter)
 	require.True(t, ok, "expected *nonStreamAudioResponseWriter when useStream=false")
 }
@@ -224,6 +301,27 @@ func TestStreamAudioResponseWriter_DurationFromChunk(t *testing.T) {
 	require.Equal(t, 12.5, usage.Duration)
 }
 
+func TestStreamAudioResponseWriter_CapturesDurationFromHeader(t *testing.T) {
+	counter := token.NewAudioUsageCounter(nil)
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("Content-Type", "application/x-ndjson")
+	recorder.Header().Set("Audio-Duration-Seconds", "9.2")
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, audioadapter.NewFunASRAdapter())
+	w.WriteHeader(http.StatusOK)
+
+	_, err := w.Write([]byte(`{"text":"hello"}` + "\n" + `{"text":"","duration":12.5}` + "\n"))
+	require.NoError(t, err)
+
+	require.Equal(t, `{"text":"hello"}`+"\n"+`{"text":"","duration":12.5}`+"\n", recorder.Body.String())
+	duration, ok := w.DurationSeconds()
+	require.True(t, ok)
+	require.Equal(t, 9.2, duration)
+	usage, err := counter.Usage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "hello", usage.CompletionDesc)
+	require.Equal(t, 9.2, usage.Duration)
+}
+
 func TestStreamAudioResponseWriter_DoesNotInventFallbackDuration(t *testing.T) {
 	counter, _, w := newTestNDJSONWriter(t)
 
@@ -251,7 +349,7 @@ func TestStreamAudioResponseWriter_WriteHeaderDeletesContentLength(t *testing.T)
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
 	recorder.Header().Set("Content-Length", "100")
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 
 	w.WriteHeader(http.StatusOK)
 
@@ -261,7 +359,7 @@ func TestStreamAudioResponseWriter_WriteHeaderDeletesContentLength(t *testing.T)
 func TestStreamAudioResponseWriter_ErrorPassthrough(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 
 	w.WriteHeader(http.StatusBadGateway)
 	_, err := w.Write([]byte(`{"error":"upstream failure"}`))
@@ -274,7 +372,7 @@ func TestStreamAudioResponseWriter_ReturnsZeroOnWriteError(t *testing.T) {
 	writeErr := errors.New("write failed")
 	internalWriter := &failingAudioResponseWriter{err: writeErr}
 	internalWriter.Header().Set("Content-Type", "application/x-ndjson")
-	w := NewResponseWriterWrapperAudio(internalWriter, token.NewAudioUsageCounter(nil), true)
+	w := NewResponseWriterWrapperAudio(internalWriter, token.NewAudioUsageCounter(nil), true, nil)
 	w.WriteHeader(http.StatusOK)
 
 	n, err := w.Write([]byte(`{"text":"hello"}` + "\n"))
@@ -313,7 +411,7 @@ func TestStreamAudioResponseWriter_SSEDecoder(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
 	recorder.Header().Set("Content-Type", "text/event-stream")
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 
 	// WriteHeader triggers SSE decoder selection.
 	w.WriteHeader(http.StatusOK)
@@ -331,7 +429,7 @@ func TestStreamAudioResponseWriter_SSEMultipleEvents(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
 	recorder.Header().Set("Content-Type", "text/event-stream")
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte("data: {\"text\":\"first\"}\n\ndata: {\"text\":\"second\"}\n\n"))
@@ -346,7 +444,7 @@ func TestStreamAudioResponseWriter_SSEDoneEvent(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
 	recorder.Header().Set("Content-Type", "text/event-stream")
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte("data: {\"text\":\"ok\"}\n\ndata: [DONE]\n\n"))
@@ -362,7 +460,7 @@ func TestStreamAudioResponseWriter_UnknownContentTypePassthrough(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
 	// No recognized Content-Type — passthrough raw without parsing.
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(`{"text":"not-parsed"}` + "\n"))

--- a/docker/inference/funasr/server.py
+++ b/docker/inference/funasr/server.py
@@ -30,6 +30,8 @@ BATCH_SIZE = 1
 BATCH_SIZE_S = 60.0
 BATCH_SIZE_THRESHOLD_S = 30.0
 STREAM_CHUNK_SECONDS = 30.0
+FFPROBE_TIMEOUT_SECONDS = 10
+AUDIO_DURATION_HEADER = "Audio-Duration-Seconds"
 
 
 def env_bool(name: str, default: bool = False) -> bool:
@@ -115,6 +117,45 @@ def transcribe_files(input_paths: list[str], language: Optional[str], hotwords: 
     return ASR_MODEL.generate(**generate_kwargs)
 
 
+def audio_duration_headers(audio_duration: float) -> dict[str, str]:
+    return {AUDIO_DURATION_HEADER: f"{audio_duration:.3f}"}
+
+
+def probe_audio_duration(input_path: str) -> float:
+    command = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "json",
+        input_path,
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=FFPROBE_TIMEOUT_SECONDS,
+        )
+        payload = json.loads(result.stdout)
+        duration = float(payload.get("format", {}).get("duration", 0))
+        if duration <= 0:
+            raise ValueError(f"invalid audio duration: {duration}")
+        return duration
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"ffprobe timed out after {FFPROBE_TIMEOUT_SECONDS}s") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        if stderr:
+            raise RuntimeError(f"ffprobe failed: {stderr}") from exc
+        raise RuntimeError("ffprobe failed") from exc
+    except (json.JSONDecodeError, TypeError, ValueError) as exc:
+        raise RuntimeError("ffprobe returned invalid audio duration") from exc
+
+
 def split_audio(input_path: str, output_dir: str) -> list[str]:
     chunk_seconds = max(STREAM_CHUNK_SECONDS, 1.0)
     output_pattern = os.path.join(output_dir, "chunk_%05d.wav")
@@ -144,9 +185,12 @@ def split_audio(input_path: str, output_dir: str) -> list[str]:
     return chunks or [input_path]
 
 
-def format_stream_chunk(text: str, response_format: Optional[str]) -> str:
+def format_stream_chunk(text: str, response_format: Optional[str], duration: Optional[float] = None) -> str:
     if response_format in {"json", "verbose_json"}:
-        return json.dumps({"text": text}, ensure_ascii=False) + "\n"
+        payload = {"text": text}
+        if duration is not None:
+            payload["duration"] = round(duration, 3)
+        return json.dumps(payload, ensure_ascii=False) + "\n"
     return text + "\n"
 
 
@@ -155,6 +199,7 @@ def stream_transcription(
     language: Optional[str],
     hotwords: Optional[str],
     response_format: Optional[str],
+    audio_duration: float,
 ):
     try:
         with tempfile.TemporaryDirectory(prefix="funasr-stream-") as chunk_dir:
@@ -166,9 +211,17 @@ def stream_transcription(
                 elapsed = time.time() - start
                 first_result = result[0] if result else {}
                 text = clean_text(first_result.get("text", ""))
-                logger.info("Streamed FunASR chunk %s/%s in %.1fs", index, total_chunks, elapsed)
-                if text:
-                    yield format_stream_chunk(text, response_format)
+                is_final = index == total_chunks
+                logger.info(
+                    "Streamed FunASR chunk %s/%s in %.1fs; audio_duration=%.3fs",
+                    index,
+                    total_chunks,
+                    elapsed,
+                    audio_duration,
+                )
+                if text or (is_final and response_format in {"json", "verbose_json"}):
+                    duration = audio_duration if is_final and response_format in {"json", "verbose_json"} else None
+                    yield format_stream_chunk(text, response_format, duration)
     except Exception as exc:
         logger.exception("Streaming transcription error")
         yield format_stream_chunk(f"[ERROR] {exc}", response_format)
@@ -197,23 +250,27 @@ async def transcribe(
             tmp.write(content)
             tmp_path = tmp.name
 
+        audio_duration = probe_audio_duration(tmp_path)
+
         if stream:
             tmp_path_for_stream = tmp_path
             tmp_path = ""
             media_type = "application/x-ndjson" if response_format in {"json", "verbose_json"} else "text/plain"
             return StreamingResponse(
-                stream_transcription(tmp_path_for_stream, language, hotwords, response_format),
+                stream_transcription(tmp_path_for_stream, language, hotwords, response_format, audio_duration),
                 media_type=media_type,
+                headers=audio_duration_headers(audio_duration),
             )
 
         start = time.time()
         result = transcribe_files([tmp_path], language, hotwords)
         elapsed = time.time() - start
+        logger.info("Transcribed FunASR request in %.1fs; audio_duration=%.3fs", elapsed, audio_duration)
 
         first_result = result[0] if result else {}
         text = clean_text(first_result.get("text", ""))
         if response_format == "text":
-            return PlainTextResponse(text)
+            return PlainTextResponse(text, headers=audio_duration_headers(audio_duration))
 
         if response_format == "verbose_json":
             segments = []
@@ -231,12 +288,13 @@ async def transcribe(
                     "text": text,
                     "segments": segments,
                     "language": language or "auto",
-                    "duration": round(elapsed, 3),
+                    "duration": round(audio_duration, 3),
                     "model": model or MODEL_ID,
-                }
+                },
+                headers=audio_duration_headers(audio_duration),
             )
 
-        return JSONResponse({"text": text})
+        return JSONResponse({"text": text}, headers=audio_duration_headers(audio_duration))
     except Exception as exc:
         logger.exception("Transcription error")
         raise HTTPException(status_code=500, detail=str(exc)) from exc


### PR DESCRIPTION
Summary:
- Enables accurate billing for FunASR audio transcription by capturing real audio duration via `ffprobe` and exposing it in the `Audio-Duration-Seconds` response header.
- Introduces a lightweight audio adapter in AIGateway to extract this header value for runtime frameworks like `funasr` or `opencsg`, ensuring duration is available even in text-only response formats.