### PR TITLE
Off-line related price while delete llm config and space resource

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/accounting/mock_AccountingClient.go
+++ b/_mocks/opencsg.com/csghub-server/builder/accounting/mock_AccountingClient.go
@@ -1073,6 +1073,64 @@ func (_c *MockAccountingClient_ListStatementByUserIDAndTime_Call) RunAndReturn(r
 	return _c
 }
 
+// OffLinePrice provides a mock function with given fields: req
+func (_m *MockAccountingClient) OffLinePrice(req types.AcctPriceOffLineReq) (any, error) {
+	ret := _m.Called(req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OffLinePrice")
+	}
+
+	var r0 any
+	var r1 error
+	if rf, ok := ret.Get(0).(func(types.AcctPriceOffLineReq) (any, error)); ok {
+		return rf(req)
+	}
+	if rf, ok := ret.Get(0).(func(types.AcctPriceOffLineReq) any); ok {
+		r0 = rf(req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(any)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(types.AcctPriceOffLineReq) error); ok {
+		r1 = rf(req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockAccountingClient_OffLinePrice_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OffLinePrice'
+type MockAccountingClient_OffLinePrice_Call struct {
+	*mock.Call
+}
+
+// OffLinePrice is a helper method to define mock.On call
+//   - req types.AcctPriceOffLineReq
+func (_e *MockAccountingClient_Expecter) OffLinePrice(req interface{}) *MockAccountingClient_OffLinePrice_Call {
+	return &MockAccountingClient_OffLinePrice_Call{Call: _e.mock.On("OffLinePrice", req)}
+}
+
+func (_c *MockAccountingClient_OffLinePrice_Call) Run(run func(req types.AcctPriceOffLineReq)) *MockAccountingClient_OffLinePrice_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(types.AcctPriceOffLineReq))
+	})
+	return _c
+}
+
+func (_c *MockAccountingClient_OffLinePrice_Call) Return(_a0 any, _a1 error) *MockAccountingClient_OffLinePrice_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockAccountingClient_OffLinePrice_Call) RunAndReturn(run func(types.AcctPriceOffLineReq) (any, error)) *MockAccountingClient_OffLinePrice_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PresentAccountingUser provides a mock function with given fields: userID, req
 func (_m *MockAccountingClient) PresentAccountingUser(userID string, req types.ActivityReq) (any, error) {
 	ret := _m.Called(userID, req)

--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_AccountPriceStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_AccountPriceStore.go
@@ -616,6 +616,53 @@ func (_c *MockAccountPriceStore_ListPricesByGroupKey_Call) RunAndReturn(run func
 	return _c
 }
 
+// OffLineBySkuTypeAndResourceID provides a mock function with given fields: ctx, req
+func (_m *MockAccountPriceStore) OffLineBySkuTypeAndResourceID(ctx context.Context, req types.AcctPriceOffLineReq) error {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OffLineBySkuTypeAndResourceID")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.AcctPriceOffLineReq) error); ok {
+		r0 = rf(ctx, req)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockAccountPriceStore_OffLineBySkuTypeAndResourceID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OffLineBySkuTypeAndResourceID'
+type MockAccountPriceStore_OffLineBySkuTypeAndResourceID_Call struct {
+	*mock.Call
+}
+
+// OffLineBySkuTypeAndResourceID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req types.AcctPriceOffLineReq
+func (_e *MockAccountPriceStore_Expecter) OffLineBySkuTypeAndResourceID(ctx interface{}, req interface{}) *MockAccountPriceStore_OffLineBySkuTypeAndResourceID_Call {
+	return &MockAccountPriceStore_OffLineBySkuTypeAndResourceID_Call{Call: _e.mock.On("OffLineBySkuTypeAndResourceID", ctx, req)}
+}
+
+func (_c *MockAccountPriceStore_OffLineBySkuTypeAndResourceID_Call) Run(run func(ctx context.Context, req types.AcctPriceOffLineReq)) *MockAccountPriceStore_OffLineBySkuTypeAndResourceID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.AcctPriceOffLineReq))
+	})
+	return _c
+}
+
+func (_c *MockAccountPriceStore_OffLineBySkuTypeAndResourceID_Call) Return(_a0 error) *MockAccountPriceStore_OffLineBySkuTypeAndResourceID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockAccountPriceStore_OffLineBySkuTypeAndResourceID_Call) RunAndReturn(run func(context.Context, types.AcctPriceOffLineReq) error) *MockAccountPriceStore_OffLineBySkuTypeAndResourceID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Update provides a mock function with given fields: ctx, input
 func (_m *MockAccountPriceStore) Update(ctx context.Context, input database.AccountPrice) (*database.AccountPrice, error) {
 	ret := _m.Called(ctx, input)

--- a/_mocks/opencsg.com/csghub-server/component/mock_AccountingComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_AccountingComponent.go
@@ -1034,6 +1034,65 @@ func (_c *MockAccountingComponent_ListStatementByUserIDAndTime_Call) RunAndRetur
 	return _c
 }
 
+// OffLinePrice provides a mock function with given fields: ctx, req
+func (_m *MockAccountingComponent) OffLinePrice(ctx context.Context, req types.AcctPriceOffLineReq) (any, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OffLinePrice")
+	}
+
+	var r0 any
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.AcctPriceOffLineReq) (any, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, types.AcctPriceOffLineReq) any); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(any)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, types.AcctPriceOffLineReq) error); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockAccountingComponent_OffLinePrice_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OffLinePrice'
+type MockAccountingComponent_OffLinePrice_Call struct {
+	*mock.Call
+}
+
+// OffLinePrice is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req types.AcctPriceOffLineReq
+func (_e *MockAccountingComponent_Expecter) OffLinePrice(ctx interface{}, req interface{}) *MockAccountingComponent_OffLinePrice_Call {
+	return &MockAccountingComponent_OffLinePrice_Call{Call: _e.mock.On("OffLinePrice", ctx, req)}
+}
+
+func (_c *MockAccountingComponent_OffLinePrice_Call) Run(run func(ctx context.Context, req types.AcctPriceOffLineReq)) *MockAccountingComponent_OffLinePrice_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.AcctPriceOffLineReq))
+	})
+	return _c
+}
+
+func (_c *MockAccountingComponent_OffLinePrice_Call) Return(_a0 any, _a1 error) *MockAccountingComponent_OffLinePrice_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockAccountingComponent_OffLinePrice_Call) RunAndReturn(run func(context.Context, types.AcctPriceOffLineReq) (any, error)) *MockAccountingComponent_OffLinePrice_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // QueryAllUsersBalance provides a mock function with given fields: ctx, per, page
 func (_m *MockAccountingComponent) QueryAllUsersBalance(ctx context.Context, per int, page int) (interface{}, error) {
 	ret := _m.Called(ctx, per, page)

--- a/aigateway/component/openai.go
+++ b/aigateway/component/openai.go
@@ -322,11 +322,11 @@ func filterAndPaginateModels(models []types.Model, req types.ListModelsReq) type
 func providerTypeFromDeployType(t int) string {
 	switch t {
 	case commontypes.ServerlessType:
-		return types.ProviderTypeServerless
+		return commontypes.ProviderTypeServerless
 	case commontypes.InferenceType:
-		return types.ProviderTypeInference
+		return commontypes.ProviderTypeInference
 	default:
-		return types.ProviderTypeInference
+		return commontypes.ProviderTypeInference
 	}
 }
 
@@ -431,7 +431,7 @@ func (m *openaiComponentImpl) getExternalModels(c context.Context) []types.Model
 					slog.WarnContext(c, "llm config repo relation unavailable", "llm_config_id", extModel.ID, "repo_id", extModel.RepoID)
 				}
 			}
-			metadata[types.MetaKeyLLMType] = types.ProviderTypeExternalLLM
+			metadata[types.MetaKeyLLMType] = commontypes.ProviderTypeExternalLLM
 			// Convert relational upstreams to types.UpstreamConfig for routing
 			upstreams := dbUpstreamsToConfigs(extModel.Upstreams)
 			provider := extModel.PrimaryProvider()
@@ -590,11 +590,11 @@ func (m *openaiComponentImpl) resolveUsageMeteringInfo(c context.Context, nsUUID
 		return usageMeteringInfo{}, err
 	}
 	switch llmType {
-	case types.ProviderTypeServerless, types.ProviderTypeInference:
+	case commontypes.ProviderTypeServerless, commontypes.ProviderTypeInference:
 		if model.CSGHubModelID == "" {
 			return usageMeteringInfo{}, fmt.Errorf("model metadata %s=%s requires csghub model id", types.MetaKeyLLMType, llmType)
 		}
-		id := fmt.Sprintf(types.CSGHubResourceFmt, llmType, model.CSGHubModelID)
+		id := fmt.Sprintf(commontypes.CSGHubResourceFmt, llmType, model.CSGHubModelID)
 		meteringInfo := usageMeteringInfo{
 			Resource: types.MeteringResource{
 				ResourceID:   id,
@@ -603,7 +603,7 @@ func (m *openaiComponentImpl) resolveUsageMeteringInfo(c context.Context, nsUUID
 			},
 			Scene: commontypes.SceneModelServerless,
 		}
-		if llmType == types.ProviderTypeInference {
+		if llmType == commontypes.ProviderTypeInference {
 			meteringInfo.Scene = commontypes.SceneModelInference
 			ownerType, err := m.resolveUsageOwnerType(c, nsUUID, model)
 			if err != nil {
@@ -614,11 +614,11 @@ func (m *openaiComponentImpl) resolveUsageMeteringInfo(c context.Context, nsUUID
 			meteringInfo.OwnerType = commontypes.CSGHubServerlessInference
 		}
 		return meteringInfo, nil
-	case types.ProviderTypeExternalLLM:
+	case commontypes.ProviderTypeExternalLLM:
 		if model.ID == "" {
 			return usageMeteringInfo{}, fmt.Errorf("model metadata %s=%s requires model id", types.MetaKeyLLMType, llmType)
 		}
-		id := fmt.Sprintf(types.ExternalLLMResourceFmt, model.ID)
+		id := fmt.Sprintf(commontypes.ExternalLLMResourceFmt, model.ID)
 		return usageMeteringInfo{
 			Resource: types.MeteringResource{
 				ResourceID:   id,

--- a/aigateway/component/openai_ce_test.go
+++ b/aigateway/component/openai_ce_test.go
@@ -321,7 +321,7 @@ func TestOpenAIComponent_GetAvailableModels_CacheUsesModelSnapshot(t *testing.T)
 			var cachedModel types.Model
 			require.NoError(t, json.Unmarshal([]byte(valueString), &cachedModel))
 			assert.Equal(t, "hf-model2:svc2", cachedModel.ID)
-			assert.Equal(t, types.ProviderTypeServerless, cachedModel.Metadata[types.MetaKeyLLMType])
+			assert.Equal(t, commontypes.ProviderTypeServerless, cachedModel.Metadata[types.MetaKeyLLMType])
 			return nil
 		}).Once()
 	mockCache.EXPECT().Expire(mock.Anything, modelCacheKey, modelCacheTTL).
@@ -417,7 +417,7 @@ func TestOpenAIComponent_ListModels_CacheUsesOriginalID(t *testing.T) {
 			require.NoError(t, json.Unmarshal([]byte(valueString), &cachedModel))
 			assert.Equal(t, "test-model-2", cachedModel.ID)
 			assert.Equal(t, "Anthropic", cachedModel.Provider)
-			assert.Equal(t, types.ProviderTypeExternalLLM, cachedModel.Metadata[types.MetaKeyLLMType])
+			assert.Equal(t, commontypes.ProviderTypeExternalLLM, cachedModel.Metadata[types.MetaKeyLLMType])
 			return nil
 		}).Once()
 	mockCache.EXPECT().Expire(mock.Anything, modelCacheKey, modelCacheTTL).
@@ -608,7 +608,7 @@ func TestOpenAIComponent_GetModelByID(t *testing.T) {
 				Created: deploys[0].CreatedAt.Unix(),
 				Task:    "text-generation",
 				Metadata: map[string]any{
-					types.MetaKeyLLMType: types.ProviderTypeInference,
+					types.MetaKeyLLMType: commontypes.ProviderTypeInference,
 				},
 			},
 			Endpoint: "endpoint1",
@@ -686,7 +686,7 @@ func TestOpenAIComponent_saveModelsToCache(t *testing.T) {
 					Object:  "model",
 					OwnedBy: "openai",
 					Metadata: map[string]any{
-						types.MetaKeyLLMType: types.ProviderTypeExternalLLM,
+						types.MetaKeyLLMType: commontypes.ProviderTypeExternalLLM,
 					},
 				},
 				Endpoint: "http://test-endpoint",
@@ -740,7 +740,7 @@ func TestOpenAIComponent_loadModelFromCache(t *testing.T) {
 				Object:  "model",
 				OwnedBy: "OpenAI",
 				Metadata: map[string]any{
-					types.MetaKeyLLMType: types.ProviderTypeExternalLLM,
+					types.MetaKeyLLMType: commontypes.ProviderTypeExternalLLM,
 				},
 			},
 			Endpoint: "http://test-endpoint",
@@ -881,7 +881,7 @@ func TestOpenAIComponent_ExtGetAvailableModels_SinglePage(t *testing.T) {
 	require.Equal(t, "test-model-1", models[0].ID)
 	require.Equal(t, "text-generation,text-to-image", models[0].Task)
 	require.Equal(t, "test-ns/test-model-1", models[0].Metadata[types.MetaKeyRepoPath])
-	require.Equal(t, types.ProviderTypeExternalLLM, models[0].Metadata[types.MetaKeyLLMType])
+	require.Equal(t, commontypes.ProviderTypeExternalLLM, models[0].Metadata[types.MetaKeyLLMType])
 	require.NotContains(t, originalMetadata, types.MetaKeyRepoPath)
 	require.NotContains(t, originalMetadata, types.MetaKeyLLMType)
 	wg.Wait()
@@ -917,6 +917,6 @@ func TestOpenAIComponent_GetExternalModelsWithoutRepoOmitsRepoPath(t *testing.T)
 	require.Len(t, models, 1)
 	require.Equal(t, "model-without-repo", models[0].ID)
 	require.Equal(t, "value", models[0].Metadata["existing"])
-	require.Equal(t, types.ProviderTypeExternalLLM, models[0].Metadata[types.MetaKeyLLMType])
+	require.Equal(t, commontypes.ProviderTypeExternalLLM, models[0].Metadata[types.MetaKeyLLMType])
 	require.NotContains(t, models[0].Metadata, types.MetaKeyRepoPath)
 }

--- a/aigateway/component/openai_test.go
+++ b/aigateway/component/openai_test.go
@@ -93,11 +93,11 @@ func TestFilterAndPaginateModels(t *testing.T) {
 
 	t.Run("llm_types filter external_llm", func(t *testing.T) {
 		modelsWithLLMTypes := []types.Model{
-			{BaseModel: types.BaseModel{ID: "inference-model", Object: "model", OwnedBy: "u1", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeInference}}},
-			{BaseModel: types.BaseModel{ID: "external-model", Object: "model", OwnedBy: "openai", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeExternalLLM, types.MetaKeyPricingConfigured: true}}},
-			{BaseModel: types.BaseModel{ID: "serverless-model", Object: "model", OwnedBy: "u2", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeServerless, types.MetaKeyPricingConfigured: true}}},
+			{BaseModel: types.BaseModel{ID: "inference-model", Object: "model", OwnedBy: "u1", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeInference}}},
+			{BaseModel: types.BaseModel{ID: "external-model", Object: "model", OwnedBy: "openai", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeExternalLLM, types.MetaKeyPricingConfigured: true}}},
+			{BaseModel: types.BaseModel{ID: "serverless-model", Object: "model", OwnedBy: "u2", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeServerless, types.MetaKeyPricingConfigured: true}}},
 		}
-		resp := filterAndPaginateModels(modelsWithLLMTypes, types.ListModelsReq{LLMTypes: []string{types.ProviderTypeExternalLLM}})
+		resp := filterAndPaginateModels(modelsWithLLMTypes, types.ListModelsReq{LLMTypes: []string{commontypes.ProviderTypeExternalLLM}})
 		assert.Equal(t, 1, resp.TotalCount)
 		require.Len(t, resp.Data, 1)
 		assert.Equal(t, "external-model", resp.Data[0].ID)
@@ -105,11 +105,11 @@ func TestFilterAndPaginateModels(t *testing.T) {
 
 	t.Run("llm_types filter supports multiple values", func(t *testing.T) {
 		modelsWithLLMTypes := []types.Model{
-			{BaseModel: types.BaseModel{ID: "inference-model", Object: "model", OwnedBy: "u1", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeInference}}},
-			{BaseModel: types.BaseModel{ID: "external-model", Object: "model", OwnedBy: "openai", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeExternalLLM, types.MetaKeyPricingConfigured: true}}},
-			{BaseModel: types.BaseModel{ID: "serverless-model", Object: "model", OwnedBy: "u2", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeServerless, types.MetaKeyPricingConfigured: true}}},
+			{BaseModel: types.BaseModel{ID: "inference-model", Object: "model", OwnedBy: "u1", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeInference}}},
+			{BaseModel: types.BaseModel{ID: "external-model", Object: "model", OwnedBy: "openai", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeExternalLLM, types.MetaKeyPricingConfigured: true}}},
+			{BaseModel: types.BaseModel{ID: "serverless-model", Object: "model", OwnedBy: "u2", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeServerless, types.MetaKeyPricingConfigured: true}}},
 		}
-		resp := filterAndPaginateModels(modelsWithLLMTypes, types.ListModelsReq{LLMTypes: []string{types.ProviderTypeServerless, types.ProviderTypeInference}})
+		resp := filterAndPaginateModels(modelsWithLLMTypes, types.ListModelsReq{LLMTypes: []string{commontypes.ProviderTypeServerless, commontypes.ProviderTypeInference}})
 		assert.Equal(t, 2, resp.TotalCount)
 		require.Len(t, resp.Data, 2)
 		assert.Equal(t, "inference-model", resp.Data[0].ID)
@@ -118,8 +118,8 @@ func TestFilterAndPaginateModels(t *testing.T) {
 
 	t.Run("llm_types filter is case-insensitive and trims spaces", func(t *testing.T) {
 		modelsWithLLMTypes := []types.Model{
-			{BaseModel: types.BaseModel{ID: "serverless-model", Object: "model", OwnedBy: "u1", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeServerless, types.MetaKeyPricingConfigured: true}}},
-			{BaseModel: types.BaseModel{ID: "external-model", Object: "model", OwnedBy: "openai", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeExternalLLM, types.MetaKeyPricingConfigured: true}}},
+			{BaseModel: types.BaseModel{ID: "serverless-model", Object: "model", OwnedBy: "u1", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeServerless, types.MetaKeyPricingConfigured: true}}},
+			{BaseModel: types.BaseModel{ID: "external-model", Object: "model", OwnedBy: "openai", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeExternalLLM, types.MetaKeyPricingConfigured: true}}},
 		}
 		resp := filterAndPaginateModels(modelsWithLLMTypes, types.ListModelsReq{LLMTypes: []string{" SERVERLESS "}})
 		assert.Equal(t, 1, resp.TotalCount)
@@ -130,9 +130,9 @@ func TestFilterAndPaginateModels(t *testing.T) {
 	t.Run("llm_types filter excludes models without llm_type", func(t *testing.T) {
 		modelsWithLLMTypes := []types.Model{
 			{BaseModel: types.BaseModel{ID: "missing-llm-type", Object: "model", OwnedBy: "u1"}},
-			{BaseModel: types.BaseModel{ID: "external-model", Object: "model", OwnedBy: "openai", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeExternalLLM, types.MetaKeyPricingConfigured: true}}},
+			{BaseModel: types.BaseModel{ID: "external-model", Object: "model", OwnedBy: "openai", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeExternalLLM, types.MetaKeyPricingConfigured: true}}},
 		}
-		resp := filterAndPaginateModels(modelsWithLLMTypes, types.ListModelsReq{LLMTypes: []string{types.ProviderTypeExternalLLM}})
+		resp := filterAndPaginateModels(modelsWithLLMTypes, types.ListModelsReq{LLMTypes: []string{commontypes.ProviderTypeExternalLLM}})
 		assert.Equal(t, 1, resp.TotalCount)
 		require.Len(t, resp.Data, 1)
 		assert.Equal(t, "external-model", resp.Data[0].ID)
@@ -224,11 +224,11 @@ func TestFilterAndPaginateModels(t *testing.T) {
 
 	t.Run("task filter combined with llm_types filter", func(t *testing.T) {
 		modelsWithTask := []types.Model{
-			{BaseModel: types.BaseModel{ID: "inference-gen", Object: "model", OwnedBy: "u1", Task: "text-generation", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeInference}}},
-			{BaseModel: types.BaseModel{ID: "inference-image", Object: "model", OwnedBy: "u1", Task: "text-to-image", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeInference}}},
-			{BaseModel: types.BaseModel{ID: "external-gen", Object: "model", OwnedBy: "openai", Task: "text-generation", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeExternalLLM, types.MetaKeyPricingConfigured: true}}},
+			{BaseModel: types.BaseModel{ID: "inference-gen", Object: "model", OwnedBy: "u1", Task: "text-generation", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeInference}}},
+			{BaseModel: types.BaseModel{ID: "inference-image", Object: "model", OwnedBy: "u1", Task: "text-to-image", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeInference}}},
+			{BaseModel: types.BaseModel{ID: "external-gen", Object: "model", OwnedBy: "openai", Task: "text-generation", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeExternalLLM, types.MetaKeyPricingConfigured: true}}},
 		}
-		resp := filterAndPaginateModels(modelsWithTask, types.ListModelsReq{LLMTypes: []string{types.ProviderTypeInference}, Task: "text-generation"})
+		resp := filterAndPaginateModels(modelsWithTask, types.ListModelsReq{LLMTypes: []string{commontypes.ProviderTypeInference}, Task: "text-generation"})
 		assert.Equal(t, 1, resp.TotalCount)
 		assert.Len(t, resp.Data, 1)
 		assert.Equal(t, "inference-gen", resp.Data[0].ID)
@@ -270,15 +270,15 @@ func TestFilterAndPaginateModels(t *testing.T) {
 	t.Run("has_associated_model combines with existing filters and pagination", func(t *testing.T) {
 		hasAssociatedModel := true
 		modelsWithRepoPath := []types.Model{
-			{BaseModel: types.BaseModel{ID: "alpha-gen", Object: "model", OwnedBy: "u1", Task: "text-generation", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeInference, types.MetaKeyRepoPath: "ns/alpha"}}},
-			{BaseModel: types.BaseModel{ID: "beta-gen", Object: "model", OwnedBy: "u1", Task: "text-generation", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeInference, types.MetaKeyRepoPath: "ns/beta"}}},
-			{BaseModel: types.BaseModel{ID: "gamma-gen", Object: "model", OwnedBy: "u1", Task: "text-generation", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeInference}}},
-			{BaseModel: types.BaseModel{ID: "delta-image", Object: "model", OwnedBy: "u1", Task: "text-to-image", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeInference, types.MetaKeyRepoPath: "ns/delta"}}},
-			{BaseModel: types.BaseModel{ID: "external-gen", Object: "model", OwnedBy: "openai", Task: "text-generation", Metadata: map[string]any{types.MetaKeyLLMType: types.ProviderTypeExternalLLM, types.MetaKeyRepoPath: "ns/external", types.MetaKeyPricingConfigured: true}}},
+			{BaseModel: types.BaseModel{ID: "alpha-gen", Object: "model", OwnedBy: "u1", Task: "text-generation", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeInference, types.MetaKeyRepoPath: "ns/alpha"}}},
+			{BaseModel: types.BaseModel{ID: "beta-gen", Object: "model", OwnedBy: "u1", Task: "text-generation", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeInference, types.MetaKeyRepoPath: "ns/beta"}}},
+			{BaseModel: types.BaseModel{ID: "gamma-gen", Object: "model", OwnedBy: "u1", Task: "text-generation", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeInference}}},
+			{BaseModel: types.BaseModel{ID: "delta-image", Object: "model", OwnedBy: "u1", Task: "text-to-image", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeInference, types.MetaKeyRepoPath: "ns/delta"}}},
+			{BaseModel: types.BaseModel{ID: "external-gen", Object: "model", OwnedBy: "openai", Task: "text-generation", Metadata: map[string]any{types.MetaKeyLLMType: commontypes.ProviderTypeExternalLLM, types.MetaKeyRepoPath: "ns/external", types.MetaKeyPricingConfigured: true}}},
 		}
 		resp := filterAndPaginateModels(modelsWithRepoPath, types.ListModelsReq{
 			ModelID:            "gen",
-			LLMTypes:           []string{types.ProviderTypeInference},
+			LLMTypes:           []string{commontypes.ProviderTypeInference},
 			Task:               "text-generation",
 			HasAssociatedModel: &hasAssociatedModel,
 			Per:                "1",
@@ -606,7 +606,7 @@ func TestOpenAIComponentImpl_RecordUsage(t *testing.T) {
 			model: &types.Model{
 				BaseModel: types.BaseModel{
 					Metadata: map[string]any{
-						types.MetaKeyLLMType: types.ProviderTypeInference,
+						types.MetaKeyLLMType: commontypes.ProviderTypeInference,
 					},
 				},
 				InternalModelInfo: types.InternalModelInfo{
@@ -688,7 +688,7 @@ func TestOpenAIComponentImpl_RecordUsage(t *testing.T) {
 			model: &types.Model{
 				BaseModel: types.BaseModel{
 					Metadata: map[string]any{
-						types.MetaKeyLLMType: types.ProviderTypeInference,
+						types.MetaKeyLLMType: commontypes.ProviderTypeInference,
 					},
 				},
 				InternalModelInfo: types.InternalModelInfo{
@@ -760,7 +760,7 @@ func TestOpenAIComponentImpl_RecordUsage(t *testing.T) {
 			model: &types.Model{
 				BaseModel: types.BaseModel{
 					Metadata: map[string]any{
-						types.MetaKeyLLMType: types.ProviderTypeInference,
+						types.MetaKeyLLMType: commontypes.ProviderTypeInference,
 					},
 				},
 				InternalModelInfo: types.InternalModelInfo{
@@ -832,7 +832,7 @@ func TestOpenAIComponentImpl_RecordUsage(t *testing.T) {
 			model: &types.Model{
 				BaseModel: types.BaseModel{
 					Metadata: map[string]any{
-						types.MetaKeyLLMType: types.ProviderTypeServerless,
+						types.MetaKeyLLMType: commontypes.ProviderTypeServerless,
 					},
 				},
 				InternalModelInfo: types.InternalModelInfo{
@@ -1000,7 +1000,7 @@ func TestOpenAIComponentImpl_RecordUsage(t *testing.T) {
 			model: &types.Model{
 				BaseModel: types.BaseModel{
 					Metadata: map[string]any{
-						types.MetaKeyLLMType: types.ProviderTypeInference,
+						types.MetaKeyLLMType: commontypes.ProviderTypeInference,
 					},
 				},
 				InternalModelInfo: types.InternalModelInfo{
@@ -1032,7 +1032,7 @@ func TestOpenAIComponentImpl_RecordUsage(t *testing.T) {
 			model: &types.Model{
 				BaseModel: types.BaseModel{
 					Metadata: map[string]any{
-						types.MetaKeyLLMType: types.ProviderTypeInference,
+						types.MetaKeyLLMType: commontypes.ProviderTypeInference,
 					},
 				},
 				InternalModelInfo: types.InternalModelInfo{
@@ -1100,7 +1100,7 @@ func TestOpenAIComponentImpl_RecordUsage_MultiModalImage(t *testing.T) {
 		BaseModel: types.BaseModel{
 			ID: "test-image-model",
 			Metadata: map[string]any{
-				types.MetaKeyLLMType: string(types.ProviderTypeServerless),
+				types.MetaKeyLLMType: string(commontypes.ProviderTypeServerless),
 			},
 		},
 		InternalModelInfo: types.InternalModelInfo{
@@ -1162,7 +1162,7 @@ func TestOpenAIComponentImpl_RecordUsage_MultiModalVideo(t *testing.T) {
 		BaseModel: types.BaseModel{
 			ID: "test-video-model",
 			Metadata: map[string]any{
-				types.MetaKeyLLMType: string(types.ProviderTypeServerless),
+				types.MetaKeyLLMType: string(commontypes.ProviderTypeServerless),
 			},
 		},
 		InternalModelInfo: types.InternalModelInfo{
@@ -1221,7 +1221,7 @@ func TestOpenAIComponentImpl_RecordUsage_MultiModalAudio(t *testing.T) {
 		BaseModel: types.BaseModel{
 			ID: "test-audio-model",
 			Metadata: map[string]any{
-				types.MetaKeyLLMType: string(types.ProviderTypeServerless),
+				types.MetaKeyLLMType: string(commontypes.ProviderTypeServerless),
 			},
 		},
 		InternalModelInfo: types.InternalModelInfo{
@@ -1280,7 +1280,7 @@ func TestOpenAIComponentImpl_RecordUsage_ExternalModel(t *testing.T) {
 					ID:      "gpt-4(openai)",
 					OwnedBy: "openai",
 					Metadata: map[string]any{
-						types.MetaKeyLLMType: types.ProviderTypeExternalLLM,
+						types.MetaKeyLLMType: commontypes.ProviderTypeExternalLLM,
 					},
 				},
 				ExternalModelInfo: types.ExternalModelInfo{
@@ -1346,7 +1346,7 @@ func TestOpenAIComponentImpl_RecordUsage_ExternalModel(t *testing.T) {
 					ID:      "gpt-3.5-turbo",
 					OwnedBy: "openai",
 					Metadata: map[string]any{
-						types.MetaKeyLLMType: types.ProviderTypeExternalLLM,
+						types.MetaKeyLLMType: commontypes.ProviderTypeExternalLLM,
 					},
 				},
 				ExternalModelInfo: types.ExternalModelInfo{
@@ -1378,7 +1378,7 @@ func TestOpenAIComponentImpl_RecordUsage_ExternalModel(t *testing.T) {
 					ID:      "gemini-pro",
 					OwnedBy: "google",
 					Metadata: map[string]any{
-						types.MetaKeyLLMType: types.ProviderTypeExternalLLM,
+						types.MetaKeyLLMType: commontypes.ProviderTypeExternalLLM,
 					},
 				},
 				ExternalModelInfo: types.ExternalModelInfo{
@@ -1414,7 +1414,7 @@ func TestOpenAIComponentImpl_RecordUsage_ExternalModel(t *testing.T) {
 					ID:      "test-model(test-provider)",
 					OwnedBy: "test-provider",
 					Metadata: map[string]any{
-						types.MetaKeyLLMType: types.ProviderTypeExternalLLM,
+						types.MetaKeyLLMType: commontypes.ProviderTypeExternalLLM,
 					},
 				},
 				ExternalModelInfo: types.ExternalModelInfo{

--- a/aigateway/handler/model_target_test.go
+++ b/aigateway/handler/model_target_test.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	responsespkg "opencsg.com/csghub-server/aigateway/handler/responses"
 	"strings"
 	"testing"
+
+	responsespkg "opencsg.com/csghub-server/aigateway/handler/responses"
 
 	"opencsg.com/csghub-server/aigateway/component/router"
 
@@ -414,7 +415,7 @@ func TestResolveModelTarget_PricedExternalLLM(t *testing.T) {
 		BaseModel: types.BaseModel{
 			ID: "external-model",
 			Metadata: map[string]any{
-				types.MetaKeyLLMType:           types.ProviderTypeExternalLLM,
+				types.MetaKeyLLMType:           commontypes.ProviderTypeExternalLLM,
 				types.MetaKeyPricingConfigured: true,
 			},
 		},
@@ -436,7 +437,7 @@ func TestResolveModelTarget_InferenceWithoutPricingFlag(t *testing.T) {
 		BaseModel: types.BaseModel{
 			ID: "inference-model",
 			Metadata: map[string]any{
-				types.MetaKeyLLMType: types.ProviderTypeInference,
+				types.MetaKeyLLMType: commontypes.ProviderTypeInference,
 			},
 		},
 		InternalModelInfo: types.InternalModelInfo{

--- a/aigateway/handler/openai.go
+++ b/aigateway/handler/openai.go
@@ -338,7 +338,7 @@ func (h *OpenAIHandlerImpl) ListModels(c *gin.Context) {
 
 func isValidListModelsLLMType(llmType string) bool {
 	switch strings.ToLower(strings.TrimSpace(llmType)) {
-	case types.ProviderTypeExternalLLM, types.ProviderTypeServerless, types.ProviderTypeInference:
+	case commonType.ProviderTypeExternalLLM, commonType.ProviderTypeServerless, commonType.ProviderTypeInference:
 		return true
 	default:
 		return false
@@ -346,7 +346,7 @@ func isValidListModelsLLMType(llmType string) bool {
 }
 
 func invalidLLMTypesErrorMessage() string {
-	return fmt.Sprintf("Invalid llm_types parameter. Allowed values: %s, %s, %s", types.ProviderTypeExternalLLM, types.ProviderTypeServerless, types.ProviderTypeInference)
+	return fmt.Sprintf("Invalid llm_types parameter. Allowed values: %s, %s, %s", commonType.ProviderTypeExternalLLM, commonType.ProviderTypeServerless, commonType.ProviderTypeInference)
 }
 
 func invalidHasAssociatedModelErrorMessage() string {

--- a/aigateway/handler/openai_test.go
+++ b/aigateway/handler/openai_test.go
@@ -296,9 +296,9 @@ func TestOpenAIHandler_ListModels(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, "invalid_request_error", errObj["code"])
 		assert.Contains(t, errObj["message"], "Invalid llm_types parameter")
-		assert.Contains(t, errObj["message"], types.ProviderTypeExternalLLM)
-		assert.Contains(t, errObj["message"], types.ProviderTypeServerless)
-		assert.Contains(t, errObj["message"], types.ProviderTypeInference)
+		assert.Contains(t, errObj["message"], commontypes.ProviderTypeExternalLLM)
+		assert.Contains(t, errObj["message"], commontypes.ProviderTypeServerless)
+		assert.Contains(t, errObj["message"], commontypes.ProviderTypeInference)
 	})
 
 	for _, value := range []string{"yes", "not-a-bool"} {
@@ -321,10 +321,10 @@ func TestOpenAIHandler_ListModels(t *testing.T) {
 
 	t.Run("valid llm_types parameter external_llm", func(t *testing.T) {
 		tester, c, w := setupTest(t)
-		tester.WithQuery("llm_types", types.ProviderTypeExternalLLM)
+		tester.WithQuery("llm_types", commontypes.ProviderTypeExternalLLM)
 
 		tester.mocks.openAIComp.EXPECT().
-			ListModels(mock.Anything, "testuser", types.ListModelsReq{LLMTypes: []string{types.ProviderTypeExternalLLM}}).
+			ListModels(mock.Anything, "testuser", types.ListModelsReq{LLMTypes: []string{commontypes.ProviderTypeExternalLLM}}).
 			Return(types.ModelList{Object: "list", Data: []types.Model{}, HasMore: false, TotalCount: 0}, nil).Once()
 
 		tester.handler.ListModels(c)
@@ -334,11 +334,11 @@ func TestOpenAIHandler_ListModels(t *testing.T) {
 
 	t.Run("valid llm_types parameter multiple values", func(t *testing.T) {
 		tester, c, w := setupTest(t)
-		tester.WithQuery("llm_types", types.ProviderTypeServerless)
-		tester.WithQuery("llm_types", types.ProviderTypeInference)
+		tester.WithQuery("llm_types", commontypes.ProviderTypeServerless)
+		tester.WithQuery("llm_types", commontypes.ProviderTypeInference)
 
 		tester.mocks.openAIComp.EXPECT().
-			ListModels(mock.Anything, "testuser", types.ListModelsReq{LLMTypes: []string{types.ProviderTypeServerless, types.ProviderTypeInference}}).
+			ListModels(mock.Anything, "testuser", types.ListModelsReq{LLMTypes: []string{commontypes.ProviderTypeServerless, commontypes.ProviderTypeInference}}).
 			Return(types.ModelList{Object: "list", Data: []types.Model{}, HasMore: false, TotalCount: 0}, nil).Once()
 
 		tester.handler.ListModels(c)
@@ -2050,7 +2050,7 @@ func TestOpenAIHandler_CreateVideo(t *testing.T) {
 				ID:   "video-model",
 				Task: "text-to-video",
 				Metadata: map[string]any{
-					types.MetaKeyLLMType:           types.ProviderTypeExternalLLM,
+					types.MetaKeyLLMType:           commontypes.ProviderTypeExternalLLM,
 					types.MetaKeyPricingConfigured: true,
 				},
 			},

--- a/aigateway/types/openai.go
+++ b/aigateway/types/openai.go
@@ -6,13 +6,6 @@ import (
 	commontypes "opencsg.com/csghub-server/common/types"
 )
 
-// Provider type values for Metadata[MetaKeyLLMType].
-const (
-	ProviderTypeServerless  = "serverless"
-	ProviderTypeInference   = "inference"
-	ProviderTypeExternalLLM = "external_llm"
-)
-
 // Metadata key constants used when enriching model metadata.
 const (
 	MetaKeyLLMType           = "llm_type"
@@ -20,12 +13,6 @@ const (
 	MetaKeyPricingConfigured = "pricing_configured"
 	MetaKeyRepoPath          = "repo_path"
 	MetaKeyTasks             = "tasks"
-)
-
-// Resource ID format strings for external LLM (model ID) and CSGHub internal (path segment, repo path).
-const (
-	ExternalLLMResourceFmt = "thirdparty://%s"
-	CSGHubResourceFmt      = "csghub://%s/%s"
 )
 
 // MeteringResource holds ResourceID, ResourceName, and CustomerID for metering events.

--- a/builder/accounting/client.go
+++ b/builder/accounting/client.go
@@ -41,6 +41,7 @@ type AccountingClient interface {
 	ListPresents(req types.PresentsIndexReq) (any, error)
 	GetOrderDetailByID(currentUser string, id int64) (any, error)
 	GetVoucherDashboard(req types.VoucherDashboardReq) (any, error)
+	OffLinePrice(req types.AcctPriceOffLineReq) (any, error)
 }
 type accountingClientImpl struct {
 	remote    *url.URL

--- a/builder/accounting/client_ce.go
+++ b/builder/accounting/client_ce.go
@@ -109,3 +109,7 @@ func (ac *accountingClientImpl) GetOrderDetailByID(currentUser string, id int64)
 func (ac *accountingClientImpl) GetVoucherDashboard(req types.VoucherDashboardReq) (any, error) {
 	return nil, nil
 }
+
+func (ac *accountingClientImpl) OffLinePrice(req types.AcctPriceOffLineReq) (any, error) {
+	return nil, nil
+}

--- a/builder/store/database/account_price.go
+++ b/builder/store/database/account_price.go
@@ -33,6 +33,7 @@ type AccountPriceStore interface {
 	ListByIds(ctx context.Context, ids []int64) ([]*types.AcctPriceResp, error)
 	ListDistinctGroupKeys(ctx context.Context, req types.AcctPriceDistinctListReq) ([]AcctPriceGroupKey, int, error)
 	ListPricesByGroupKey(ctx context.Context, req types.AcctPriceGroupKeyReq) ([]AccountPrice, error)
+	OffLineBySkuTypeAndResourceID(ctx context.Context, req types.AcctPriceOffLineReq) error
 }
 
 func NewAccountPriceStore() AccountPriceStore {
@@ -321,4 +322,17 @@ func (a *accountPriceStoreImpl) ListPricesByGroupKey(ctx context.Context, req ty
 		return nil, errorx.HandleDBError(err, nil)
 	}
 	return result, nil
+}
+
+func (a *accountPriceStoreImpl) OffLineBySkuTypeAndResourceID(ctx context.Context, req types.AcctPriceOffLineReq) error {
+	_, err := a.db.Core.NewUpdate().Model(&AccountPrice{}).
+		Where("sku_type = ?", req.SkuType).
+		Where("resource_id = ?", req.ResourceID).
+		Where("sku_status = ?", types.SkuStatusEnabled).
+		Set("sku_status = ?", types.SkuStatusDisabled).
+		Exec(ctx)
+	if err != nil {
+		return errorx.HandleDBError(err, nil)
+	}
+	return nil
 }

--- a/builder/store/database/account_price_test.go
+++ b/builder/store/database/account_price_test.go
@@ -512,3 +512,141 @@ func TestAccountPriceStore_ListBySkuTypeAndKinds(t *testing.T) {
 		require.Equal(t, 0, len(result))
 	})
 }
+
+func TestAccountPriceStore_OffLineBySkuTypeAndResourceID(t *testing.T) {
+	db := tests.InitTestDB()
+	defer db.Close()
+	ctx := context.TODO()
+
+	store := database.NewAccountPriceStoreWithDB(db)
+
+	t.Run("disable enabled prices matching sku_type and resource_id", func(t *testing.T) {
+		p1, err := store.Create(ctx, database.AccountPrice{
+			SkuType: types.SKUCSGHub, SkuKind: types.SKUPayAsYouGo, ResourceID: "r1",
+			SkuDesc: "price_1", SkuStatus: types.SkuStatusEnabled,
+		})
+		require.Nil(t, err)
+
+		p2, err := store.Create(ctx, database.AccountPrice{
+			SkuType: types.SKUCSGHub, SkuKind: types.SKUPromptToken, ResourceID: "r1",
+			SkuDesc: "price_2", SkuStatus: types.SkuStatusEnabled,
+		})
+		require.Nil(t, err)
+
+		err = store.OffLineBySkuTypeAndResourceID(ctx, types.AcctPriceOffLineReq{
+			SkuType:    types.SKUCSGHub,
+			ResourceID: "r1",
+		})
+		require.Nil(t, err)
+
+		r1 := &database.AccountPrice{}
+		err = db.Core.NewSelect().Model(r1).Where("id=?", p1.ID).Scan(ctx)
+		require.Nil(t, err)
+		require.Equal(t, types.SkuStatusDisabled, r1.SkuStatus)
+
+		r2 := &database.AccountPrice{}
+		err = db.Core.NewSelect().Model(r2).Where("id=?", p2.ID).Scan(ctx)
+		require.Nil(t, err)
+		require.Equal(t, types.SkuStatusDisabled, r2.SkuStatus)
+	})
+
+	t.Run("do not affect prices with different sku_type", func(t *testing.T) {
+		p1, err := store.Create(ctx, database.AccountPrice{
+			SkuType: types.SKUCSGHub, SkuKind: types.SKUPayAsYouGo, ResourceID: "r2",
+			SkuDesc: "csghub_price", SkuStatus: types.SkuStatusEnabled,
+		})
+		require.Nil(t, err)
+
+		p2, err := store.Create(ctx, database.AccountPrice{
+			SkuType: types.SKUReserve, SkuKind: types.SKUPayAsYouGo, ResourceID: "r2",
+			SkuDesc: "reserve_price", SkuStatus: types.SkuStatusEnabled,
+		})
+		require.Nil(t, err)
+
+		err = store.OffLineBySkuTypeAndResourceID(ctx, types.AcctPriceOffLineReq{
+			SkuType:    types.SKUCSGHub,
+			ResourceID: "r2",
+		})
+		require.Nil(t, err)
+
+		r1 := &database.AccountPrice{}
+		err = db.Core.NewSelect().Model(r1).Where("id=?", p1.ID).Scan(ctx)
+		require.Nil(t, err)
+		require.Equal(t, types.SkuStatusDisabled, r1.SkuStatus)
+
+		r2 := &database.AccountPrice{}
+		err = db.Core.NewSelect().Model(r2).Where("id=?", p2.ID).Scan(ctx)
+		require.Nil(t, err)
+		require.Equal(t, types.SkuStatusEnabled, r2.SkuStatus)
+	})
+
+	t.Run("do not affect prices with different resource_id", func(t *testing.T) {
+		p1, err := store.Create(ctx, database.AccountPrice{
+			SkuType: types.SKUCSGHub, SkuKind: types.SKUPayAsYouGo, ResourceID: "r3",
+			SkuDesc: "target_price", SkuStatus: types.SkuStatusEnabled,
+		})
+		require.Nil(t, err)
+
+		p2, err := store.Create(ctx, database.AccountPrice{
+			SkuType: types.SKUCSGHub, SkuKind: types.SKUPayAsYouGo, ResourceID: "r4",
+			SkuDesc: "other_price", SkuStatus: types.SkuStatusEnabled,
+		})
+		require.Nil(t, err)
+
+		err = store.OffLineBySkuTypeAndResourceID(ctx, types.AcctPriceOffLineReq{
+			SkuType:    types.SKUCSGHub,
+			ResourceID: "r3",
+		})
+		require.Nil(t, err)
+
+		r1 := &database.AccountPrice{}
+		err = db.Core.NewSelect().Model(r1).Where("id=?", p1.ID).Scan(ctx)
+		require.Nil(t, err)
+		require.Equal(t, types.SkuStatusDisabled, r1.SkuStatus)
+
+		r2 := &database.AccountPrice{}
+		err = db.Core.NewSelect().Model(r2).Where("id=?", p2.ID).Scan(ctx)
+		require.Nil(t, err)
+		require.Equal(t, types.SkuStatusEnabled, r2.SkuStatus)
+	})
+
+	t.Run("do not affect already disabled prices", func(t *testing.T) {
+		p1, err := store.Create(ctx, database.AccountPrice{
+			SkuType: types.SKUCSGHub, SkuKind: types.SKUPayAsYouGo, ResourceID: "r5",
+			SkuDesc: "enabled_price", SkuStatus: types.SkuStatusEnabled,
+		})
+		require.Nil(t, err)
+
+		// Manually insert a disabled price (bypassing Create's auto-disable logic)
+		p2 := &database.AccountPrice{
+			SkuType: types.SKUCSGHub, SkuKind: types.SKUPayAsYouGo, ResourceID: "r5",
+			SkuDesc: "already_disabled", SkuStatus: types.SkuStatusDisabled,
+		}
+		_, err = db.Core.NewInsert().Model(p2).Exec(ctx)
+		require.Nil(t, err)
+
+		err = store.OffLineBySkuTypeAndResourceID(ctx, types.AcctPriceOffLineReq{
+			SkuType:    types.SKUCSGHub,
+			ResourceID: "r5",
+		})
+		require.Nil(t, err)
+
+		r1 := &database.AccountPrice{}
+		err = db.Core.NewSelect().Model(r1).Where("id=?", p1.ID).Scan(ctx)
+		require.Nil(t, err)
+		require.Equal(t, types.SkuStatusDisabled, r1.SkuStatus)
+
+		r2 := &database.AccountPrice{}
+		err = db.Core.NewSelect().Model(r2).Where("id=?", p2.ID).Scan(ctx)
+		require.Nil(t, err)
+		require.Equal(t, types.SkuStatusDisabled, r2.SkuStatus)
+	})
+
+	t.Run("no matching enabled prices does not return error", func(t *testing.T) {
+		err := store.OffLineBySkuTypeAndResourceID(ctx, types.AcctPriceOffLineReq{
+			SkuType:    types.SKUReserve,
+			ResourceID: "nonexistent",
+		})
+		require.Nil(t, err)
+	})
+}

--- a/common/types/accounting.go
+++ b/common/types/accounting.go
@@ -888,3 +888,9 @@ const (
 	AccountPresentStatusUsed     AccountPresentStatus = 1
 	AccountPresentStatusCanceled AccountPresentStatus = 2
 )
+
+type AcctPriceOffLineReq struct {
+	CurrentUser string  `json:"-"`
+	SkuType     SKUType `json:"sku_type" binding:"required"`
+	ResourceID  string  `json:"resource_id" binding:"required"`
+}

--- a/common/types/llm_service.go
+++ b/common/types/llm_service.go
@@ -2,6 +2,19 @@ package types
 
 import "time"
 
+// Resource ID format strings for external LLM (model ID) and CSGHub internal (path segment, repo path).
+const (
+	ExternalLLMResourceFmt = "thirdparty://%s"
+	CSGHubResourceFmt      = "csghub://%s/%s"
+)
+
+// Provider type values for Metadata[MetaKeyLLMType].
+const (
+	ProviderTypeServerless  = "serverless"
+	ProviderTypeInference   = "inference"
+	ProviderTypeExternalLLM = "external_llm"
+)
+
 type RepositoryLite struct {
 	ID          int64     `json:"id"`
 	Path        string    `json:"path"`

--- a/component/accounting.go
+++ b/component/accounting.go
@@ -54,6 +54,7 @@ type AccountingComponent interface {
 	WeeklyRecharges(ctx context.Context, emails []string) error
 	GetOrderDetailByID(ctx context.Context, currentUser string, id int64) (*database.AccountOrderDetail, error)
 	GetVoucherDashboard(ctx context.Context, req types.VoucherDashboardReq) (*types.VoucherDashboardStatusItem, error)
+	OffLinePrice(ctx context.Context, req types.AcctPriceOffLineReq) (any, error)
 }
 
 func NewAccountingComponent(config *config.Config) (AccountingComponent, error) {

--- a/component/accounting_ce.go
+++ b/component/accounting_ce.go
@@ -116,3 +116,7 @@ func (ac *accountingComponentImpl) WeeklyRecharges(ctx context.Context, emails [
 func (ac *accountingComponentImpl) GetVoucherDashboard(ctx context.Context, req types.VoucherDashboardReq) (*types.VoucherDashboardStatusItem, error) {
 	return nil, nil
 }
+
+func (ac *accountingComponentImpl) OffLinePrice(ctx context.Context, req types.AcctPriceOffLineReq) (any, error) {
+	return nil, nil
+}

--- a/component/llm_service.go
+++ b/component/llm_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"strings"
 
@@ -50,6 +51,7 @@ type llmServiceComponentImpl struct {
 	repoStore         database.RepoStore
 	healthStateStore  database.AIGatewayUpstreamHealthStateStore
 	circuitStateStore database.AIGatewayUpstreamCircuitStateStore
+	accountComponent  AccountingComponent
 }
 
 var ErrInvalidLLMConfig = errors.New("invalid llm config")
@@ -61,6 +63,10 @@ func NewLLMServiceComponent(config *config.Config) (LLMServiceComponent, error) 
 	upstreamStore := database.NewUpstreamStore(config)
 	healthStateStore := database.NewAIGatewayUpstreamHealthStateStore()
 	circuitStateStore := database.NewAIGatewayUpstreamCircuitStateStore()
+	ac, err := NewAccountingComponent(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create accounting component: %w", err)
+	}
 	llmServiceComp := &llmServiceComponentImpl{
 		llmConfigStore:    llmConfigStore,
 		upstreamStore:     upstreamStore,
@@ -68,6 +74,7 @@ func NewLLMServiceComponent(config *config.Config) (LLMServiceComponent, error) 
 		repoStore:         repoStore,
 		healthStateStore:  healthStateStore,
 		circuitStateStore: circuitStateStore,
+		accountComponent:  ac,
 	}
 	return llmServiceComp, nil
 }
@@ -360,14 +367,32 @@ func (s *llmServiceComponentImpl) CreatePromptPrefix(ctx context.Context, req *t
 }
 
 func (s *llmServiceComponentImpl) DeleteLLMConfig(ctx context.Context, id int64) error {
-	// Clean up relational upstreams
-	_ = s.upstreamStore.DeleteByLLMConfigID(ctx, id)
-	err := s.llmConfigStore.Delete(ctx, id)
+	llmConfig, err := s.llmConfigStore.GetByID(ctx, id)
 	if err != nil {
 		return err
 	}
+	llmName := llmConfig.ModelName
+	// Clean up relational upstreams
+	_ = s.upstreamStore.DeleteByLLMConfigID(ctx, id)
+	err = s.llmConfigStore.Delete(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	// Off-line the corresponding price info
+	delReq := types.AcctPriceOffLineReq{
+		SkuType:    types.SKUCSGHub,
+		ResourceID: fmt.Sprintf(types.ExternalLLMResourceFmt, llmName),
+	}
+	_, err = s.accountComponent.OffLinePrice(ctx, delReq)
+	if err != nil {
+		slog.WarnContext(ctx, "off-line price failed for delete llm config",
+			slog.Any("err", err), slog.Any("llmConfig", llmConfig), slog.Any("delReq", delReq))
+	}
+
 	return nil
 }
+
 func (s *llmServiceComponentImpl) DeletePromptPrefix(ctx context.Context, id int64) error {
 	err := s.promptPrefixStore.Delete(ctx, id)
 	if err != nil {

--- a/component/llm_service_test.go
+++ b/component/llm_service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	mockdatabase "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/store/database"
+	mockComps "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/component"
 	aigatewaytypes "opencsg.com/csghub-server/aigateway/types"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/tests"
@@ -561,13 +562,20 @@ func TestLLMServiceComponent_DeleteLLMConfig(t *testing.T) {
 	ctx := context.TODO()
 	stores := tests.NewMockStores(t)
 	upstreamStore := mockdatabase.NewMockUpstreamStore(t)
+	mockAcct := mockComps.NewMockAccountingComponent(t)
 	upstreamStore.EXPECT().DeleteByLLMConfigID(ctx, int64(123)).Return(nil)
 	mc := &llmServiceComponentImpl{
 		llmConfigStore:    stores.LLMConfig,
 		promptPrefixStore: stores.PromptPrefix,
 		upstreamStore:     upstreamStore,
+		accountComponent:  mockAcct,
 	}
+	stores.LLMConfigMock().EXPECT().GetByID(ctx, int64(123)).Return(&database.LLMConfig{ModelName: "test-model"}, nil)
 	stores.LLMConfigMock().EXPECT().Delete(ctx, int64(123)).Return(nil)
+	mockAcct.EXPECT().OffLinePrice(ctx, types.AcctPriceOffLineReq{
+		SkuType:    types.SKUCSGHub,
+		ResourceID: fmt.Sprintf(types.ExternalLLMResourceFmt, "test-model"),
+	}).Return(nil, nil)
 	err := mc.DeleteLLMConfig(ctx, int64(123))
 	require.Nil(t, err)
 }

--- a/component/repo_deploy.go
+++ b/component/repo_deploy.go
@@ -12,13 +12,14 @@ import (
 	"strconv"
 	"strings"
 
+	"time"
+
 	"github.com/hashicorp/go-version"
 	"opencsg.com/csghub-server/builder/deploy"
 	deployStatus "opencsg.com/csghub-server/builder/deploy/common"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
-	"time"
 	"opencsg.com/csghub-server/common/utils/common"
 )
 
@@ -403,14 +404,16 @@ func (c *repoComponentImpl) ListDeploy(ctx context.Context, repoType types.Repos
 }
 
 func (c *repoComponentImpl) DeleteDeploy(ctx context.Context, delReq types.DeployActReq) error {
+	repoPath := ""
 	if delReq.DeployType == types.ServerlessType {
 		repo, err := c.repoStore.FindByPath(ctx, delReq.RepoType, delReq.Namespace, delReq.Name)
 		if err != nil {
-			return fmt.Errorf("fail to find repo for serverless, %w", err)
+			return fmt.Errorf("failed to find repo for serverless, %w", err)
 		}
+		repoPath = repo.Path
 		d, err := c.deployTaskStore.GetServerlessDeployByRepID(ctx, repo.ID)
 		if err != nil {
-			return fmt.Errorf("fail to get deploy for serverless, %w", err)
+			return fmt.Errorf("failed to get deploy for serverless, %w", err)
 		}
 		if d != nil {
 			delReq.DeployID = d.ID
@@ -442,12 +445,12 @@ func (c *repoComponentImpl) DeleteDeploy(ctx context.Context, delReq types.Deplo
 	exist, err := c.deployer.Exist(ctx, deployRepo)
 	if err != nil {
 		//add deploy id and repo in the log
-		slog.Warn("fail to check deploy instance exist in remote cluster, will delete deploy instance in database", slog.Any("deploy id", delReq.DeployID), slog.Any("repo", deployRepo.Name))
+		slog.Warn("failed to check deploy instance exist in remote cluster, will delete deploy instance in database", slog.Any("deploy id", delReq.DeployID), slog.Any("repo", deployRepo.Name))
 	}
 
 	if exist && err == nil {
 		// fail to delete service
-		return errors.New("fail to delete service")
+		return errors.New("failed to delete service")
 	}
 
 	// update database deploy
@@ -458,18 +461,33 @@ func (c *repoComponentImpl) DeleteDeploy(ctx context.Context, delReq types.Deplo
 	}
 
 	if err != nil {
-		return fmt.Errorf("fail to remove deploy instance, %w", err)
+		return fmt.Errorf("failed to remove deploy instance %d error: %w", delReq.DeployID, err)
 	}
+
+	if delReq.DeployType == types.ServerlessType {
+		llmID := fmt.Sprintf(types.CSGHubResourceFmt, types.ProviderTypeServerless, repoPath)
+		// Off-line the corresponding price info
+		pDelReq := types.AcctPriceOffLineReq{
+			SkuType:    types.SKUCSGHub,
+			ResourceID: llmID,
+		}
+		_, err = c.accountingComponent.OffLinePrice(ctx, pDelReq)
+		if err != nil {
+			slog.WarnContext(ctx, "off-line price failed for delete serverless",
+				slog.Any("err", err), slog.Any("deployid", delReq.DeployID), slog.Any("delReq", pDelReq))
+		}
+	}
+
 	// release resource if it's a order case
 	if deploy.OrderDetailID != 0 {
 		ur, err := c.userResourcesStore.FindUserResourcesByOrderDetailId(ctx, deploy.UserUUID, deploy.OrderDetailID)
 		if err != nil {
-			return fmt.Errorf("fail to find user resource, %w", err)
+			return fmt.Errorf("failed to find user resource, %w", err)
 		}
 		ur.DeployId = 0
 		err = c.userResourcesStore.UpdateDeployId(ctx, ur)
 		if err != nil {
-			return fmt.Errorf("fail to release resource, %w", err)
+			return fmt.Errorf("failed to release resource, %w", err)
 		}
 
 	}

--- a/component/space_resource.go
+++ b/component/space_resource.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"math"
+	"strconv"
 	"strings"
 
 	"opencsg.com/csghub-server/builder/deploy"
@@ -223,15 +225,25 @@ func (c *spaceResourceComponentImpl) Create(ctx context.Context, req *types.Crea
 func (c *spaceResourceComponentImpl) Delete(ctx context.Context, id int64) error {
 	sr, err := c.spaceResourceStore.FindByID(ctx, id)
 	if err != nil {
-		slog.Error("error finding space resource", slog.Any("error", err))
-		return err
+		return fmt.Errorf("error finding space resource %d failed: %w", id, err)
 	}
 
 	err = c.spaceResourceStore.Delete(ctx, *sr)
 	if err != nil {
-		slog.Error("error deleting space resource", slog.Any("error", err))
-		return err
+		return fmt.Errorf("error deleting space resource %d failed: %w", id, err)
 	}
+
+	// Off-line the corresponding price info
+	delReq := types.AcctPriceOffLineReq{
+		SkuType:    types.SKUCSGHub,
+		ResourceID: strconv.FormatInt(id, 10),
+	}
+	_, err = c.accountComponent.OffLinePrice(ctx, delReq)
+	if err != nil {
+		slog.WarnContext(ctx, "off-line price failed for delete space resource",
+			slog.Any("err", err), slog.Any("spaceResource", sr), slog.Any("delReq", delReq))
+	}
+
 	return nil
 }
 

--- a/component/space_resource_test.go
+++ b/component/space_resource_test.go
@@ -143,6 +143,10 @@ func TestSpaceResourceComponent_Delete(t *testing.T) {
 		&database.SpaceResource{}, nil,
 	)
 	sc.mocks.stores.SpaceResourceMock().EXPECT().Delete(ctx, database.SpaceResource{}).Return(nil)
+	sc.mocks.components.accounting.EXPECT().OffLinePrice(ctx, types.AcctPriceOffLineReq{
+		SkuType:    types.SKUCSGHub,
+		ResourceID: "1",
+	}).Return(nil, nil)
 
 	err := sc.Delete(ctx, 1)
 	require.Nil(t, err)


### PR DESCRIPTION
Summary:
- Introduces a new `Off-Line Price` API and logic to automatically disable `AccountPrice` records when deleting LLM Configs or Space Resources, preventing stale billing data from causing errors.
- Migrates resource ID format constants to a shared location and updates deletion handlers to call the offline price service, ensuring price status is updated without blocking the primary delete operation.