### PR TITLE
fix audio token usages in aigateway

### DIFF
--- a/aigateway/handler/response_writer_wrapper_audio_test.go
+++ b/aigateway/handler/response_writer_wrapper_audio_test.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"net/http"
@@ -8,7 +10,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	audioadapter "opencsg.com/csghub-server/aigateway/component/adapter/audio"
 	"opencsg.com/csghub-server/aigateway/token"
+	commontypes "opencsg.com/csghub-server/common/types"
 )
 
 type failingAudioResponseWriter struct {
@@ -32,7 +36,7 @@ func (w *failingAudioResponseWriter) Write([]byte) (int, error) {
 func TestResponseWriterWrapperAudio_UsesResponseUsage(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, false)
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, nil)
 
 	_, err := w.Write([]byte(`{"text":"hello","usage":{"prompt_tokens":371,"completion_tokens":52,"total_tokens":423,"seconds":9.2}}`))
 	require.NoError(t, err)
@@ -48,7 +52,7 @@ func TestResponseWriterWrapperAudio_UsesResponseUsage(t *testing.T) {
 func TestResponseWriterWrapperAudio_UsesResponseUsageFromChunkedJSON(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, false)
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, nil)
 
 	_, err := w.Write([]byte(`{"text":"hello","usage":`))
 	require.NoError(t, err)
@@ -84,7 +88,7 @@ func TestResponseWriterWrapperAudio_CapturesDurationFromUsage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			counter := token.NewAudioUsageCounter(nil)
 			recorder := httptest.NewRecorder()
-			w := NewResponseWriterWrapperAudio(recorder, counter, false)
+			w := NewResponseWriterWrapperAudio(recorder, counter, false, nil)
 
 			_, err := w.Write([]byte(tt.body))
 			require.NoError(t, err)
@@ -103,7 +107,7 @@ func TestResponseWriterWrapperAudio_CapturesDurationFromUsage(t *testing.T) {
 func TestResponseWriterWrapperAudio_CapturesFunASRVerboseJSONDuration(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, false)
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, nil)
 
 	_, err := w.Write([]byte(`{"text":"hello","segments":[{"start":0,"end":1.23,"text":"hello","speaker":null}],"language":"auto","duration":1.23,"model":"local"}`))
 	require.NoError(t, err)
@@ -121,7 +125,7 @@ func TestResponseWriterWrapperAudio_CapturesFunASRVerboseJSONDuration(t *testing
 func TestResponseWriterWrapperAudio_SkipsMissingDuration(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, false)
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, nil)
 
 	_, err := w.Write([]byte(`{"text":"hello","usage":{"prompt_tokens":1,"total_tokens":1}}`))
 	require.NoError(t, err)
@@ -130,12 +134,86 @@ func TestResponseWriterWrapperAudio_SkipsMissingDuration(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestAudioResponseWriter_NonStreamCapturesDurationFromHeader(t *testing.T) {
+	counter := token.NewAudioUsageCounter(nil)
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("Audio-Duration-Seconds", "9.2")
+	recorder.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, audioadapter.NewFunASRAdapter())
+	w.WriteHeader(http.StatusOK)
+
+	_, err := w.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	require.Equal(t, "hello", recorder.Body.String())
+	require.Equal(t, "text/plain; charset=utf-8", recorder.Header().Get("Content-Type"))
+	duration, ok := w.DurationSeconds()
+	require.True(t, ok)
+	require.Equal(t, 9.2, duration)
+	usage, err := counter.Usage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 9.2, usage.Duration)
+	require.Equal(t, "hello", usage.CompletionDesc)
+}
+
+func TestAudioResponseWriter_NonStreamHeaderDurationWinsOverBody(t *testing.T) {
+	counter := token.NewAudioUsageCounter(nil)
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("Audio-Duration-Seconds", "9.2")
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, audioadapter.NewFunASRAdapter())
+	w.WriteHeader(http.StatusOK)
+
+	_, err := w.Write([]byte(`{"text":"hello","segments":[{"start":0,"end":1.2,"text":"hello"}],"duration":12.5}`))
+	require.NoError(t, err)
+
+	require.JSONEq(t, `{"text":"hello","segments":[{"start":0,"end":1.2,"text":"hello"}],"duration":12.5}`, recorder.Body.String())
+	duration, ok := w.DurationSeconds()
+	require.True(t, ok)
+	require.Equal(t, 9.2, duration)
+}
+
+func TestFunASRAudioResponseWriter_NonStreamVerboseJSONPassthroughCapturesDuration(t *testing.T) {
+	counter := token.NewAudioUsageCounter(nil)
+	recorder := httptest.NewRecorder()
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, audioadapter.NewFunASRAdapter())
+	body := `{"text":"hello","segments":[],"duration":12.5}`
+	w.WriteHeader(http.StatusOK)
+
+	_, err := w.Write([]byte(body))
+	require.NoError(t, err)
+
+	require.JSONEq(t, body, recorder.Body.String())
+	duration, ok := w.DurationSeconds()
+	require.True(t, ok)
+	require.Equal(t, 12.5, duration)
+}
+
+func TestAudioResponseWriter_OpenAICompatibleAdapterPassesThroughGzipBody(t *testing.T) {
+	counter := token.NewAudioUsageCounter(nil)
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("Content-Encoding", "gzip")
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, audioadapter.NewOpenAICompatibleAdapter())
+	w.WriteHeader(http.StatusOK)
+
+	var body bytes.Buffer
+	gzipWriter := gzip.NewWriter(&body)
+	_, err := gzipWriter.Write([]byte(`{"text":"hello"}`))
+	require.NoError(t, err)
+	require.NoError(t, gzipWriter.Close())
+
+	_, err = w.Write(body.Bytes())
+	require.NoError(t, err)
+
+	require.Equal(t, body.Bytes(), recorder.Body.Bytes())
+	require.Equal(t, "gzip", recorder.Header().Get("Content-Encoding"))
+}
+
 func newTestNDJSONWriter(t *testing.T) (*token.AudioUsageCounter, *httptest.ResponseRecorder, audioResponseWriter) {
 	t.Helper()
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
 	recorder.Header().Set("Content-Type", "application/x-ndjson")
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 	w.WriteHeader(http.StatusOK)
 	return counter, recorder, w
 }
@@ -143,7 +221,7 @@ func newTestNDJSONWriter(t *testing.T) (*token.AudioUsageCounter, *httptest.Resp
 func TestNewResponseWriterWrapperAudio_FactoryStream(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 	_, ok := w.(*streamAudioResponseWriter)
 	require.True(t, ok, "expected *streamAudioResponseWriter when useStream=true")
 }
@@ -151,7 +229,7 @@ func TestNewResponseWriterWrapperAudio_FactoryStream(t *testing.T) {
 func TestNewResponseWriterWrapperAudio_FactoryNonStream(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, false)
+	w := NewResponseWriterWrapperAudio(recorder, counter, false, nil)
 	_, ok := w.(*nonStreamAudioResponseWriter)
 	require.True(t, ok, "expected *nonStreamAudioResponseWriter when useStream=false")
 }
@@ -224,6 +302,68 @@ func TestStreamAudioResponseWriter_DurationFromChunk(t *testing.T) {
 	require.Equal(t, 12.5, usage.Duration)
 }
 
+func TestStreamAudioResponseWriter_DurationOnlyChunk(t *testing.T) {
+	counter, recorder, w := newTestNDJSONWriter(t)
+
+	_, err := w.Write([]byte(`{"text":"","duration":12.5}` + "\n"))
+	require.NoError(t, err)
+
+	require.Equal(t, `{"text":"","duration":12.5}`+"\n", recorder.Body.String())
+	duration, ok := w.DurationSeconds()
+	require.True(t, ok)
+	require.Equal(t, 12.5, duration)
+
+	usage, err := counter.Usage(context.Background())
+	require.NoError(t, err)
+	require.Zero(t, usage.TotalTokens)
+	require.Zero(t, usage.CompletionTokens)
+	require.Equal(t, string(commontypes.DataTypeAudio), usage.DataType)
+	require.Equal(t, 12.5, usage.Duration)
+	require.Equal(t, int64(1), usage.CompletionRC)
+	require.Empty(t, usage.CompletionDesc)
+}
+
+func TestStreamAudioResponseWriter_CountOnlyChunk(t *testing.T) {
+	counter, recorder, w := newTestNDJSONWriter(t)
+
+	_, err := w.Write([]byte(`{"text":""}` + "\n"))
+	require.NoError(t, err)
+
+	require.Equal(t, `{"text":""}`+"\n", recorder.Body.String())
+	_, ok := w.DurationSeconds()
+	require.False(t, ok)
+
+	usage, err := counter.Usage(context.Background())
+	require.NoError(t, err)
+	require.Zero(t, usage.TotalTokens)
+	require.Zero(t, usage.CompletionTokens)
+	require.Equal(t, string(commontypes.DataTypeAudio), usage.DataType)
+	require.Zero(t, usage.Duration)
+	require.Equal(t, int64(1), usage.CompletionRC)
+	require.Empty(t, usage.CompletionDesc)
+}
+
+func TestStreamAudioResponseWriter_CapturesDurationFromHeader(t *testing.T) {
+	counter := token.NewAudioUsageCounter(nil)
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("Content-Type", "application/x-ndjson")
+	recorder.Header().Set("Audio-Duration-Seconds", "9.2")
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, audioadapter.NewFunASRAdapter())
+	w.WriteHeader(http.StatusOK)
+
+	_, err := w.Write([]byte(`{"text":"hello"}` + "\n" + `{"text":"","duration":12.5}` + "\n"))
+	require.NoError(t, err)
+
+	require.Equal(t, `{"text":"hello"}`+"\n"+`{"text":"","duration":12.5}`+"\n", recorder.Body.String())
+	duration, ok := w.DurationSeconds()
+	require.True(t, ok)
+	require.Equal(t, 9.2, duration)
+	usage, err := counter.Usage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "hello", usage.CompletionDesc)
+	require.Equal(t, 9.2, usage.Duration)
+}
+
 func TestStreamAudioResponseWriter_DoesNotInventFallbackDuration(t *testing.T) {
 	counter, _, w := newTestNDJSONWriter(t)
 
@@ -251,7 +391,7 @@ func TestStreamAudioResponseWriter_WriteHeaderDeletesContentLength(t *testing.T)
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
 	recorder.Header().Set("Content-Length", "100")
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 
 	w.WriteHeader(http.StatusOK)
 
@@ -261,7 +401,7 @@ func TestStreamAudioResponseWriter_WriteHeaderDeletesContentLength(t *testing.T)
 func TestStreamAudioResponseWriter_ErrorPassthrough(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 
 	w.WriteHeader(http.StatusBadGateway)
 	_, err := w.Write([]byte(`{"error":"upstream failure"}`))
@@ -274,7 +414,7 @@ func TestStreamAudioResponseWriter_ReturnsZeroOnWriteError(t *testing.T) {
 	writeErr := errors.New("write failed")
 	internalWriter := &failingAudioResponseWriter{err: writeErr}
 	internalWriter.Header().Set("Content-Type", "application/x-ndjson")
-	w := NewResponseWriterWrapperAudio(internalWriter, token.NewAudioUsageCounter(nil), true)
+	w := NewResponseWriterWrapperAudio(internalWriter, token.NewAudioUsageCounter(nil), true, nil)
 	w.WriteHeader(http.StatusOK)
 
 	n, err := w.Write([]byte(`{"text":"hello"}` + "\n"))
@@ -313,7 +453,7 @@ func TestStreamAudioResponseWriter_SSEDecoder(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
 	recorder.Header().Set("Content-Type", "text/event-stream")
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 
 	// WriteHeader triggers SSE decoder selection.
 	w.WriteHeader(http.StatusOK)
@@ -331,7 +471,7 @@ func TestStreamAudioResponseWriter_SSEMultipleEvents(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
 	recorder.Header().Set("Content-Type", "text/event-stream")
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte("data: {\"text\":\"first\"}\n\ndata: {\"text\":\"second\"}\n\n"))
@@ -346,7 +486,7 @@ func TestStreamAudioResponseWriter_SSEDoneEvent(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
 	recorder.Header().Set("Content-Type", "text/event-stream")
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte("data: {\"text\":\"ok\"}\n\ndata: [DONE]\n\n"))
@@ -362,7 +502,7 @@ func TestStreamAudioResponseWriter_UnknownContentTypePassthrough(t *testing.T) {
 	counter := token.NewAudioUsageCounter(nil)
 	recorder := httptest.NewRecorder()
 	// No recognized Content-Type — passthrough raw without parsing.
-	w := NewResponseWriterWrapperAudio(recorder, counter, true)
+	w := NewResponseWriterWrapperAudio(recorder, counter, true, nil)
 	w.WriteHeader(http.StatusOK)
 
 	_, err := w.Write([]byte(`{"text":"not-parsed"}` + "\n"))
@@ -371,7 +511,12 @@ func TestStreamAudioResponseWriter_UnknownContentTypePassthrough(t *testing.T) {
 	// Raw bytes forwarded as-is.
 	require.Equal(t, "{\"text\":\"not-parsed\"}\n", recorder.Body.String())
 
-	// No usage captured since decoder was nil.
-	_, err = counter.Usage(context.Background())
-	require.Error(t, err)
+	usage, err := counter.Usage(context.Background())
+	require.NoError(t, err)
+	require.Zero(t, usage.TotalTokens)
+	require.Zero(t, usage.CompletionTokens)
+	require.Equal(t, string(commontypes.DataTypeAudio), usage.DataType)
+	require.Zero(t, usage.Duration)
+	require.Equal(t, int64(1), usage.CompletionRC)
+	require.Empty(t, usage.CompletionDesc)
 }

--- a/aigateway/token/audio_usage_counter.go
+++ b/aigateway/token/audio_usage_counter.go
@@ -2,7 +2,7 @@ package token
 
 import (
 	"context"
-	"errors"
+	"log/slog"
 	"unicode/utf8"
 
 	commontypes "opencsg.com/csghub-server/common/types"
@@ -44,15 +44,14 @@ func (c *AudioUsageCounter) Usage(ctx context.Context) (*Usage, error) {
 	if c.usage != nil {
 		return c.usage, nil
 	}
-	if c.text == "" {
-		return nil, errors.New("no transcription text found")
-	}
+	// Audio billing can fall back to completion count when text and duration are unavailable.
 	tokenCount := int64(utf8.RuneCountInString(c.text))
-	if c.tokenizer != nil {
-		var err error
-		tokenCount, err = c.tokenizer.EmbeddingEncode(c.text)
-		if err != nil {
-			return nil, err
+	if c.text != "" && c.tokenizer != nil {
+		if count, err := c.tokenizer.EmbeddingEncode(c.text); err != nil {
+			// Tokenizer failures should not block audio billing; keep the rune-count fallback.
+			slog.WarnContext(ctx, "failed to encode audio transcription text, using rune count", slog.Any("error", err))
+		} else {
+			tokenCount = count
 		}
 	}
 	return &Usage{

--- a/aigateway/token/audio_usage_counter_test.go
+++ b/aigateway/token/audio_usage_counter_test.go
@@ -2,10 +2,23 @@ package token
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/types"
+	commontypes "opencsg.com/csghub-server/common/types"
 )
+
+type failingEmbeddingTokenizer struct{}
+
+func (t failingEmbeddingTokenizer) Encode(types.Message) (int64, error) {
+	return 0, errors.New("encode failed")
+}
+
+func (t failingEmbeddingTokenizer) EmbeddingEncode(string) (int64, error) {
+	return 0, errors.New("embedding encode failed")
+}
 
 func TestAudioUsageCounter_Usage(t *testing.T) {
 	counter := NewAudioUsageCounter(&DumyTokenizer{})
@@ -30,6 +43,32 @@ func TestAudioUsageCounter_Usage_FallbackWithoutTokenizer(t *testing.T) {
 	require.Equal(t, int64(5), usage.TotalTokens)
 }
 
+func TestAudioUsageCounter_Usage_FallbackWhenTokenizerFails(t *testing.T) {
+	counter := NewAudioUsageCounter(failingEmbeddingTokenizer{})
+	counter.Text("hello")
+
+	usage, err := counter.Usage(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, int64(5), usage.TotalTokens)
+	require.Equal(t, int64(5), usage.CompletionTokens)
+}
+
+func TestAudioUsageCounter_Usage_DurationOnly(t *testing.T) {
+	counter := NewAudioUsageCounter(&DumyTokenizer{})
+	counter.Duration(3.5)
+
+	usage, err := counter.Usage(context.Background())
+
+	require.NoError(t, err)
+	require.Zero(t, usage.TotalTokens)
+	require.Zero(t, usage.CompletionTokens)
+	require.Equal(t, string(commontypes.DataTypeAudio), usage.DataType)
+	require.Equal(t, 3.5, usage.Duration)
+	require.Equal(t, int64(1), usage.CompletionRC)
+	require.Empty(t, usage.CompletionDesc)
+}
+
 func TestAudioUsageCounter_Usage_ResponseUsage(t *testing.T) {
 	counter := NewAudioUsageCounter(&DumyTokenizer{})
 	counter.Text("hello")
@@ -49,10 +88,16 @@ func TestAudioUsageCounter_Usage_ResponseUsage(t *testing.T) {
 	require.Equal(t, 9.2, usage.Duration)
 }
 
-func TestAudioUsageCounter_Usage_NoText(t *testing.T) {
+func TestAudioUsageCounter_Usage_CountOnly(t *testing.T) {
 	counter := NewAudioUsageCounter(&DumyTokenizer{})
 
-	_, err := counter.Usage(context.Background())
+	usage, err := counter.Usage(context.Background())
 
-	require.ErrorContains(t, err, "no transcription text found")
+	require.NoError(t, err)
+	require.Zero(t, usage.TotalTokens)
+	require.Zero(t, usage.CompletionTokens)
+	require.Equal(t, string(commontypes.DataTypeAudio), usage.DataType)
+	require.Zero(t, usage.Duration)
+	require.Equal(t, int64(1), usage.CompletionRC)
+	require.Empty(t, usage.CompletionDesc)
 }


### PR DESCRIPTION
Summary:
- Adjusted `AudioUsageCounter.Usage` to emit count-only audio usage for successful requests even when text or duration is missing, ensuring billing reliability in streaming scenarios where full text caching is unstable.
- Retained duration-based billing logic while making tokenizer failures non-blocking by falling back to rune counting, preventing usage recording from being blocked by encoding errors.