### PR TITLE
feat(moderation): implement image content safety check

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/sensitive/mock_SensitiveChecker.go
+++ b/_mocks/opencsg.com/csghub-server/builder/sensitive/mock_SensitiveChecker.go
@@ -4,6 +4,7 @@ package sensitive
 
 import (
 	context "context"
+	io "io"
 
 	mock "github.com/stretchr/testify/mock"
 	sensitive "opencsg.com/csghub-server/builder/sensitive"
@@ -141,6 +142,66 @@ func (_c *MockSensitiveChecker_PassImageURLCheck_Call) Return(_a0 *sensitive.Che
 }
 
 func (_c *MockSensitiveChecker_PassImageURLCheck_Call) RunAndReturn(run func(context.Context, types.SensitiveScenario, string) (*sensitive.CheckResult, error)) *MockSensitiveChecker_PassImageURLCheck_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PassImageStreamCheck provides a mock function with given fields: ctx, scenario, reader
+func (_m *MockSensitiveChecker) PassImageStreamCheck(ctx context.Context, scenario types.SensitiveScenario, reader io.Reader) (*sensitive.CheckResult, error) {
+	ret := _m.Called(ctx, scenario, reader)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PassImageStreamCheck")
+	}
+
+	var r0 *sensitive.CheckResult
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.SensitiveScenario, io.Reader) (*sensitive.CheckResult, error)); ok {
+		return rf(ctx, scenario, reader)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, types.SensitiveScenario, io.Reader) *sensitive.CheckResult); ok {
+		r0 = rf(ctx, scenario, reader)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sensitive.CheckResult)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, types.SensitiveScenario, io.Reader) error); ok {
+		r1 = rf(ctx, scenario, reader)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockSensitiveChecker_PassImageStreamCheck_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PassImageStreamCheck'
+type MockSensitiveChecker_PassImageStreamCheck_Call struct {
+	*mock.Call
+}
+
+// PassImageStreamCheck is a helper method to define mock.On call
+//   - ctx context.Context
+//   - scenario types.SensitiveScenario
+//   - reader io.Reader
+func (_e *MockSensitiveChecker_Expecter) PassImageStreamCheck(ctx interface{}, scenario interface{}, reader interface{}) *MockSensitiveChecker_PassImageStreamCheck_Call {
+	return &MockSensitiveChecker_PassImageStreamCheck_Call{Call: _e.mock.On("PassImageStreamCheck", ctx, scenario, reader)}
+}
+
+func (_c *MockSensitiveChecker_PassImageStreamCheck_Call) Run(run func(ctx context.Context, scenario types.SensitiveScenario, reader io.Reader)) *MockSensitiveChecker_PassImageStreamCheck_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.SensitiveScenario), args[2].(io.Reader))
+	})
+	return _c
+}
+
+func (_c *MockSensitiveChecker_PassImageStreamCheck_Call) Return(_a0 *sensitive.CheckResult, _a1 error) *MockSensitiveChecker_PassImageStreamCheck_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockSensitiveChecker_PassImageStreamCheck_Call) RunAndReturn(run func(context.Context, types.SensitiveScenario, io.Reader) (*sensitive.CheckResult, error)) *MockSensitiveChecker_PassImageStreamCheck_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/builder/sensitive/aho_corasick.go
+++ b/builder/sensitive/aho_corasick.go
@@ -2,6 +2,7 @@ package sensitive
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"strings"
 
@@ -71,6 +72,14 @@ func (iac *ACAutomation) PassImageCheck(ctx context.Context, scenario types.Sens
 // PassImageURLCheck implements the SensitiveChecker interface for ImmutableAC
 func (iac *ACAutomation) PassImageURLCheck(ctx context.Context, scenario types.SensitiveScenario, imageURL string) (*CheckResult, error) {
 	slog.WarnContext(ctx, "PassImageURLCheck not implemented in Immutable AC checker")
+	return &CheckResult{
+		IsSensitive: false,
+	}, nil
+}
+
+// PassImageStreamCheck implements the SensitiveChecker interface for ImmutableAC
+func (iac *ACAutomation) PassImageStreamCheck(ctx context.Context, scenario types.SensitiveScenario, reader io.Reader) (*CheckResult, error) {
+	slog.WarnContext(ctx, "PassImageStreamCheck not implemented in Immutable AC checker")
 	return &CheckResult{
 		IsSensitive: false,
 	}, nil

--- a/builder/sensitive/aliyun_green.go
+++ b/builder/sensitive/aliyun_green.go
@@ -5,15 +5,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	openapi "github.com/alibabacloud-go/darabonba-openapi/v2/client"
 	green20220302 "github.com/alibabacloud-go/green-20220302/v2/client"
 	util "github.com/alibabacloud-go/tea-utils/v2/service"
 	"github.com/google/uuid"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 
 	"github.com/alibabacloud-go/tea/tea"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/green"
@@ -92,12 +96,36 @@ type AliyunGreenChecker struct {
 	green2022 Green2022Client
 	//normal client
 	green GreenClient
+	//s3Client is a minio client pointing at Aliyun OSS, used for temporary
+	//image uploads when checking images from private repos. nil if OSS is
+	//not configured.
+	s3Client s3Client
+	//s3BucketName is the name of the Aliyun OSS bucket used for temp uploads.
+	s3BucketName string
+}
+
+// s3Client is the subset of minio.Client methods used by AliyunGreenChecker
+// for temporary image uploads. It allows mocking in tests.
+type s3Client interface {
+	PutObject(ctx context.Context, bucketName, objectName string, reader io.Reader, objectSize int64, opts minio.PutObjectOptions) (minio.UploadInfo, error)
+	RemoveObject(ctx context.Context, bucketName, objectName string, opts minio.RemoveObjectOptions) error
 }
 
 func NewAliyunChecker(green GreenClient, green2022 Green2022Client) *AliyunGreenChecker {
 	return &AliyunGreenChecker{
 		green:     green,
 		green2022: green2022,
+	}
+}
+
+// NewAliyunCheckerWithS3 creates an AliyunGreenChecker with an OSS client for
+// image stream checks. Used in tests; production code uses initS3Client.
+func NewAliyunCheckerWithS3(green GreenClient, green2022 Green2022Client, s3Cli s3Client, bucketName string) *AliyunGreenChecker {
+	return &AliyunGreenChecker{
+		green:        green,
+		green2022:    green2022,
+		s3Client:     s3Cli,
+		s3BucketName: bucketName,
 	}
 }
 
@@ -112,7 +140,6 @@ func NewAliyunGreenCheckerFromConfig(config *config.Config) *AliyunGreenChecker 
 	accessKeySecret := config.SensitiveCheck.AccessKeySecret
 	region := config.SensitiveCheck.Region
 	slog.Debug("Aliyun client init", slog.String("accessKeyID", accessKeyID),
-		slog.String("accessKeySecret", accessKeySecret),
 		slog.String("region", region))
 
 	aliyunConfig := &openapi.Config{
@@ -135,7 +162,45 @@ func NewAliyunGreenCheckerFromConfig(config *config.Config) *AliyunGreenChecker 
 	return &AliyunGreenChecker{
 		&green2022ClientImpl{green: cip},
 		&greenClientImpl{green: c},
+		nil,
+		"",
 	}
+}
+
+// initS3Client initializes a minio client pointing at Aliyun OSS using the
+// SensitiveCheck credentials (same AK/SK as Aliyun Green). This ensures the
+// temporary uploaded objects are in the same Aliyun OSS account, so Aliyun
+// Green can read them directly via PassImageCheck (ossBucketName + ossObjectName).
+//
+// Called separately to allow the checker to function without OSS (URL-based
+// checks still work). If OSSBucket is empty, s3Client stays nil.
+func (c *AliyunGreenChecker) initS3Client(config *config.Config) {
+	bucketName := config.SensitiveCheck.OSSBucket
+	if bucketName == "" {
+		slog.Warn("sensitive check OSS bucket not configured, image stream check will be unavailable for private repos")
+		return
+	}
+
+	endpoint := config.SensitiveCheck.Endpoint
+	accessKeyID := config.SensitiveCheck.AccessKeyID
+	accessKeySecret := config.SensitiveCheck.AccessKeySecret
+	region := config.SensitiveCheck.Region
+	enableSSL := config.SensitiveCheck.EnableSSL
+
+	client, err := minio.New(endpoint, &minio.Options{
+		Creds:        credentials.NewStaticV4(accessKeyID, accessKeySecret, ""),
+		Secure:       enableSSL,
+		BucketLookup: minio.BucketLookupAuto,
+		Region:       region,
+	})
+	if err != nil {
+		slog.Error("failed to create OSS client for sensitive check", slog.Any("error", err))
+		return
+	}
+
+	c.s3Client = client
+	c.s3BucketName = bucketName
+	slog.Info("sensitive check OSS client initialized", slog.String("bucket", bucketName), slog.String("endpoint", endpoint))
 }
 
 // passLargeTextCheck splits large text into smaller `largeTextSize` bytes chunks and check them in batch
@@ -384,4 +449,37 @@ func (c *AliyunGreenChecker) PassImageCheck(ctx context.Context, scenario types.
 	}
 	labelStr := strings.Join(labels, ",")
 	return &CheckResult{IsSensitive: true, Reason: labelStr}, nil
+}
+
+// PassImageStreamCheck uploads an image stream to a temporary Aliyun OSS object,
+// then calls PassImageCheck for moderation. Aliyun Green reads the object
+// directly from OSS using the bucket name and object key (no presigned URL needed).
+// The temporary object is always deleted after the check completes.
+func (c *AliyunGreenChecker) PassImageStreamCheck(ctx context.Context, scenario types.SensitiveScenario, reader io.Reader) (*CheckResult, error) {
+	if c.s3Client == nil {
+		return nil, errors.New("OSS client is not initialized, image stream check is unavailable")
+	}
+
+	// Generate a unique object key for the temporary upload
+	objectKey := fmt.Sprintf("moderation/temp/%s", uuid.New().String())
+
+	// Upload the image stream to OSS. Set Expires to 30 minutes from now as a
+	// safety net — even if the defer delete fails, the object auto-expires.
+	_, err := c.s3Client.PutObject(ctx, c.s3BucketName, objectKey, reader, -1, minio.PutObjectOptions{
+		ContentType: "application/octet-stream",
+		Expires:     time.Now().Add(30 * time.Minute),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to upload image stream to OSS: %w", err)
+	}
+
+	// Always clean up the temporary object
+	defer func() {
+		if delErr := c.s3Client.RemoveObject(ctx, c.s3BucketName, objectKey, minio.RemoveObjectOptions{}); delErr != nil {
+			slog.ErrorContext(ctx, "failed to delete temporary image from OSS", slog.String("objectKey", objectKey), slog.Any("error", delErr))
+		}
+	}()
+
+	// Aliyun Green reads the object directly from OSS via bucket name + object key
+	return c.PassImageCheck(ctx, scenario, c.s3BucketName, objectKey)
 }

--- a/builder/sensitive/aliyun_green_stream_test.go
+++ b/builder/sensitive/aliyun_green_stream_test.go
@@ -1,0 +1,162 @@
+package sensitive
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	green20220302 "github.com/alibabacloud-go/green-20220302/v2/client"
+	util "github.com/alibabacloud-go/tea-utils/v2/service"
+	"github.com/alibabacloud-go/tea/tea"
+	"github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"opencsg.com/csghub-server/common/types"
+)
+
+// mockS3Client is a test double for the s3Client interface.
+type mockS3Client struct {
+	mock.Mock
+}
+
+func (m *mockS3Client) PutObject(ctx context.Context, bucketName, objectName string, reader io.Reader, objectSize int64, opts minio.PutObjectOptions) (minio.UploadInfo, error) {
+	args := m.Called(ctx, bucketName, objectName, reader, objectSize, opts)
+	return args.Get(0).(minio.UploadInfo), args.Error(1)
+}
+
+func (m *mockS3Client) RemoveObject(ctx context.Context, bucketName, objectName string, opts minio.RemoveObjectOptions) error {
+	return m.Called(ctx, bucketName, objectName, opts).Error(0)
+}
+
+// mockGreen2022 is a minimal test double for Green2022Client.
+type mockGreen2022 struct {
+	mock.Mock
+}
+
+func (m *mockGreen2022) GetRegionId() string {
+	return m.Called().String(0)
+}
+
+func (m *mockGreen2022) TextModeration(request *green20220302.TextModerationRequest) (*green20220302.TextModerationResponse, error) {
+	args := m.Called(request)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*green20220302.TextModerationResponse), args.Error(1)
+}
+
+func (m *mockGreen2022) ImageModeration(request *green20220302.ImageModerationRequest) (*green20220302.ImageModerationResponse, error) {
+	args := m.Called(request)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*green20220302.ImageModerationResponse), args.Error(1)
+}
+
+func (m *mockGreen2022) TextModerationPlusWithOptions(request *green20220302.TextModerationPlusRequest, options *util.RuntimeOptions) (*green20220302.TextModerationPlusResponse, error) {
+	args := m.Called(request, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*green20220302.TextModerationPlusResponse), args.Error(1)
+}
+
+func TestPassImageStreamCheck_NilS3Client(t *testing.T) {
+	checker := NewAliyunChecker(nil, &mockGreen2022{})
+	_, err := checker.PassImageStreamCheck(context.Background(), types.ScenarioImageBaseLineCheck, strings.NewReader("image-data"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not initialized")
+}
+
+func TestPassImageStreamCheck_UploadFailed(t *testing.T) {
+	g2c := &mockGreen2022{}
+	mc := &mockS3Client{}
+	mc.On("PutObject", mock.Anything, "test-bucket", mock.AnythingOfType("string"), mock.Anything, int64(-1), mock.Anything).
+		Return(minio.UploadInfo{}, errors.New("upload failed")).Once()
+	mc.On("RemoveObject", mock.Anything, "test-bucket", mock.AnythingOfType("string"), mock.Anything).
+		Return(nil).Once()
+
+	checker := NewAliyunCheckerWithS3(nil, g2c, mc, "test-bucket")
+	_, err := checker.PassImageStreamCheck(context.Background(), types.ScenarioImageBaseLineCheck, strings.NewReader("image-data"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to upload")
+}
+
+func TestPassImageStreamCheck_PassCheck(t *testing.T) {
+	g2c := &mockGreen2022{}
+	mc := &mockS3Client{}
+	mc.On("PutObject", mock.Anything, "test-bucket", mock.AnythingOfType("string"), mock.Anything, int64(-1), mock.MatchedBy(func(opts minio.PutObjectOptions) bool {
+		// Verify Expires is set to ~30 minutes from now
+		return !opts.Expires.IsZero() && opts.Expires.After(time.Now().Add(29*time.Minute)) && opts.Expires.Before(time.Now().Add(31*time.Minute))
+	})).Return(minio.UploadInfo{}, nil).Once()
+	mc.On("RemoveObject", mock.Anything, "test-bucket", mock.AnythingOfType("string"), mock.Anything).
+		Return(nil).Once()
+	g2c.On("GetRegionId").Return("cn-beijing").Once()
+	g2c.On("ImageModeration", mock.Anything).Return(&green20220302.ImageModerationResponse{
+		StatusCode: tea.Int32(200),
+		Body: &green20220302.ImageModerationResponseBody{
+			Code:      tea.Int32(200),
+			RequestId: tea.String("req-1"),
+			Data: &green20220302.ImageModerationResponseBodyData{
+				Result: []*green20220302.ImageModerationResponseBodyDataResult{},
+			},
+		},
+	}, nil).Once()
+
+	checker := NewAliyunCheckerWithS3(nil, g2c, mc, "test-bucket")
+	result, err := checker.PassImageStreamCheck(context.Background(), types.ScenarioImageBaseLineCheck, strings.NewReader("image-data"))
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.False(t, result.IsSensitive)
+	mc.AssertExpectations(t)
+}
+
+func TestPassImageStreamCheck_SensitiveDetected(t *testing.T) {
+	g2c := &mockGreen2022{}
+	mc := &mockS3Client{}
+	mc.On("PutObject", mock.Anything, "test-bucket", mock.AnythingOfType("string"), mock.Anything, int64(-1), mock.Anything).
+		Return(minio.UploadInfo{}, nil).Once()
+	mc.On("RemoveObject", mock.Anything, "test-bucket", mock.AnythingOfType("string"), mock.Anything).
+		Return(nil).Once()
+	g2c.On("GetRegionId").Return("cn-beijing").Once()
+	g2c.On("ImageModeration", mock.Anything).Return(&green20220302.ImageModerationResponse{
+		StatusCode: tea.Int32(200),
+		Body: &green20220302.ImageModerationResponseBody{
+			Code:      tea.Int32(200),
+			RequestId: tea.String("req-2"),
+			Data: &green20220302.ImageModerationResponseBodyData{
+				Result: []*green20220302.ImageModerationResponseBodyDataResult{
+					{
+						Label:      tea.String("porn"),
+						Confidence: tea.Float32(95),
+					},
+				},
+			},
+		},
+	}, nil).Once()
+
+	checker := NewAliyunCheckerWithS3(nil, g2c, mc, "test-bucket")
+	result, err := checker.PassImageStreamCheck(context.Background(), types.ScenarioImageBaseLineCheck, strings.NewReader("image-data"))
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, result.IsSensitive)
+	assert.Contains(t, result.Reason, "porn")
+}
+
+func TestPassImageStreamCheck_ModerationError(t *testing.T) {
+	g2c := &mockGreen2022{}
+	mc := &mockS3Client{}
+	mc.On("PutObject", mock.Anything, "test-bucket", mock.AnythingOfType("string"), mock.Anything, int64(-1), mock.Anything).
+		Return(minio.UploadInfo{}, nil).Once()
+	mc.On("RemoveObject", mock.Anything, "test-bucket", mock.AnythingOfType("string"), mock.Anything).
+		Return(nil).Once()
+	g2c.On("GetRegionId").Return("cn-beijing").Once()
+	g2c.On("ImageModeration", mock.Anything).Return(nil, errors.New("moderation api error")).Once()
+
+	checker := NewAliyunCheckerWithS3(nil, g2c, mc, "test-bucket")
+	_, err := checker.PassImageStreamCheck(context.Background(), types.ScenarioImageBaseLineCheck, strings.NewReader("image-data"))
+	assert.Error(t, err)
+}

--- a/builder/sensitive/chain.go
+++ b/builder/sensitive/chain.go
@@ -2,6 +2,7 @@ package sensitive
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"strings"
 
@@ -32,6 +33,7 @@ func WithAliYunChecker() ChainOption {
 			config.SensitiveCheck.AccessKeySecret != "" &&
 			config.SensitiveCheck.Region != "" {
 			checker := NewAliyunGreenCheckerFromConfig(config)
+			checker.initS3Client(config)
 			c.checkers = append(c.checkers, checker)
 		} else {
 			slog.Warn("sensitive config for AliYun modereation service not set")
@@ -109,6 +111,20 @@ func (c *chainImpl) PassImageCheck(ctx context.Context, scenario types.Sensitive
 func (c *chainImpl) PassImageURLCheck(ctx context.Context, scenario types.SensitiveScenario, imageURL string) (*CheckResult, error) {
 	for _, checker := range c.checkers {
 		res, err := checker.PassImageURLCheck(ctx, scenario, imageURL)
+		if err != nil {
+			return nil, err
+		}
+		if res.IsSensitive {
+			// If any checker detects sensitivity, return immediately
+			return res, nil
+		}
+	}
+	return &CheckResult{IsSensitive: false}, nil
+}
+
+func (c *chainImpl) PassImageStreamCheck(ctx context.Context, scenario types.SensitiveScenario, reader io.Reader) (*CheckResult, error) {
+	for _, checker := range c.checkers {
+		res, err := checker.PassImageStreamCheck(ctx, scenario, reader)
 		if err != nil {
 			return nil, err
 		}

--- a/builder/sensitive/sensitive_checker.go
+++ b/builder/sensitive/sensitive_checker.go
@@ -2,6 +2,7 @@ package sensitive
 
 import (
 	"context"
+	"io"
 
 	"opencsg.com/csghub-server/common/types"
 )
@@ -10,6 +11,7 @@ type SensitiveChecker interface {
 	PassTextCheck(ctx context.Context, scenario types.SensitiveScenario, text string) (*CheckResult, error)
 	PassImageCheck(ctx context.Context, scenario types.SensitiveScenario, ossBucketName, ossObjectName string) (*CheckResult, error)
 	PassImageURLCheck(ctx context.Context, scenario types.SensitiveScenario, imageURL string) (*CheckResult, error)
+	PassImageStreamCheck(ctx context.Context, scenario types.SensitiveScenario, reader io.Reader) (*CheckResult, error)
 	PassLLMCheck(ctx context.Context, req *types.LLMCheckRequest) (*CheckResult, error)
 }
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -139,18 +139,33 @@ type Config struct {
 	}
 
 	SensitiveCheck struct {
-		Enable              bool     `env:"STARHUB_SERVER_SENSITIVE_CHECK_ENABLE" default:"false"`
-		AccessKeyID         string   `env:"STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_ID"`
-		AccessKeySecret     string   `env:"STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_SECRET"`
-		Region              string   `env:"STARHUB_SERVER_SENSITIVE_CHECK_REGION"`
-		Endpoint            string   `env:"STARHUB_SERVER_SENSITIVE_CHECK_ENDPOINT" default:"oss-cn-beijing.aliyuncs.com"`
-		EnableSSL           bool     `env:"STARHUB_SERVER_SENSITIVE_CHECK_ENABLE_SSL" default:"true"`
+		Enable          bool   `env:"STARHUB_SERVER_SENSITIVE_CHECK_ENABLE" default:"false"`
+		AccessKeyID     string `env:"STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_ID"`
+		AccessKeySecret string `env:"STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_SECRET"`
+		Region          string `env:"STARHUB_SERVER_SENSITIVE_CHECK_REGION"`
+		Endpoint        string `env:"STARHUB_SERVER_SENSITIVE_CHECK_ENDPOINT" default:"oss-cn-beijing.aliyuncs.com"`
+		EnableSSL       bool   `env:"STARHUB_SERVER_SENSITIVE_CHECK_ENABLE_SSL" default:"true"`
+		// OSSBucket is the Aliyun OSS bucket used for temporary image uploads
+		// when checking images from private repos (where no public URL is
+		// available). The bucket must be in the same Aliyun account as
+		// AccessKeyID/AccessKeySecret so that Aliyun Green can read it directly.
+		// Required only when ImageCheckEnable is true and private repos need
+		// image moderation.
+		OSSBucket string `env:"STARHUB_SERVER_SENSITIVE_CHECK_OSS_BUCKET" default:"sensitive-check"`
+
 		DictDir             string   `env:"STARHUB_SERVER_SENSITIVE_CHECK_DICT_DIR" default:"/starhub-bin/vocabulary"`
 		CheckChain          []string `env:"STARHUB_SERVER_SENSITIVE_CHECK_CHECK_CHAIN" default:"[ac_automaton,mutable_ac_automaton,aliyun_green]"`
 		StreamCheckMode     string   `env:"STARHUB_SERVER_SENSITIVE_CHECK_STREAM_CHECK_MODE" default:"async"` // sync | async
 		AsyncBufferMaxChars int      `env:"STARHUB_SERVER_SENSITIVE_CHECK_ASYNC_BUFFER_MAX_CHARS" default:"50"`
 		// aliyun green max content length: 2000 | qwen guard max content length: 7000
 		MaxContentLength int `env:"STARHUB_SERVER_SENSITIVE_CHECK_MAX_CONTENT_LENGTH" default:"2000"`
+		// ImageCheckEnable controls whether image files are sent to the remote
+		// moderation service for content safety checking. Disabled by default
+		// because image moderation incurs extra API costs.
+		ImageCheckEnable bool `env:"STARHUB_SERVER_SENSITIVE_CHECK_IMAGE_ENABLE" default:"false"`
+		// ImageCheckScenario is the Aliyun Green scenario used for image moderation.
+		// Defaults to "baselineCheck" (ScenarioImageBaseLineCheck).
+		ImageCheckScenario string `env:"STARHUB_SERVER_SENSITIVE_CHECK_IMAGE_SCENARIO" default:"baselineCheck"`
 
 		LLM struct {
 			Enable       bool    `env:"STARHUB_SERVER_SENSITIVE_CHECK_LLM_ENABLE" default:"false"`

--- a/common/config/config.toml.example
+++ b/common/config/config.toml.example
@@ -80,11 +80,14 @@ public_bucket = "opencsg-public-resource"
 
 [sensitive_check]
 enable = false
+image_check_enable = false
 access_key_id = ""
 access_key_secret = ""
 region = ""
 endpoint = "oss-cn-beijing.aliyuncs.com"
 enable_ssl = true
+oss_bucket = "sensitive-check"
+image_check_scenario = "baselineCheck"
 # "ac_automaton", "mutable_ac_automaton", "aliyun_green", "guard_llm"]
 check_chain = ["ac_automaton", "mutable_ac_automaton", "aliyun_green"]
 stream_check_mode = "async"

--- a/common/types/repo.go
+++ b/common/types/repo.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"path"
+	"strings"
 	"time"
 )
 
@@ -8,6 +10,24 @@ var (
 	REPOCARD_FILENAME = "README.md"
 	HUGGINGFACE_HOST  = "huggingface.co"
 )
+
+// KnownImageFileExts lists file extensions recognised as image files.
+// Keep this as the single source of truth — do not duplicate elsewhere.
+var KnownImageFileExts = []string{".png", ".jpg", ".jpeg", ".gif", ".tif", ".tiff", ".svg", ".bmp", ".webp"}
+
+// IsImageFile returns true if the file path has a known image extension.
+func IsImageFile(filePath string) bool {
+	ext := path.Ext(filePath)
+	if len(ext) == 0 {
+		return false
+	}
+	for _, imageExt := range KnownImageFileExts {
+		if strings.EqualFold(ext, imageExt) {
+			return true
+		}
+	}
+	return false
+}
 
 type (
 	RepositoryType       string

--- a/go.mod
+++ b/go.mod
@@ -252,7 +252,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
-	github.com/rs/dnscache v0.0.0-20230804202142-fc85eb664529 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/samber/lo v1.47.0 // indirect
 	github.com/sebest/xff v0.0.0-20210106013422-671bd2870b3a // indirect

--- a/go.sum
+++ b/go.sum
@@ -1660,8 +1660,6 @@ github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
-github.com/gpustack/gguf-parser-go v0.17.2 h1:/51oABezbPgRT0mPmdO6H8JTaGvXf4yzfJn/IBu0rwY=
-github.com/gpustack/gguf-parser-go v0.17.2/go.mod h1:GvHh1Kvvq5ojCOsJ5UpwiJJmIjFw3Qk5cW7R+CZ3IJo=
 github.com/gpustack/gguf-parser-go v0.24.1 h1:nTYtL8HFK6ZhB90RKBu4oX2b3ZHpJLrMmKRfL9w9Cyc=
 github.com/gpustack/gguf-parser-go v0.24.1/go.mod h1:y4TwTtDqFWTK+xvprOjRUh+dowgU2TKCX37vRKvGiZ0=
 github.com/grafana/sigil-sdk/go v0.5.0 h1:VKOV7cHa6v07bHhU0eApOs/5Nrl6FAgkImr69tw+fQA=
@@ -2281,8 +2279,6 @@ github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rs/dnscache v0.0.0-20230804202142-fc85eb664529 h1:18kd+8ZUlt/ARXhljq+14TwAoKa61q6dX8jtwOf6DH8=
-github.com/rs/dnscache v0.0.0-20230804202142-fc85eb664529/go.mod h1:qe5TWALJ8/a1Lqznoc5BDHpYX/8HU60Hm2AwRmqzxqA=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=

--- a/moderation/checker/file_checker.go
+++ b/moderation/checker/file_checker.go
@@ -3,21 +3,29 @@ package checker
 import (
 	"context"
 	"io"
+	"log/slog"
 	"path"
 	"slices"
 	"strings"
+	"time"
 
+	"github.com/avast/retry-go/v4"
 	"opencsg.com/csghub-server/builder/sensitive"
 	"opencsg.com/csghub-server/common/types"
 )
 
-var knownImageFileExts = []string{".png", ".jpg", ".jpeg", ".gif", ".tif", ".tiff", ".svg", ".bmp", ".webp"}
 var knownTextFileExts = []string{".md", ".txt", ".csv", ".json", ".jsonl", ".html",
 	//code file types
 	".cs", ".js", ".ts", ".py", ".php", ".java", ".c", ".cpp", ".go", ".rb", ".sh"}
 
+// FileCheckContext carries the file content reader and metadata needed by file checkers.
+type FileCheckContext struct {
+	Reader   io.Reader
+	ImageURL string // publicly-accessible URL for image files; empty for non-image files
+}
+
 type FileChecker interface {
-	Run(ctx context.Context, reader io.Reader) (types.SensitiveCheckStatus, string)
+	Run(ctx context.Context, fctx FileCheckContext) (types.SensitiveCheckStatus, string)
 }
 
 // GetFileChecker returns a FileChecker for a given file based on its type and path.
@@ -43,7 +51,7 @@ func GetFileChecker(fileType string, filePath, lfsRelativePath string) FileCheck
 		return &UnkownFileChecker{}
 	}
 
-	if slices.ContainsFunc(knownImageFileExts, func(imageExt string) bool {
+	if slices.ContainsFunc(types.KnownImageFileExts, func(imageExt string) bool {
 		return strings.EqualFold(ext, imageExt)
 	}) {
 		return NewImageFileChecker()
@@ -58,24 +66,105 @@ func GetFileChecker(fileType string, filePath, lfsRelativePath string) FileCheck
 	return &UnkownFileChecker{}
 }
 
+// ImageFileChecker checks image files for sensitive content by delegating to a
+// SensitiveChecker. The checker needs a publicly-accessible image URL so that
+// the remote moderation service can fetch the image.
+//
+// The enable flag and scenario are injected at construction time to avoid
+// global state and ensure test isolation.
 type ImageFileChecker struct {
-	checker sensitive.SensitiveChecker
+	checker  sensitive.SensitiveChecker
+	enabled  bool
+	scenario types.SensitiveScenario
 }
 
 func NewImageFileChecker() FileChecker {
 	return &ImageFileChecker{
-		checker: contentChecker,
+		checker:  contentChecker,
+		enabled:  imageCheckEnabled,
+		scenario: imageCheckScenario,
 	}
 }
-func (c *ImageFileChecker) Run(context.Context, io.Reader) (types.SensitiveCheckStatus, string) {
-	//TODO:check image in the future
-	return types.SensitiveCheckSkip, "skip image file"
+
+func (c *ImageFileChecker) Run(ctx context.Context, fctx FileCheckContext) (types.SensitiveCheckStatus, string) {
+	if !c.enabled {
+		return types.SensitiveCheckSkip, "skip image file, image check is not enabled"
+	}
+
+	// For public repos, ImageURL is available — check by URL.
+	// For private repos, ImageURL is empty — check by uploading the stream to S3.
+	if fctx.ImageURL != "" {
+		return c.checkByURL(ctx, fctx.ImageURL)
+	}
+	if fctx.Reader != nil {
+		return c.checkByStream(ctx, fctx.Reader)
+	}
+	return types.SensitiveCheckException, "image url is empty and no stream available"
+}
+
+// checkByURL checks an image via its publicly-accessible URL.
+func (c *ImageFileChecker) checkByURL(ctx context.Context, imageURL string) (types.SensitiveCheckStatus, string) {
+	// Each attempt gets a 10s timeout. With 3 attempts and backoff delay,
+	// worst case is ~30s per file. This is acceptable because CheckRepoFiles
+	// is a Temporal activity with no hard 30s limit, and concurrency is
+	// bounded by concurrencyLimit in the repo component.
+	res, err := retry.DoWithData(
+		func() (*sensitive.CheckResult, error) {
+			reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			return c.checker.PassImageURLCheck(reqCtx, c.scenario, imageURL)
+		}, retry.Attempts(3), retry.DelayType(retry.BackOffDelay), retry.LastErrorOnly(true),
+		retry.RetryIf(func(error) bool {
+			// stop retrying once the parent context is cancelled.
+			// All other errors (including Aliyun 4xx) are retried because
+			// the Aliyun SDK does not expose a structured error type that
+			// reliably distinguishes transient vs permanent failures.
+			return ctx.Err() == nil
+		}))
+
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to check image content by url", slog.String("imageURL", imageURL), slog.Any("error", err))
+		return types.SensitiveCheckException, "call sensitive image url checker api failed"
+	}
+
+	if res.IsSensitive {
+		slog.InfoContext(ctx, "url image content is sensitive", slog.String("imageURL", imageURL), slog.String("reason", res.Reason))
+		return types.SensitiveCheckFail, res.Reason
+	}
+
+	return types.SensitiveCheckPass, ""
+}
+
+// checkByStream checks an image by uploading its stream to S3 and generating
+// a presigned URL. Used for private repos where no public URL is available.
+func (c *ImageFileChecker) checkByStream(ctx context.Context, reader io.Reader) (types.SensitiveCheckStatus, string) {
+	res, err := retry.DoWithData(
+		func() (*sensitive.CheckResult, error) {
+			reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+			return c.checker.PassImageStreamCheck(reqCtx, c.scenario, reader)
+		}, retry.Attempts(3), retry.DelayType(retry.BackOffDelay), retry.LastErrorOnly(true),
+		retry.RetryIf(func(error) bool {
+			return ctx.Err() == nil
+		}))
+
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to check image content by stream", slog.Any("error", err))
+		return types.SensitiveCheckException, "call sensitive image stream checker api failed"
+	}
+
+	if res.IsSensitive {
+		slog.InfoContext(ctx, "stream image content is sensitive", slog.String("reason", res.Reason))
+		return types.SensitiveCheckFail, res.Reason
+	}
+
+	return types.SensitiveCheckPass, ""
 }
 
 type LfsFileChecker struct {
 }
 
-func (c *LfsFileChecker) Run(context.Context, io.Reader) (types.SensitiveCheckStatus, string) {
+func (c *LfsFileChecker) Run(ctx context.Context, fctx FileCheckContext) (types.SensitiveCheckStatus, string) {
 	// dont need to check lfs file content
 	return types.SensitiveCheckSkip, "skip lfs file"
 }
@@ -83,6 +172,6 @@ func (c *LfsFileChecker) Run(context.Context, io.Reader) (types.SensitiveCheckSt
 type FolderChecker struct {
 }
 
-func (c *FolderChecker) Run(ctx context.Context, reader io.Reader) (types.SensitiveCheckStatus, string) {
+func (c *FolderChecker) Run(ctx context.Context, fctx FileCheckContext) (types.SensitiveCheckStatus, string) {
 	return types.SensitiveCheckSkip, "skip folder"
 }

--- a/moderation/checker/file_checker_test.go
+++ b/moderation/checker/file_checker_test.go
@@ -2,9 +2,14 @@ package checker
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/mock"
+	mocksens "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/sensitive"
+	"opencsg.com/csghub-server/builder/sensitive"
 	"opencsg.com/csghub-server/common/types"
 )
 
@@ -61,33 +66,188 @@ func TestGetFileChecker(t *testing.T) {
 }
 
 func TestImageFileChecker_Run(t *testing.T) {
-	checker := &ImageFileChecker{}
-	reader := strings.NewReader("image content")
-	expectedStatus := types.SensitiveCheckSkip
-	expectedMessage := "skip image file"
-	status, message := checker.Run(context.Background(), reader)
-	if status != expectedStatus || message != expectedMessage {
-		t.Errorf("Expected (%v, %v), got (%v, %v)", expectedStatus, expectedMessage, status, message)
+	const testImageURL = "http://example.com/images/test.png"
+
+	// newEnabledChecker creates an ImageFileChecker with the given enable flag
+	// and mock sensitive checker, avoiding global state mutation.
+	newEnabledChecker := func(enabled bool, mockChecker sensitive.SensitiveChecker) *ImageFileChecker {
+		return &ImageFileChecker{checker: mockChecker, enabled: enabled, scenario: types.ScenarioImageBaseLineCheck}
 	}
+
+	t.Run("image check disabled should skip", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		c := newEnabledChecker(false, mockChecker)
+		status, message := c.Run(context.Background(), FileCheckContext{Reader: strings.NewReader(""), ImageURL: testImageURL})
+		if status != types.SensitiveCheckSkip {
+			t.Errorf("Expected status %v, got %v", types.SensitiveCheckSkip, status)
+		}
+		if message != "skip image file, image check is not enabled" {
+			t.Errorf("Expected message '%s', got '%s'", "skip image file, image check is not enabled", message)
+		}
+	})
+
+	t.Run("sensitive image detected", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		mockChecker.EXPECT().PassImageURLCheck(mock.Anything, types.ScenarioImageBaseLineCheck, testImageURL).
+			Return(&sensitive.CheckResult{IsSensitive: true, Reason: "label:porn,confidence:0.95"}, nil)
+
+		c := newEnabledChecker(true, mockChecker)
+		status, message := c.Run(context.Background(), FileCheckContext{Reader: strings.NewReader(""), ImageURL: testImageURL})
+		if status != types.SensitiveCheckFail {
+			t.Errorf("Expected status %v, got %v", types.SensitiveCheckFail, status)
+		}
+		if message != "label:porn,confidence:0.95" {
+			t.Errorf("Expected message '%s', got '%s'", "label:porn,confidence:0.95", message)
+		}
+	})
+
+	t.Run("image passes check", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		mockChecker.EXPECT().PassImageURLCheck(mock.Anything, types.ScenarioImageBaseLineCheck, testImageURL).
+			Return(&sensitive.CheckResult{IsSensitive: false}, nil)
+
+		c := newEnabledChecker(true, mockChecker)
+		status, message := c.Run(context.Background(), FileCheckContext{Reader: strings.NewReader(""), ImageURL: testImageURL})
+		if status != types.SensitiveCheckPass {
+			t.Errorf("Expected status %v, got %v", types.SensitiveCheckPass, status)
+		}
+		if message != "" {
+			t.Errorf("Expected empty message, got '%s'", message)
+		}
+	})
+
+	t.Run("empty image url with reader falls back to stream check", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		mockChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).
+			Return(&sensitive.CheckResult{IsSensitive: false}, nil)
+
+		c := newEnabledChecker(true, mockChecker)
+		status, message := c.Run(context.Background(), FileCheckContext{Reader: strings.NewReader("image-bytes")})
+		if status != types.SensitiveCheckPass {
+			t.Errorf("Expected status %v, got %v", types.SensitiveCheckPass, status)
+		}
+		if message != "" {
+			t.Errorf("Expected empty message, got '%s'", message)
+		}
+	})
+
+	t.Run("empty image url without reader returns exception", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		c := newEnabledChecker(true, mockChecker)
+		status, message := c.Run(context.Background(), FileCheckContext{})
+		if status != types.SensitiveCheckException {
+			t.Errorf("Expected status %v, got %v", types.SensitiveCheckException, status)
+		}
+		if message != "image url is empty and no stream available" {
+			t.Errorf("Expected message '%s', got '%s'", "image url is empty and no stream available", message)
+		}
+	})
+
+	t.Run("checker error with retry", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		mockChecker.EXPECT().PassImageURLCheck(mock.Anything, types.ScenarioImageBaseLineCheck, testImageURL).Once().
+			Return(nil, errors.New("network error"))
+		mockChecker.EXPECT().PassImageURLCheck(mock.Anything, types.ScenarioImageBaseLineCheck, testImageURL).Once().
+			Return(nil, errors.New("network error"))
+		mockChecker.EXPECT().PassImageURLCheck(mock.Anything, types.ScenarioImageBaseLineCheck, testImageURL).Once().
+			Return(&sensitive.CheckResult{IsSensitive: false}, nil)
+
+		c := newEnabledChecker(true, mockChecker)
+		status, _ := c.Run(context.Background(), FileCheckContext{Reader: strings.NewReader(""), ImageURL: testImageURL})
+		if status != types.SensitiveCheckPass {
+			t.Errorf("Expected status %v, got %v", types.SensitiveCheckPass, status)
+		}
+	})
+
+	t.Run("all retries failed", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		mockChecker.EXPECT().PassImageURLCheck(mock.Anything, types.ScenarioImageBaseLineCheck, testImageURL).Times(3).
+			Return(nil, errors.New("service unavailable"))
+
+		c := newEnabledChecker(true, mockChecker)
+		status, message := c.Run(context.Background(), FileCheckContext{Reader: strings.NewReader(""), ImageURL: testImageURL})
+		if status != types.SensitiveCheckException {
+			t.Errorf("Expected status %v, got %v", types.SensitiveCheckException, status)
+		}
+		if message != "call sensitive image url checker api failed" {
+			t.Errorf("Expected message '%s', got '%s'", "call sensitive image url checker api failed", message)
+		}
+	})
+
+	t.Run("context canceled", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		// mock a slow call that will be interrupted by context cancellation
+		mockChecker.EXPECT().PassImageURLCheck(mock.Anything, types.ScenarioImageBaseLineCheck, testImageURL).
+			RunAndReturn(func(ctx context.Context, scenario types.SensitiveScenario, imageURL string) (*sensitive.CheckResult, error) {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(5 * time.Second):
+					return &sensitive.CheckResult{IsSensitive: false}, nil
+				}
+			})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		c := newEnabledChecker(true, mockChecker)
+		status, message := c.Run(ctx, FileCheckContext{Reader: strings.NewReader(""), ImageURL: testImageURL})
+		if status != types.SensitiveCheckException {
+			t.Errorf("Expected status %v, got %v", types.SensitiveCheckException, status)
+		}
+		if message != "call sensitive image url checker api failed" {
+			t.Errorf("Expected message '%s', got '%s'", "call sensitive image url checker api failed", message)
+		}
+	})
+
+	t.Run("stream check sensitive image detected", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		mockChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).
+			Return(&sensitive.CheckResult{IsSensitive: true, Reason: "label:porn,confidence:0.95"}, nil)
+
+		c := newEnabledChecker(true, mockChecker)
+		status, message := c.Run(context.Background(), FileCheckContext{Reader: strings.NewReader("image-bytes")})
+		if status != types.SensitiveCheckFail {
+			t.Errorf("Expected status %v, got %v", types.SensitiveCheckFail, status)
+		}
+		if message != "label:porn,confidence:0.95" {
+			t.Errorf("Expected message '%s', got '%s'", "label:porn,confidence:0.95", message)
+		}
+	})
+
+	t.Run("stream check all retries failed", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		mockChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).Times(3).
+			Return(nil, errors.New("service unavailable"))
+
+		c := newEnabledChecker(true, mockChecker)
+		status, message := c.Run(context.Background(), FileCheckContext{Reader: strings.NewReader("image-bytes")})
+		if status != types.SensitiveCheckException {
+			t.Errorf("Expected status %v, got %v", types.SensitiveCheckException, status)
+		}
+		if message != "call sensitive image stream checker api failed" {
+			t.Errorf("Expected message '%s', got '%s'", "call sensitive image stream checker api failed", message)
+		}
+	})
 }
 
 func TestLfsFileChecker_Run(t *testing.T) {
-	checker := &LfsFileChecker{}
+	c := &LfsFileChecker{}
 	reader := strings.NewReader("lfs content")
 	expectedStatus := types.SensitiveCheckSkip
 	expectedMessage := "skip lfs file"
-	status, message := checker.Run(context.Background(), reader)
+	status, message := c.Run(context.Background(), FileCheckContext{Reader: reader})
 	if status != expectedStatus || message != expectedMessage {
 		t.Errorf("Expected (%v, %v), got (%v, %v)", expectedStatus, expectedMessage, status, message)
 	}
 }
 
 func TestFolderChecker_Run(t *testing.T) {
-	checker := &FolderChecker{}
+	c := &FolderChecker{}
 	reader := strings.NewReader("folder content")
 	expectedStatus := types.SensitiveCheckSkip
 	expectedMessage := "skip folder"
-	status, message := checker.Run(context.Background(), reader)
+	status, message := c.Run(context.Background(), FileCheckContext{Reader: reader})
 	if status != expectedStatus || message != expectedMessage {
 		t.Errorf("Expected (%v, %v), got (%v, %v)", expectedStatus, expectedMessage, status, message)
 	}

--- a/moderation/checker/init.go
+++ b/moderation/checker/init.go
@@ -3,15 +3,26 @@ package checker
 import (
 	"opencsg.com/csghub-server/builder/sensitive"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/types"
 )
 
 var contentChecker sensitive.SensitiveChecker
+
+// imageCheckEnabled controls whether image files are sent to the remote
+// moderation service. It is set from config during Init.
+var imageCheckEnabled bool
+
+// imageCheckScenario is the Aliyun Green scenario used for image moderation.
+// It is set from config during Init, defaulting to ScenarioImageBaseLineCheck.
+var imageCheckScenario types.SensitiveScenario
 
 func Init(config *config.Config) {
 	if !config.SensitiveCheck.Enable {
 		panic("SensitiveCheck is not enable")
 	}
 	contentChecker = sensitive.NewChainCheckerFromConfig(config)
+	imageCheckEnabled = config.SensitiveCheck.ImageCheckEnable
+	imageCheckScenario = resolveImageCheckScenario(config)
 }
 
 // InitWithContentChecker supports custom sensitive checker, this func mostly used in unit test
@@ -24,4 +35,16 @@ func InitWithContentChecker(config *config.Config, checker sensitive.SensitiveCh
 		panic("param checker can not be nil")
 	}
 	contentChecker = checker
+	imageCheckEnabled = config.SensitiveCheck.ImageCheckEnable
+	imageCheckScenario = resolveImageCheckScenario(config)
+}
+
+// resolveImageCheckScenario returns the configured image check scenario,
+// falling back to ScenarioImageBaseLineCheck if not set.
+func resolveImageCheckScenario(config *config.Config) types.SensitiveScenario {
+	s := config.SensitiveCheck.ImageCheckScenario
+	if s == "" {
+		return types.ScenarioImageBaseLineCheck
+	}
+	return types.SensitiveScenario(s)
 }

--- a/moderation/checker/text_file_checker.go
+++ b/moderation/checker/text_file_checker.go
@@ -22,7 +22,8 @@ func NewTextFileChecker() *TextFileChecker {
 	}
 }
 
-func (c *TextFileChecker) Run(ctx context.Context, reader io.Reader) (types.SensitiveCheckStatus, string) {
+func (c *TextFileChecker) Run(ctx context.Context, fctx FileCheckContext) (types.SensitiveCheckStatus, string) {
+	reader := fctx.Reader
 	type result struct {
 		status  types.SensitiveCheckStatus
 		message string

--- a/moderation/checker/text_file_checker_test.go
+++ b/moderation/checker/text_file_checker_test.go
@@ -30,7 +30,7 @@ func TestTextFileChecker_Run(t *testing.T) {
 		reader1 := bytes.NewReader([]byte("This text contains sensitive word."))
 		expectedStatus1 := types.SensitiveCheckFail
 		expectedMessage1 := "contains sensitive word"
-		status1, message1 := checker.Run(context.Background(), reader1)
+		status1, message1 := checker.Run(context.Background(), FileCheckContext{Reader: reader1})
 		if status1 != expectedStatus1 || message1 != expectedMessage1 {
 			t.Errorf("Test case 1 failed: Expected (%v, %v), Got (%v, %v)", expectedStatus1, expectedMessage1, status1, message1)
 		}
@@ -47,7 +47,7 @@ func TestTextFileChecker_Run(t *testing.T) {
 		reader2 := bytes.NewReader([]byte("This is a regular text file."))
 		expectedStatus2 := types.SensitiveCheckPass
 		expectedMessage2 := ""
-		status2, message2 := checker.Run(context.Background(), reader2)
+		status2, message2 := checker.Run(context.Background(), FileCheckContext{Reader: reader2})
 		if status2 != expectedStatus2 || message2 != expectedMessage2 {
 			t.Errorf("Test case 2 failed: Expected (%v, %v), Got (%v, %v)", expectedStatus2, expectedMessage2, status2, message2)
 		}
@@ -60,7 +60,7 @@ func TestTextFileChecker_Run(t *testing.T) {
 		reader.EXPECT().Read(mock.Anything).Return(0, errors.New("failed to read file content"))
 		expectedStatus3 := types.SensitiveCheckException
 		expectedMessage3 := "failed to read file content"
-		status3, message3 := checker.Run(context.Background(), reader)
+		status3, message3 := checker.Run(context.Background(), FileCheckContext{Reader: reader})
 		if status3 != expectedStatus3 || message3 != expectedMessage3 {
 			t.Errorf("Test case 3 failed: Expected (%v, %v), Got (%v, %v)", expectedStatus3, expectedMessage3, status3, message3)
 		}
@@ -74,7 +74,7 @@ func TestTextFileChecker_Run(t *testing.T) {
 		// a reader that will block longer than the context timeout
 		reader, _ := io.Pipe()
 
-		status, message := checker.Run(ctx, reader)
+		status, message := checker.Run(ctx, FileCheckContext{Reader: reader})
 		if status != types.SensitiveCheckException {
 			t.Errorf("Expected status %v, got %v", types.SensitiveCheckException, status)
 		}
@@ -95,7 +95,7 @@ func TestTextFileChecker_Run(t *testing.T) {
 		reader2 := bytes.NewReader([]byte("This is a regular text file."))
 		expectedStatus2 := types.SensitiveCheckPass
 		expectedMessage2 := ""
-		status2, message2 := checker.Run(context.Background(), reader2)
+		status2, message2 := checker.Run(context.Background(), FileCheckContext{Reader: reader2})
 		if status2 != expectedStatus2 || message2 != expectedMessage2 {
 			t.Errorf("Test case failed: Expected (%v, %v), Got (%v, %v)", expectedStatus2, expectedMessage2, status2, message2)
 		}
@@ -112,7 +112,7 @@ func TestTextFileChecker_Run(t *testing.T) {
 		reader2 := bytes.NewReader([]byte("This is a regular text file."))
 		expectedStatus2 := types.SensitiveCheckFail
 		expectedMessage2 := ""
-		status2, message2 := checker.Run(context.Background(), reader2)
+		status2, message2 := checker.Run(context.Background(), FileCheckContext{Reader: reader2})
 		if status2 != expectedStatus2 || message2 != expectedMessage2 {
 			t.Errorf("Test case failed: Expected (%v, %v), Got (%v, %v)", expectedStatus2, expectedMessage2, status2, message2)
 		}

--- a/moderation/checker/unknown_file_checker.go
+++ b/moderation/checker/unknown_file_checker.go
@@ -18,7 +18,8 @@ import (
 type UnkownFileChecker struct {
 }
 
-func (c *UnkownFileChecker) Run(ctx context.Context, reader io.Reader) (types.SensitiveCheckStatus, string) {
+func (c *UnkownFileChecker) Run(ctx context.Context, fctx FileCheckContext) (types.SensitiveCheckStatus, string) {
+	reader := fctx.Reader
 	// read the first 512 bytes and detect the content type
 	buffer := make([]byte, 512)
 	n, err := reader.Read(buffer)
@@ -36,12 +37,12 @@ func (c *UnkownFileChecker) Run(ctx context.Context, reader io.Reader) (types.Se
 		slog.Debug("use text file checker for unknown file", slog.String("content_type", detectedType))
 		tc := NewTextFileChecker()
 		mreader := io.MultiReader(bytes.NewReader(buffer), reader)
-		return tc.Run(ctx, mreader)
+		return tc.Run(ctx, FileCheckContext{Reader: mreader})
 	case strings.HasPrefix(detectedType, "image"):
 		slog.Debug("use image file checker for unknown file", slog.String("content_type", detectedType))
 		ic := NewImageFileChecker()
 		mreader := io.MultiReader(bytes.NewReader(buffer), reader)
-		return ic.Run(ctx, mreader)
+		return ic.Run(ctx, FileCheckContext{Reader: mreader, ImageURL: fctx.ImageURL})
 	case strings.HasPrefix(detectedType, "audio"):
 		slog.Debug("skip audio checker for unknown file", slog.String("content_type", detectedType))
 		return types.SensitiveCheckSkip, "skip binary audio file"

--- a/moderation/checker/unknown_file_checker_test.go
+++ b/moderation/checker/unknown_file_checker_test.go
@@ -49,7 +49,8 @@ func TestUnkownFileChecker_Run(t *testing.T) {
 
 		// Build a minimal PNG so http.DetectContentType returns "image/png"
 		var pngBuf bytes.Buffer
-		png.Encode(&pngBuf, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+		err := png.Encode(&pngBuf, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+		require.NoError(t, err)
 
 		const testURL = "http://example.com/image.png"
 		mockChecker.EXPECT().PassImageURLCheck(mock.Anything, types.ScenarioImageBaseLineCheck, testURL).
@@ -69,7 +70,8 @@ func TestUnkownFileChecker_Run(t *testing.T) {
 		InitWithContentChecker(cfg, mockChecker)
 
 		var pngBuf bytes.Buffer
-		png.Encode(&pngBuf, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+		err := png.Encode(&pngBuf, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+		require.NoError(t, err)
 
 		mockChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).
 			Return(&sensitive.CheckResult{IsSensitive: false}, nil)
@@ -88,7 +90,8 @@ func TestUnkownFileChecker_Run(t *testing.T) {
 		InitWithContentChecker(cfg, mockChecker)
 
 		var pngBuf bytes.Buffer
-		png.Encode(&pngBuf, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+		err := png.Encode(&pngBuf, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+		require.NoError(t, err)
 
 		mockChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).
 			Return(&sensitive.CheckResult{IsSensitive: true, Reason: "label:porn"}, nil)

--- a/moderation/checker/unknown_file_checker_test.go
+++ b/moderation/checker/unknown_file_checker_test.go
@@ -1,13 +1,19 @@
 package checker
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"image"
+	"image/png"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	mockio "opencsg.com/csghub-server/_mocks/io"
+	mocksens "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/sensitive"
+	"opencsg.com/csghub-server/builder/sensitive"
+	"opencsg.com/csghub-server/common/config"
 	"opencsg.com/csghub-server/common/types"
 )
 
@@ -16,7 +22,7 @@ func TestUnkownFileChecker_Run(t *testing.T) {
 		reader := mockio.NewMockReader(t)
 		reader.EXPECT().Read(mock.Anything).Return(0, errors.New("unknown exception"))
 		c := &UnkownFileChecker{}
-		status, msg := c.Run(context.Background(), reader)
+		status, msg := c.Run(context.Background(), FileCheckContext{Reader: reader})
 		require.Equal(t, types.SensitiveCheckException, status)
 		require.Equal(t, "failed to read file contents", msg)
 	})
@@ -30,7 +36,66 @@ func TestUnkownFileChecker_Run(t *testing.T) {
 
 		})
 		c := &UnkownFileChecker{}
-		status, _ := c.Run(context.Background(), reader)
+		status, _ := c.Run(context.Background(), FileCheckContext{Reader: reader})
 		require.Equal(t, types.SensitiveCheckSkip, status)
+	})
+
+	t.Run("image detected with URL uses URL check", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		cfg := &config.Config{}
+		cfg.SensitiveCheck.Enable = true
+		cfg.SensitiveCheck.ImageCheckEnable = true
+		InitWithContentChecker(cfg, mockChecker)
+
+		// Build a minimal PNG so http.DetectContentType returns "image/png"
+		var pngBuf bytes.Buffer
+		png.Encode(&pngBuf, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+
+		const testURL = "http://example.com/image.png"
+		mockChecker.EXPECT().PassImageURLCheck(mock.Anything, types.ScenarioImageBaseLineCheck, testURL).
+			Return(&sensitive.CheckResult{IsSensitive: false}, nil)
+
+		c := &UnkownFileChecker{}
+		status, msg := c.Run(context.Background(), FileCheckContext{Reader: &pngBuf, ImageURL: testURL})
+		require.Equal(t, types.SensitiveCheckPass, status)
+		require.Empty(t, msg)
+	})
+
+	t.Run("image detected without URL falls back to stream check", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		cfg := &config.Config{}
+		cfg.SensitiveCheck.Enable = true
+		cfg.SensitiveCheck.ImageCheckEnable = true
+		InitWithContentChecker(cfg, mockChecker)
+
+		var pngBuf bytes.Buffer
+		png.Encode(&pngBuf, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+
+		mockChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).
+			Return(&sensitive.CheckResult{IsSensitive: false}, nil)
+
+		c := &UnkownFileChecker{}
+		status, msg := c.Run(context.Background(), FileCheckContext{Reader: &pngBuf})
+		require.Equal(t, types.SensitiveCheckPass, status)
+		require.Empty(t, msg)
+	})
+
+	t.Run("image detected without URL sensitive content detected", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		cfg := &config.Config{}
+		cfg.SensitiveCheck.Enable = true
+		cfg.SensitiveCheck.ImageCheckEnable = true
+		InitWithContentChecker(cfg, mockChecker)
+
+		var pngBuf bytes.Buffer
+		png.Encode(&pngBuf, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+
+		mockChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).
+			Return(&sensitive.CheckResult{IsSensitive: true, Reason: "label:porn"}, nil)
+
+		c := &UnkownFileChecker{}
+		status, msg := c.Run(context.Background(), FileCheckContext{Reader: &pngBuf})
+		require.Equal(t, types.SensitiveCheckFail, status)
+		require.Equal(t, "label:porn", msg)
 	})
 }

--- a/moderation/component/repo.go
+++ b/moderation/component/repo.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -176,8 +178,10 @@ func (c *repoComponentImpl) CheckRepoFiles(ctx context.Context, repoID int64, op
 
 func (c *repoComponentImpl) processFile(ctx context.Context, file *database.RepositoryFile) {
 	reader := NewRepoFileContentReader(file, c.git)
-	checker := checker.GetFileChecker(file.FileType, file.Path, file.LfsRelativePath)
-	status, msg := checker.Run(ctx, reader)
+	defer reader.Close()
+	imageURL := c.buildImageURL(file)
+	fc := checker.GetFileChecker(file.FileType, file.Path, file.LfsRelativePath)
+	status, msg := fc.Run(ctx, checker.FileCheckContext{Reader: reader, ImageURL: imageURL})
 	if status == types.SensitiveCheckException {
 		slog.ErrorContext(ctx, "failed to check repo file content", slog.Int64("repo_id", file.RepositoryID), slog.Int64("repo_file_id", file.ID), slog.String("file", file.Path),
 			slog.String("err", msg))
@@ -187,6 +191,61 @@ func (c *repoComponentImpl) processFile(ctx context.Context, file *database.Repo
 	if err != nil {
 		slog.ErrorContext(ctx, "save check result failed", slog.Any("error", err))
 	}
+}
+
+// repoTypeURLPath maps a repository type to the URL path segment used by the
+// public API routes (e.g. "model" -> "models", "mcpserver" -> "mcps").
+func repoTypeURLPath(repoType types.RepositoryType) string {
+	if repoType == types.MCPServerRepo {
+		return "mcps"
+	}
+	return string(repoType) + "s"
+}
+
+// buildImageURL constructs a publicly-accessible URL for an image file so that
+// the remote moderation service (e.g. Aliyun Green) can fetch it. The URL uses
+// the download endpoint which streams raw bytes.
+//
+// Returns an empty string for non-image files, private repos (the URL would not
+// be accessible without auth), or when repository metadata is missing.
+func (c *repoComponentImpl) buildImageURL(file *database.RepositoryFile) string {
+	if file == nil || file.Repository == nil {
+		return ""
+	}
+
+	if !types.IsImageFile(file.Path) {
+		return ""
+	}
+
+	// For private repos, the download URL requires authentication and cannot
+	// be fetched by the remote moderation service. Return empty so that
+	// ImageFileChecker falls back to checkByStream (upload to S3 + presigned URL).
+	if file.Repository.Private {
+		return ""
+	}
+
+	namespace, name := file.Repository.NamespaceAndName()
+	if namespace == "" || name == "" {
+		slog.Warn("failed to build image url, invalid repository path", slog.String("path", file.Repository.Path))
+		return ""
+	}
+
+	ref := file.Repository.DefaultBranch
+	if ref == "" {
+		ref = "main"
+	}
+
+	domain := strings.TrimSuffix(c.config.APIServer.PublicDomain, "/")
+	// e.g. https://opencsg.com/api/v1/codes/cemeng/sensitive-test/download/example.jpg
+	imageURL := fmt.Sprintf("%s/api/v1/%s/%s/%s/download/%s?ref=%s",
+		domain,
+		repoTypeURLPath(file.Repository.RepositoryType),
+		namespace,
+		name,
+		file.Path,
+		url.QueryEscape(ref),
+	)
+	return imageURL
 }
 
 func (c *repoComponentImpl) saveCheckResult(ctx context.Context, file *database.RepositoryFile, status types.SensitiveCheckStatus, msg string) error {

--- a/moderation/component/repo_test.go
+++ b/moderation/component/repo_test.go
@@ -398,3 +398,144 @@ func TestRepoComponent_GetNamespaceWhiteList(t *testing.T) {
 		require.Nil(t, patterns)
 	})
 }
+
+func TestRepoComponent_buildImageURL(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.APIServer.PublicDomain = "https://hub.opencsg.com"
+
+	tests := []struct {
+		name     string
+		file     *database.RepositoryFile
+		wantURL  string
+		wantEmpty bool
+	}{
+		{
+			name: "model repo image file",
+			file: &database.RepositoryFile{
+				Path: "images/banner.png",
+				Repository: &database.Repository{
+					Path:           "alice/my-model",
+					RepositoryType: types.ModelRepo,
+					DefaultBranch:  "main",
+				},
+			},
+			wantURL: "https://hub.opencsg.com/api/v1/models/alice/my-model/download/images/banner.png?ref=main",
+		},
+		{
+			name: "dataset repo image file",
+			file: &database.RepositoryFile{
+				Path: "preview/img.jpg",
+				Repository: &database.Repository{
+					Path:           "bob/my-dataset",
+					RepositoryType: types.DatasetRepo,
+					DefaultBranch:  "dev",
+				},
+			},
+			wantURL: "https://hub.opencsg.com/api/v1/datasets/bob/my-dataset/download/preview/img.jpg?ref=dev",
+		},
+		{
+			name: "mcpserver repo image file",
+			file: &database.RepositoryFile{
+				Path: "logo.png",
+				Repository: &database.Repository{
+					Path:           "carol/my-mcp",
+					RepositoryType: types.MCPServerRepo,
+					DefaultBranch:  "main",
+				},
+			},
+			wantURL: "https://hub.opencsg.com/api/v1/mcps/carol/my-mcp/download/logo.png?ref=main",
+		},
+		{
+			name: "code repo image with special chars in ref",
+			file: &database.RepositoryFile{
+				Path: "docs/arch.png",
+				Repository: &database.Repository{
+					Path:           "dave/my-code",
+					RepositoryType: types.CodeRepo,
+					DefaultBranch:  "feature/branch",
+				},
+			},
+			wantURL: "https://hub.opencsg.com/api/v1/codes/dave/my-code/download/docs/arch.png?ref=feature%2Fbranch",
+		},
+		{
+			name: "private repo returns empty",
+			file: &database.RepositoryFile{
+				Path: "images/banner.png",
+				Repository: &database.Repository{
+					Path:           "alice/private-model",
+					RepositoryType: types.ModelRepo,
+					DefaultBranch:  "main",
+					Private:        true,
+				},
+			},
+			wantEmpty: true,
+		},
+		{
+			name: "non-image file returns empty",
+			file: &database.RepositoryFile{
+				Path: "readme.txt",
+				Repository: &database.Repository{
+					Path:           "alice/my-model",
+					RepositoryType: types.ModelRepo,
+					DefaultBranch:  "main",
+				},
+			},
+			wantEmpty: true,
+		},
+		{
+			name:      "nil file returns empty",
+			file:      nil,
+			wantEmpty: true,
+		},
+		{
+			name: "nil repository returns empty",
+			file: &database.RepositoryFile{
+				Path:       "image.png",
+				Repository: nil,
+			},
+			wantEmpty: true,
+		},
+		{
+			name: "empty default branch falls back to main",
+			file: &database.RepositoryFile{
+				Path: "img.png",
+				Repository: &database.Repository{
+					Path:           "eve/repo",
+					RepositoryType: types.SpaceRepo,
+					DefaultBranch:  "",
+				},
+			},
+			wantURL: "https://hub.opencsg.com/api/v1/spaces/eve/repo/download/img.png?ref=main",
+		},
+		{
+			name: "public domain with trailing slash is trimmed",
+			file: &database.RepositoryFile{
+				Path: "img.png",
+				Repository: &database.Repository{
+					Path:           "eve/repo",
+					RepositoryType: types.SpaceRepo,
+					DefaultBranch:  "main",
+				},
+			},
+			wantURL: "https://hub.opencsg.com/api/v1/spaces/eve/repo/download/img.png?ref=main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comp := &repoComponentImpl{config: cfg}
+			// for the trailing-slash test, use a dedicated config
+			if tt.name == "public domain with trailing slash is trimmed" {
+				slashCfg := &config.Config{}
+				slashCfg.APIServer.PublicDomain = "https://hub.opencsg.com/"
+				comp.config = slashCfg
+			}
+			got := comp.buildImageURL(tt.file)
+			if tt.wantEmpty {
+				require.Empty(t, got)
+			} else {
+				require.Equal(t, tt.wantURL, got)
+			}
+		})
+	}
+}

--- a/moderation/workflow/activity/repo.go
+++ b/moderation/workflow/activity/repo.go
@@ -26,6 +26,7 @@ func GenRepoFileList(ctx context.Context, repo *database.Repository, config *con
 func CheckRepoFiles(ctx context.Context, repo *database.Repository, config *config.Config) error {
 	logger := activity.GetLogger(ctx)
 	logger.Info("check repo files start", "repo_path", repo.Path)
+
 	rc, err := component.NewRepoComponent(config)
 	if err != nil {
 		return fmt.Errorf("failed to create repo component, error: %w", err)

--- a/moderation/workflow/activity/repo_test.go
+++ b/moderation/workflow/activity/repo_test.go
@@ -1,0 +1,66 @@
+package activity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/types"
+)
+
+func TestCheckRepoFiles_PrivateRepo(t *testing.T) {
+	// Private repos must also be checked per policy compliance.
+	// The activity should NOT skip private repos — it proceeds to create
+	// a repo component just like public repos. With an empty config this
+	// fails, confirming the activity does not early-return for private repos.
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestActivityEnvironment()
+	env.RegisterActivity(CheckRepoFiles)
+
+	privateRepo := &database.Repository{
+		ID:             1,
+		Path:           "user/private-repo",
+		DefaultBranch:  "main",
+		Name:           "private-repo",
+		RepositoryType: types.ModelRepo,
+		Private:        true,
+	}
+
+	cfg := &config.Config{}
+
+	_, err := env.ExecuteActivity(CheckRepoFiles, privateRepo, cfg)
+	// Expect an error because NewRepoComponent will fail without proper
+	// config. The key assertion is that we get an error (not nil) — the
+	// activity did NOT skip the private repo.
+	require.Error(t, err)
+}
+
+func TestCheckRepoFiles_PublicRepo(t *testing.T) {
+	// For a public repo, the activity will attempt to create a real repo
+	// component (NewRepoComponent), which requires database/git server
+	// connections. This path is already covered by the workflow-level tests
+	// in repo_full_check_test.go where the activity is mocked via
+	// env.OnActivity. Here we only verify that a public repo proceeds past
+	// component creation, which fails without a real config.
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestActivityEnvironment()
+	env.RegisterActivity(CheckRepoFiles)
+
+	publicRepo := &database.Repository{
+		ID:             2,
+		Path:           "user/public-repo",
+		DefaultBranch:  "main",
+		Name:           "public-repo",
+		RepositoryType: types.ModelRepo,
+		Private:        false,
+	}
+
+	cfg := &config.Config{}
+
+	_, err := env.ExecuteActivity(CheckRepoFiles, publicRepo, cfg)
+	// Expect an error because NewRepoComponent will fail without proper
+	// config (no git server, no database).
+	require.Error(t, err)
+}


### PR DESCRIPTION
Summary:
- Implements image content safety checks by integrating Alibaba Cloud's PassImageURLCheck API to detect sensitive media, including support for both public URLs and private repository streams.
- Introduces a unified `FileCheckContext` to standardize file checking across all types and adds a configurable environment switch (`STARHUB_SERVER_SENSITIVE_CHECK_IMAGE_ENABLE`) to enable/disable the feature.
- Consolidates image file extension definitions into a single source of truth and ensures proper context cancellation handling with retry logic to prevent resource leaks.