### PR TITLE
Add codes import by git url

### DIFF
--- a/common/errorx/error_git.go
+++ b/common/errorx/error_git.go
@@ -47,6 +47,7 @@ const (
 	gitGetRepositorySizeFailed
 	gitCreateForkFailed
 	gitGetArchiveFailed
+	gitInvalidURL
 )
 
 var (
@@ -498,6 +499,18 @@ var (
 	//
 	// zh-HK: 獲取 git 歸檔文件失敗
 	ErrGitGetArchiveFailed error = CustomError{prefix: errGitPrefix, code: gitGetArchiveFailed}
+	// the git url is invalid or malformed
+	//
+	// Description: The provided git URL is invalid or malformed. Please check the URL format and try again.
+	//
+	// Description_ZH: 提供的 Git URL 无效或格式错误。请检查 URL 格式并重试。
+	//
+	// en-US: Invalid git URL
+	//
+	// zh-CN: Git URL 无效
+	//
+	// zh-HK: Git URL 無效
+	ErrGitInvalidURL error = CustomError{prefix: errGitPrefix, code: gitInvalidURL}
 	// --- GIT-ERR-xxx: Git/Upload, Download, Resource Synchronization ---
 	// using git in xnet-enabled repository error
 	//
@@ -762,5 +775,13 @@ func GetArchiveFailed(err error, ctx context) error {
 		code:    gitGetArchiveFailed,
 		err:     err,
 		context: ctx,
+	}
+}
+
+func GitInvalidURL(err error) error {
+	return CustomError{
+		prefix: errGitPrefix,
+		code:   gitInvalidURL,
+		err:    err,
 	}
 }

--- a/common/i18n/en-US/err_git.json
+++ b/common/i18n/en-US/err_git.json
@@ -112,5 +112,8 @@
     },
     "error.GIT-ERR-9": {
         "other": "Repository not found"
+    },
+    "error.GIT-ERR-41": {
+        "other": "Invalid git URL"
     }
 }

--- a/common/i18n/zh-CN/err_git.json
+++ b/common/i18n/zh-CN/err_git.json
@@ -112,5 +112,8 @@
     },
     "error.GIT-ERR-9": {
         "other": "仓库未找到"
+    },
+    "error.GIT-ERR-41": {
+        "other": "Git URL 无效"
     }
 }

--- a/common/i18n/zh-HK/err_git.json
+++ b/common/i18n/zh-HK/err_git.json
@@ -112,5 +112,8 @@
     },
     "error.GIT-ERR-9": {
         "other": "儲存庫未找到"
+    },
+    "error.GIT-ERR-41": {
+        "other": "Git URL 無效"
     }
 }

--- a/common/types/code.go
+++ b/common/types/code.go
@@ -12,6 +12,9 @@ type CreateCodeReq struct {
 	CreateRepoReq
 	// Code package SHA256 hash
 	CodePackageSHA256 string `json:"code_file"`
+	GitURL             string `json:"git_url"`
+	GitUsername        string `json:"git_username"`
+	GitPassword        string `json:"git_password"`
 }
 
 type UpdateCodeReq struct {

--- a/component/code.go
+++ b/component/code.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
 	"path"
 	"path/filepath"
 	"slices"
@@ -182,6 +183,10 @@ func (c *codeComponentImpl) Create(ctx context.Context, req *types.CreateCodeReq
 
 	if commitFilesReq != nil {
 		_ = c.gitServer.CommitFiles(ctx, *commitFilesReq)
+	}
+
+	if err := c.createMirrorIfNeeded(ctx, req); err != nil {
+		return nil, err
 	}
 
 	for _, tag := range code.Repository.Tags {
@@ -747,4 +752,39 @@ func decompressTarGzForCode(reader io.Reader) ([]types.CommitFile, error) {
 	}
 
 	return commitFiles, nil
+}
+
+func (c *codeComponentImpl) createMirrorIfNeeded(ctx context.Context, req *types.CreateCodeReq) error {
+	if req.GitURL == "" {
+		return nil
+	}
+
+	gitUrl := req.GitURL
+	if req.GitUsername != "" && req.GitPassword != "" {
+		parsedUrl, err := url.Parse(gitUrl)
+		if err != nil {
+			return errorx.GitInvalidURL(err)
+		}
+		parsedUrl.User = url.UserPassword(req.GitUsername, req.GitPassword)
+		gitUrl = parsedUrl.String()
+	}
+
+	mirrorReq := types.CreateMirrorReq{
+		Namespace:   req.Namespace,
+		Name:        req.Name,
+		SourceUrl:   gitUrl,
+		Username:    req.GitUsername,
+		AccessToken: req.GitPassword,
+		CurrentUser: req.Username,
+		RepoType:    types.CodeRepo,
+		Interval:    "24h",
+		SyncLfs:     true,
+	}
+
+	_, err := c.repoComponent.CreateMirror(ctx, mirrorReq)
+	if err != nil {
+		return fmt.Errorf("failed to create mirror: %w", err)
+	}
+
+	return nil
 }

--- a/component/code_test.go
+++ b/component/code_test.go
@@ -304,3 +304,93 @@ func TestCodeComponent_OrgCodes(t *testing.T) {
 	}, data)
 
 }
+
+func TestCodeComponent_CreateWithGitURL(t *testing.T) {
+	ctx := context.TODO()
+	cc := initializeTestCodeComponent(ctx, t)
+
+	req := &types.CreateCodeReq{
+		CreateRepoReq: types.CreateRepoReq{
+			Username:  "user",
+			Namespace: "ns",
+			Name:      "n",
+			License:   "l",
+			Readme:    "r",
+		},
+		GitURL:      "https://github.com/test/test.git",
+		GitUsername: "testuser",
+		GitPassword: "testpass",
+	}
+	dbrepo := &database.Repository{
+		ID:   1,
+		Path: "ns/n",
+		User: database.User{Username: "user", UUID: "user-uuid"},
+		Tags: []database.Tag{{Name: "t1"}},
+	}
+	crq := req.CreateRepoReq
+	crq.Nickname = "n"
+	crq.Readme = generateReadmeData(req.License)
+	crq.RepoType = types.CodeRepo
+	crq.DefaultBranch = "main"
+	crq.CommitFiles = []types.CommitFile{
+		{
+			Content: crq.Readme,
+			Path:    types.ReadmeFileName,
+		},
+		{
+			Content: codeGitattributesContent,
+			Path:    types.GitattributesFileName,
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	cc.mocks.components.repo.EXPECT().
+		SendAssetManagementMsg(mock.Anything, mock.MatchedBy(func(req types.RepoNotificationReq) bool {
+			return req.RepoType == types.CodeRepo &&
+				req.Operation == types.OperationCreate &&
+				req.RepoPath == "ns/n" &&
+				req.UserUUID == "user-uuid"
+		})).
+		RunAndReturn(func(ctx context.Context, req types.RepoNotificationReq) error {
+			wg.Done()
+			return nil
+		}).Once()
+	cc.mocks.components.repo.EXPECT().CreateRepo(ctx, crq).Return(
+		nil, dbrepo, &gitserver.CommitFilesReq{}, nil,
+	)
+
+	cc.mocks.components.repo.EXPECT().CreateMirror(ctx, mock.MatchedBy(func(req types.CreateMirrorReq) bool {
+		return req.Namespace == "ns" &&
+			req.Name == "n" &&
+			req.SourceUrl == "https://testuser:testpass@github.com/test/test.git" &&
+			req.Username == "testuser" &&
+			req.AccessToken == "testpass" &&
+			req.RepoType == types.CodeRepo
+	})).Return(&database.Mirror{}, nil)
+
+	cc.mocks.gitServer.EXPECT().CommitFiles(ctx, gitserver.CommitFilesReq{}).Return(nil)
+	cc.mocks.stores.CodeMock().EXPECT().CreateAndUpdateRepoPath(ctx, database.Code{
+		Repository:   dbrepo,
+		RepositoryID: 1,
+	}, "ns/n").Return(&database.Code{
+		RepositoryID: 1,
+		Repository:   dbrepo,
+	}, nil)
+
+	resp, err := cc.Create(ctx, req)
+	require.Nil(t, err)
+	require.Equal(t, &types.Code{
+		RepositoryID: 1,
+		User: types.User{
+			Username: "user",
+		},
+		Path: "ns/n",
+		Repository: types.Repository{
+			HTTPCloneURL: "/s/ns/n.git",
+			SSHCloneURL:  ":s/ns/n.git",
+		},
+		Tags: []types.RepoTag{{Name: "t1"}},
+	}, resp)
+	wg.Wait()
+}

--- a/component/skill.go
+++ b/component/skill.go
@@ -383,10 +383,11 @@ func (c *skillComponentImpl) createMirrorIfNeeded(ctx context.Context, req *type
 	if req.GitUsername != "" && req.GitPassword != "" {
 		// Parse the URL to add authentication
 		parsedUrl, err := url.Parse(gitUrl)
-		if err == nil {
-			parsedUrl.User = url.UserPassword(req.GitUsername, req.GitPassword)
-			gitUrl = parsedUrl.String()
+		if err != nil {
+			return errorx.GitInvalidURL(err)
 		}
+		parsedUrl.User = url.UserPassword(req.GitUsername, req.GitPassword)
+		gitUrl = parsedUrl.String()
 	}
 
 	mirrorReq := types.CreateMirrorReq{


### PR DESCRIPTION
Summary:
- Adds support for importing code repositories via Git URL, addressing the previous limitation where only ZIP imports were available.
- Enables users to create code repositories by providing a Git URL, which automatically synchronizes the repository content upon creation.