### PR TITLE
remove default pagination from aigateway model list

### DIFF
--- a/aigateway/component/openai.go
+++ b/aigateway/component/openai.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -274,33 +273,28 @@ func filterAndPaginateModels(models []types.Model, req types.ListModelsReq) type
 
 	models = applyFilters(models, filters)
 
-	per := 20
-	page := 1
-	if req.Per != "" {
-		if parsedPer, err := strconv.Atoi(req.Per); err == nil && parsedPer > 0 {
-			per = parsedPer
-			if per > 100 {
-				per = 100
-			}
-		}
-	}
-	if req.Page != "" {
-		if parsedPage, err := strconv.Atoi(req.Page); err == nil && parsedPage > 0 {
-			page = parsedPage
-		}
-	}
-
 	totalCount := len(models)
-	startIndex := (page - 1) * per
-	if startIndex > totalCount {
-		startIndex = totalCount
-	}
-	endIndex := startIndex + per
-	if endIndex > totalCount {
-		endIndex = totalCount
-	}
+	paginated := models
+	hasMore := false
 
-	paginated := models[startIndex:endIndex]
+	if req.Per > 0 && req.Page > 0 {
+		per := req.Per
+		if per > 100 {
+			per = 100
+		}
+
+		startIndex := (req.Page - 1) * per
+		if startIndex > totalCount {
+			startIndex = totalCount
+		}
+		endIndex := startIndex + per
+		if endIndex > totalCount {
+			endIndex = totalCount
+		}
+
+		paginated = models[startIndex:endIndex]
+		hasMore = endIndex < totalCount
+	}
 
 	var firstID, lastID *string
 	if len(paginated) > 0 {
@@ -313,7 +307,7 @@ func filterAndPaginateModels(models []types.Model, req types.ListModelsReq) type
 		Data:       paginated,
 		FirstID:    firstID,
 		LastID:     lastID,
-		HasMore:    endIndex < totalCount,
+		HasMore:    hasMore,
 		TotalCount: totalCount,
 	}
 }

--- a/aigateway/component/openai_test.go
+++ b/aigateway/component/openai_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -64,7 +65,7 @@ func TestFilterAndPaginateModels(t *testing.T) {
 		{BaseModel: types.BaseModel{ID: "gpt-4o:svc4", Object: "model", OwnedBy: "u3"}},
 	}
 
-	t.Run("no filters default pagination", func(t *testing.T) {
+	t.Run("no filters returns all models without pagination params", func(t *testing.T) {
 		resp := filterAndPaginateModels(models, types.ListModelsReq{})
 		assert.Equal(t, "list", resp.Object)
 		assert.Equal(t, 4, resp.TotalCount)
@@ -83,12 +84,33 @@ func TestFilterAndPaginateModels(t *testing.T) {
 	})
 
 	t.Run("pagination per/page applied after filters", func(t *testing.T) {
-		resp := filterAndPaginateModels(models, types.ListModelsReq{ModelID: "gpt", Per: "2", Page: "2"})
+		resp := filterAndPaginateModels(models, types.ListModelsReq{ModelID: "gpt", Per: 2, Page: 2})
 		// gpt matches 3 models; page=2 per=2 yields 1 item
 		assert.Equal(t, 3, resp.TotalCount)
 		assert.Len(t, resp.Data, 1)
 		assert.Equal(t, "gpt-4o:svc4", resp.Data[0].ID)
 		assert.False(t, resp.HasMore)
+	})
+
+	t.Run("pagination has more when more filtered models remain", func(t *testing.T) {
+		resp := filterAndPaginateModels(models, types.ListModelsReq{ModelID: "gpt", Per: 2, Page: 1})
+		assert.Equal(t, 3, resp.TotalCount)
+		require.Len(t, resp.Data, 2)
+		assert.Equal(t, "gpt-4:svc1", resp.Data[0].ID)
+		assert.Equal(t, "gpt-3.5:svc2", resp.Data[1].ID)
+		assert.True(t, resp.HasMore)
+	})
+
+	t.Run("per is capped at 100 when pagination is requested", func(t *testing.T) {
+		manyModels := make([]types.Model, 105)
+		for i := range manyModels {
+			manyModels[i] = types.Model{BaseModel: types.BaseModel{ID: fmt.Sprintf("model-%03d", i), Object: "model", OwnedBy: "u1"}}
+		}
+
+		resp := filterAndPaginateModels(manyModels, types.ListModelsReq{Per: 101, Page: 1})
+		assert.Equal(t, 105, resp.TotalCount)
+		assert.Len(t, resp.Data, 100)
+		assert.True(t, resp.HasMore)
 	})
 
 	t.Run("llm_types filter external_llm", func(t *testing.T) {
@@ -281,8 +303,8 @@ func TestFilterAndPaginateModels(t *testing.T) {
 			LLMTypes:           []string{types.ProviderTypeInference},
 			Task:               "text-generation",
 			HasAssociatedModel: &hasAssociatedModel,
-			Per:                "1",
-			Page:               "2",
+			Per:                1,
+			Page:               2,
 		})
 		assert.Equal(t, 2, resp.TotalCount)
 		require.Len(t, resp.Data, 1)

--- a/aigateway/handler/openai.go
+++ b/aigateway/handler/openai.go
@@ -273,10 +273,10 @@ type OpenAIHandlerImpl struct {
 // @Param        llm_types query []string false "Filter by LLM types" Enums(external_llm, serverless, inference)
 // @Param        task query string false "Filter by task (e.g., text-generation, text-to-image, image-to-image)"
 // @Param        has_associated_model query bool false "Filter by whether models are linked to a CSGHub model repository"
-// @Param        per query int false "Models per page (default 20, max 100)"
-// @Param        page query int false "Page number (1-based, default 1)"
+// @Param        per query int false "Models per page, must be provided with page (max 100)"
+// @Param        page query int false "Page number, must be provided with per (1-based)"
 // @Success      200  {object}  types.ModelList "OK"
-// @Failure      400  {object}  error "Invalid llm_types or has_associated_model parameter"
+// @Failure      400  {object}  error "Invalid llm_types, has_associated_model, or pagination parameter"
 // @Failure      500  {object}  error "Internal server error"
 // @Router       /v1/models [get]
 func (h *OpenAIHandlerImpl) ListModels(c *gin.Context) {
@@ -314,13 +314,21 @@ func (h *OpenAIHandlerImpl) ListModels(c *gin.Context) {
 		hasAssociatedModel = &parsed
 	}
 
+	per, page, paginationErr := parseListModelsPagination(c)
+	if paginationErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": *paginationErr,
+		})
+		return
+	}
+
 	resp, err := h.openaiComponent.ListModels(c.Request.Context(), currentUser, types.ListModelsReq{
 		ModelID:            c.Query("model_id"),
 		LLMTypes:           llmTypes,
 		Task:               c.Query("task"),
 		HasAssociatedModel: hasAssociatedModel,
-		Per:                c.Query("per"),
-		Page:               c.Query("page"),
+		Per:                per,
+		Page:               page,
 	})
 	if err != nil {
 		slog.ErrorContext(c.Request.Context(), "failed to get available models", "error", err.Error(), "current_user", currentUser)
@@ -351,6 +359,32 @@ func invalidLLMTypesErrorMessage() string {
 
 func invalidHasAssociatedModelErrorMessage() string {
 	return "Invalid has_associated_model parameter. Allowed values: true, false"
+}
+
+func parseListModelsPagination(c *gin.Context) (int, int, *types.Error) {
+	perValue, hasPer := c.GetQuery("per")
+	pageValue, hasPage := c.GetQuery("page")
+	if hasPer != hasPage {
+		return 0, 0, &types.Error{
+			Code:    "invalid_request_error",
+			Message: "per and page must be provided together",
+			Type:    "invalid_request_error",
+		}
+	}
+	if !hasPer {
+		return 0, 0, nil
+	}
+
+	per, perErr := strconv.Atoi(perValue)
+	page, pageErr := strconv.Atoi(pageValue)
+	if perErr != nil || pageErr != nil || per <= 0 || page <= 0 {
+		return 0, 0, &types.Error{
+			Code:    "invalid_request_error",
+			Message: "Invalid pagination parameter. per and page must be positive integers",
+			Type:    "invalid_request_error",
+		}
+	}
+	return per, page, nil
 }
 
 // GetModel godoc

--- a/aigateway/handler/openai_test.go
+++ b/aigateway/handler/openai_test.go
@@ -181,8 +181,8 @@ func TestOpenAIHandler_ListModels(t *testing.T) {
 		tester.mocks.openAIComp.EXPECT().
 			ListModels(mock.Anything, "testuser", types.ListModelsReq{
 				ModelID: "gpt",
-				Per:     "2",
-				Page:    "3",
+				Per:     2,
+				Page:    3,
 			}).
 			Return(types.ModelList{Object: "list", Data: []types.Model{}, HasMore: false, TotalCount: 0}, nil).Once()
 
@@ -201,8 +201,8 @@ func TestOpenAIHandler_ListModels(t *testing.T) {
 		tester.mocks.openAIComp.EXPECT().
 			ListModels(mock.Anything, "testuser", types.ListModelsReq{
 				Task: "text-generation",
-				Per:  "10",
-				Page: "1",
+				Per:  10,
+				Page: 1,
 			}).
 			Return(types.ModelList{
 				Object:     "list",
@@ -316,6 +316,68 @@ func TestOpenAIHandler_ListModels(t *testing.T) {
 			assert.True(t, ok)
 			assert.Equal(t, "invalid_request_error", errObj["code"])
 			assert.Contains(t, errObj["message"], "Invalid has_associated_model parameter")
+		})
+	}
+
+	t.Run("only per returns bad request", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		tester.WithQuery("per", "20")
+
+		tester.handler.ListModels(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		errObj, ok := response["error"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "invalid_request_error", errObj["code"])
+		assert.Contains(t, errObj["message"], "per and page must be provided together")
+	})
+
+	t.Run("only page returns bad request", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		tester.WithQuery("page", "1")
+
+		tester.handler.ListModels(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		errObj, ok := response["error"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "invalid_request_error", errObj["code"])
+		assert.Contains(t, errObj["message"], "per and page must be provided together")
+	})
+
+	for _, tc := range []struct {
+		name string
+		per  string
+		page string
+	}{
+		{name: "non-integer per", per: "abc", page: "1"},
+		{name: "non-integer page", per: "20", page: "abc"},
+		{name: "zero per", per: "0", page: "1"},
+		{name: "zero page", per: "20", page: "0"},
+		{name: "negative per", per: "-1", page: "1"},
+		{name: "negative page", per: "20", page: "-1"},
+	} {
+		t.Run("invalid pagination parameter "+tc.name, func(t *testing.T) {
+			tester, c, w := setupTest(t)
+			tester.WithQuery("per", tc.per)
+			tester.WithQuery("page", tc.page)
+
+			tester.handler.ListModels(c)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			var response map[string]interface{}
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			assert.NoError(t, err)
+			errObj, ok := response["error"].(map[string]interface{})
+			assert.True(t, ok)
+			assert.Equal(t, "invalid_request_error", errObj["code"])
+			assert.Contains(t, errObj["message"], "Invalid pagination parameter")
 		})
 	}
 

--- a/aigateway/types/openai.go
+++ b/aigateway/types/openai.go
@@ -274,12 +274,10 @@ type ModelList struct {
 }
 
 // ListModelsReq defines query-like parameters for listing models.
-// Fields are passed as strings so the component layer can own parsing,
-// filtering, and pagination behavior consistently.
 type ListModelsReq struct {
 	ModelID            string   `json:"model_id"`
-	Per                string   `json:"per"`
-	Page               string   `json:"page"`
+	Per                int      `json:"per"`
+	Page               int      `json:"page"`
 	LLMTypes           []string `json:"llm_types"` // filter by llm_type
 	Task               string   `json:"task"`      // filter by task
 	HasAssociatedModel *bool    `json:"has_associated_model"`


### PR DESCRIPTION
Summary:
- Removed default pagination from the AIGateway model list to ensure all models are returned by default, aligning with standard OpenAI `/v1/models` behavior and fixing display issues in third-party tools.
- Pagination is now strictly opt-in, requiring both `per` and `page` parameters to be provided together; requests with missing, partial, or invalid parameters now return a `400 invalid_request_error`.