### PR TITLE
fix(reconcile): fix zombie deploys, Running↔Startup oscillation, and workflow timeout fallback

### DIFF
--- a/api/workflow/activity/deploy_reconcile_activity.go
+++ b/api/workflow/activity/deploy_reconcile_activity.go
@@ -140,9 +140,21 @@ func processBatchResult(ctx context.Context, a *Activities, deploy *database.Dep
 				return
 			}
 		case common.Running:
+			// For Deploying/Startup, the informer handles normal flow
+			// with more accurate status mapping (Deploying/Sleeping/Running).
+			// Reconcile should only fix anomalies, not interfere.
+			if currentStatus == common.Deploying || currentStatus == common.Startup {
+				return
+			}
 			newStatus = common.Running
 			instances = r.Instances
 		default:
+			// Service exists but not fully ready (Startup from batch API).
+			// Deploying/Startup: let informer handle the normal transition.
+			// Running: don't downgrade (scale-to-zero is normal).
+			if currentStatus == common.Deploying || currentStatus == common.Startup || currentStatus == common.Running {
+				return
+			}
 			newStatus = common.Startup
 			instances = r.Instances
 		}
@@ -212,7 +224,21 @@ func reconcileWorkflowCluster(ctx context.Context, a *Activities, cid string, wf
 		func(wf *database.ArgoWorkflow) (string, runnerTypes.BatchStatusItem) {
 			return wf.TaskId, runnerTypes.BatchStatusItem{Type: runnerTypes.ResourceTypeWorkflow, Name: wf.TaskId}
 		},
-		nil, // onBatchError: nil means no error handling (skip)
+		func(wf *database.ArgoWorkflow) {
+			lastUpdate := wf.StatusUpdateAt
+			if lastUpdate.IsZero() {
+				lastUpdate = wf.SubmitTime
+			}
+			if time.Since(lastUpdate) > hardTimeout {
+				a.getLogger(ctx).Warn("reconcile(wf): batch error timeout, marking failed",
+					"wf_id", wf.ID, "hard_timeout", hardTimeout)
+				wf.Status = v1alpha1.WorkflowFailed
+				wf.StatusUpdateAt = time.Now()
+				if _, err := a.stores.argoWorkFlow.UpdateWorkFlow(ctx, *wf); err != nil {
+					a.getLogger(ctx).Error("reconcile(wf): mark failed error", "wf_id", wf.ID, "error", err)
+				}
+			}
+		},
 		func(wf *database.ArgoWorkflow, r *runnerTypes.BatchStatusItemResult) {
 			if string(wf.Status) != r.Phase && len(r.Phase) > 0 {
 				wf.Status = v1alpha1.WorkflowPhase(r.Phase)
@@ -274,7 +300,7 @@ func clusterBatchDo[T any](
 
 	resp, err := a.deployer.BatchStatus(ctx, &runnerTypes.BatchStatusRequest{ClusterID: cid, Items: batchItems})
 	if err != nil {
-		logger.Error("reconcile: BatchStatus failed",
+		logger.Warn("reconcile: BatchStatus failed",
 			"cluster_id", cid, "count", len(items), "error", err)
 		if onBatchError != nil {
 			for i := range items {
@@ -293,6 +319,11 @@ func clusterBatchDo[T any](
 			if r.Error != "" {
 				logger.Warn("reconcile: batch item error",
 					"name", r.Name, "error", r.Error)
+			}
+			// Apply timeout fallback for individual errors,
+			// same as the whole-batch-failure path.
+			if ok && onBatchError != nil {
+				onBatchError(&items[idx])
 			}
 			continue
 		}

--- a/api/workflow/activity/deploy_reconcile_activity_test.go
+++ b/api/workflow/activity/deploy_reconcile_activity_test.go
@@ -78,13 +78,11 @@ func TestApplyStatusUpdate_ConcurrentModification(t *testing.T) {
 }
 
 func TestProcessBatchResult_KsvcRunning(t *testing.T) {
+	// When a Deploying deploy gets Running from runner, the informer handles
+	// this transition. Reconcile should skip — not interfere.
 	a := newTestActivities(t)
-	ds := a.stores.deployTask.(*mockdb.MockDeployTaskStore)
 	deploy := &database.Deploy{ID: 1, Type: types.SpaceType, SvcName: "s1", Status: common.Deploying}
-	ds.EXPECT().GetDeployByID(mock.Anything, int64(1)).Return(&database.Deploy{ID: 1, Status: common.Deploying}, nil).Once()
-	ds.EXPECT().UpdateDeploy(mock.Anything, mock.MatchedBy(func(d *database.Deploy) bool {
-		return d.Status == common.Running && !d.StatusUpdateAt.IsZero()
-	})).Return(nil).Once()
+	// No DB calls expected — informer handles normal Deploying→Running flow
 	processBatchResult(context.WithValue(context.Background(), "test", "test"), a, deploy, &runnerTypes.BatchStatusItemResult{Code: common.Running}, common.Deploying)
 }
 
@@ -111,6 +109,8 @@ func TestProcessBatchResult_SandboxRunning(t *testing.T) {
 }
 
 func TestReconcileDeployCluster_BatchSuccess(t *testing.T) {
+	// KSVC Deploying/Startup deploys are skipped (informer handles normal flow).
+	// Sandbox deploys are still processed. This test verifies both paths.
 	a := newTestActivities(t)
 	ds := a.stores.deployTask.(*mockdb.MockDeployTaskStore)
 	md := a.deployer.(*mock_deploy.MockDeployer)
@@ -120,13 +120,16 @@ func TestReconcileDeployCluster_BatchSuccess(t *testing.T) {
 		return req.ClusterID == "c1" && len(req.Items) == 2
 	})).Return(&runnerTypes.BatchStatusResponse{
 		Items: []runnerTypes.BatchStatusItemResult{
-			{Type: runnerTypes.ResourceTypeKsvc, Name: "s1", Code: common.Running},
-			{Type: runnerTypes.ResourceTypeSandbox, Name: "s2", Status: common.Running},
+			{Type: runnerTypes.ResourceTypeKsvc, Name: "s1", Code: common.Running},    // Deploying KSVC → skipped
+			{Type: runnerTypes.ResourceTypeSandbox, Name: "s2", Status: common.Running}, // Deploying Sandbox → processed
 		},
 	}, nil).Once()
 
-	ds.EXPECT().GetDeployByID(mock.Anything, mock.Anything).Return(&database.Deploy{ID: 1, Status: common.Deploying}, nil).Times(2)
-	ds.EXPECT().UpdateDeploy(mock.Anything, mock.Anything).Return(nil).Times(2)
+	// Only sandbox deploy gets updated; KSVC deploy is skipped
+	ds.EXPECT().GetDeployByID(mock.Anything, int64(2)).Return(&database.Deploy{ID: 2, Status: common.Deploying}, nil).Once()
+	ds.EXPECT().UpdateDeploy(mock.Anything, mock.MatchedBy(func(d *database.Deploy) bool {
+		return d.Status == common.Running && d.ID == int64(2)
+	})).Return(nil).Once()
 
 	deploys := []database.Deploy{
 		{ID: 1, Type: types.SpaceType, SvcName: "s1", ClusterID: "c1", Status: common.Deploying},
@@ -142,4 +145,150 @@ func TestReconcileAllStatus(t *testing.T) {
 	ds.EXPECT().ListDeploysNeedingReconcile(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Times(3)
 	wfs.EXPECT().ListWorkflowsNeedingReconcile(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Times(2)
 	require.NoError(t, a.ReconcileAllStatus(context.WithValue(context.Background(), "test", "test")))
+}
+
+func TestReconcileDeployCluster_BatchItemError_TimeoutFallback(t *testing.T) {
+	// When individual batch items have errors and are past hardTimeout,
+	// onBatchError should mark them as DeployFailed.
+	a := newTestActivities(t)
+	ds := a.stores.deployTask.(*mockdb.MockDeployTaskStore)
+	md := a.deployer.(*mock_deploy.MockDeployer)
+
+	md.EXPECT().CheckHeartbeatTimeout(mock.Anything, "c1").Return(false, nil).Once()
+	// BatchStatus returns individual item errors
+	md.EXPECT().BatchStatus(mock.Anything, mock.MatchedBy(func(req *runnerTypes.BatchStatusRequest) bool {
+		return req.ClusterID == "c1" && len(req.Items) == 1
+	})).Return(&runnerTypes.BatchStatusResponse{
+		Items: []runnerTypes.BatchStatusItemResult{
+			{Type: runnerTypes.ResourceTypeKsvc, Name: "s1", Error: "service not found in cluster"},
+		},
+	}, nil).Once()
+
+	// onBatchError will re-read the deploy, then update to DeployFailed
+	ds.EXPECT().GetDeployByID(mock.Anything, int64(1)).Return(&database.Deploy{ID: 1, Status: common.Deploying}, nil).Once()
+	ds.EXPECT().UpdateDeploy(mock.Anything, mock.MatchedBy(func(d *database.Deploy) bool {
+		return d.Status == common.DeployFailed && d.ID == int64(1)
+	})).Return(nil).Once()
+
+	// Set StatusUpdateAt far in the past so hardTimeout is exceeded
+	pastTime := time.Now().Add(-2 * time.Hour)
+	deploys := []database.Deploy{
+		{ID: 1, Type: types.SpaceType, SvcName: "s1", ClusterID: "c1", Status: common.Deploying, StatusUpdateAt: pastTime},
+	}
+	reconcileDeployCluster(context.WithValue(context.Background(), "test", "test"), a, "c1", deploys, common.Deploying, 30*time.Minute)
+}
+
+func TestReconcileDeployCluster_BatchItemError_NotTimedOut(t *testing.T) {
+	// When individual batch items have errors but are NOT past hardTimeout,
+	// onBatchError should be called but the internal check should skip the update.
+	a := newTestActivities(t)
+	md := a.deployer.(*mock_deploy.MockDeployer)
+
+	md.EXPECT().CheckHeartbeatTimeout(mock.Anything, "c1").Return(false, nil).Once()
+	md.EXPECT().BatchStatus(mock.Anything, mock.Anything).Return(&runnerTypes.BatchStatusResponse{
+		Items: []runnerTypes.BatchStatusItemResult{
+			{Type: runnerTypes.ResourceTypeKsvc, Name: "s1", Error: "service not found in cluster"},
+		},
+	}, nil).Once()
+
+	// onBatchError checks hardTimeout internally; since StatusUpdateAt is recent,
+	// it should NOT call GetDeployByID or UpdateDeploy.
+	// No mock expectations set → test will fail if those are called.
+
+	recentTime := time.Now() // not past hardTimeout
+	deploys := []database.Deploy{
+		{ID: 1, Type: types.SpaceType, SvcName: "s1", ClusterID: "c1", Status: common.Deploying, StatusUpdateAt: recentTime},
+	}
+	reconcileDeployCluster(context.WithValue(context.Background(), "test", "test"), a, "c1", deploys, common.Deploying, 30*time.Minute)
+}
+
+func TestReconcileWorkflowCluster_BatchItemError_TimeoutFallback(t *testing.T) {
+	// When workflow batch items have errors and are past hardTimeout,
+	// onBatchError should mark them as WorkflowFailed.
+	a := newTestActivities(t)
+	wfs := a.stores.argoWorkFlow.(*mockdb.MockArgoWorkFlowStore)
+	md := a.deployer.(*mock_deploy.MockDeployer)
+
+	md.EXPECT().CheckHeartbeatTimeout(mock.Anything, "c1").Return(false, nil).Once()
+	md.EXPECT().BatchStatus(mock.Anything, mock.Anything).Return(&runnerTypes.BatchStatusResponse{
+		Items: []runnerTypes.BatchStatusItemResult{
+			{Type: runnerTypes.ResourceTypeWorkflow, Name: "wf-task-1", Error: "workflow not found in cluster"},
+		},
+	}, nil).Once()
+
+	// onBatchError will check hardTimeout, then update the workflow
+	wfs.EXPECT().UpdateWorkFlow(mock.Anything, mock.MatchedBy(func(wf database.ArgoWorkflow) bool {
+		return string(wf.Status) == "Failed" && wf.ID == int64(1)
+	})).Return(&database.ArgoWorkflow{ID: 1, Status: "Failed"}, nil).Once()
+
+	pastTime := time.Now().Add(-2 * time.Hour)
+	wfsList := []database.ArgoWorkflow{
+		{ID: 1, TaskId: "wf-task-1", ClusterID: "c1", Status: "Running", StatusUpdateAt: pastTime},
+	}
+	reconcileWorkflowCluster(context.WithValue(context.Background(), "test", "test"), a, "c1", wfsList, 30*time.Minute)
+}
+
+func TestReconcileWorkflowCluster_BatchItemError_NotTimedOut(t *testing.T) {
+	// When workflow batch items have errors but are NOT past hardTimeout,
+	// onBatchError should be called but skip the update.
+	a := newTestActivities(t)
+	md := a.deployer.(*mock_deploy.MockDeployer)
+
+	md.EXPECT().CheckHeartbeatTimeout(mock.Anything, "c1").Return(false, nil).Once()
+	md.EXPECT().BatchStatus(mock.Anything, mock.Anything).Return(&runnerTypes.BatchStatusResponse{
+		Items: []runnerTypes.BatchStatusItemResult{
+			{Type: runnerTypes.ResourceTypeWorkflow, Name: "wf-task-1", Error: "workflow not found in cluster"},
+		},
+	}, nil).Once()
+
+	// No DB calls expected — onBatchError checks hardTimeout internally and skips
+
+	recentTime := time.Now()
+	wfsList := []database.ArgoWorkflow{
+		{ID: 1, TaskId: "wf-task-1", ClusterID: "c1", Status: "Running", StatusUpdateAt: recentTime},
+	}
+	reconcileWorkflowCluster(context.WithValue(context.Background(), "test", "test"), a, "c1", wfsList, 30*time.Minute)
+}
+
+func TestReconcileWorkflowCluster_BatchSuccess(t *testing.T) {
+	// Normal path: status synced from runner
+	a := newTestActivities(t)
+	wfs := a.stores.argoWorkFlow.(*mockdb.MockArgoWorkFlowStore)
+	md := a.deployer.(*mock_deploy.MockDeployer)
+
+	md.EXPECT().CheckHeartbeatTimeout(mock.Anything, "c1").Return(false, nil).Once()
+	md.EXPECT().BatchStatus(mock.Anything, mock.Anything).Return(&runnerTypes.BatchStatusResponse{
+		Items: []runnerTypes.BatchStatusItemResult{
+			{Type: runnerTypes.ResourceTypeWorkflow, Name: "wf-task-1", Phase: "Succeeded"},
+		},
+	}, nil).Once()
+
+	wfs.EXPECT().UpdateWorkFlow(mock.Anything, mock.MatchedBy(func(wf database.ArgoWorkflow) bool {
+		return string(wf.Status) == "Succeeded" && wf.ID == int64(1)
+	})).Return(&database.ArgoWorkflow{ID: 1, Status: "Succeeded"}, nil).Once()
+
+	wfsList := []database.ArgoWorkflow{
+		{ID: 1, TaskId: "wf-task-1", ClusterID: "c1", Status: "Running"},
+	}
+	reconcileWorkflowCluster(context.WithValue(context.Background(), "test", "test"), a, "c1", wfsList, 30*time.Minute)
+}
+
+func TestProcessBatchResult_RunningNotDowngraded(t *testing.T) {
+	// When a KSVC deploy is Running and the runner returns Startup (e.g. scale-to-zero),
+	// the status should NOT be downgraded.
+	a := newTestActivities(t)
+	deploy := &database.Deploy{ID: 1, Type: types.SpaceType, SvcName: "s1", Status: common.Running}
+	// No DB calls expected — processBatchResult should return early
+	processBatchResult(context.WithValue(context.Background(), "test", "test"), a, deploy,
+		&runnerTypes.BatchStatusItemResult{Code: common.Startup}, common.Running)
+}
+
+func TestProcessBatchResult_DeployingStillStartup(t *testing.T) {
+	// When a Deploying deploy gets Startup from runner, the informer handles
+	// the normal transition. Reconcile should skip — not interfere.
+	a := newTestActivities(t)
+	deploy := &database.Deploy{ID: 1, Type: types.SpaceType, SvcName: "s1", Status: common.Deploying}
+	// No DB calls expected — informer handles normal Deploying→Startup flow
+	processBatchResult(context.WithValue(context.Background(), "test", "test"), a, deploy,
+		&runnerTypes.BatchStatusItemResult{Code: common.Startup}, common.Deploying)
 }


### PR DESCRIPTION
Summary:
- Fixes zombie deployments and workflow timeouts by applying `onBatchError` fallback logic to individual batch item errors, ensuring resources are marked as failed after the hard timeout threshold is exceeded.
- Resolves Running↔Startup state oscillation by preventing state downgrades when a runner returns non-Running codes (e.g., Knative scale-to-zero) while the deployment is already in a Running state.
- Reduces log noise by downgrading error logs for non-existent cluster IDs to warnings, as these cases are already handled by the existing timeout fallback mechanism.