### PR TITLE
Clean knative service instance when report kservice delete event

### DIFF
--- a/component/executors/webhook_executor_kservice.go
+++ b/component/executors/webhook_executor_kservice.go
@@ -132,6 +132,9 @@ func (k *kserviceExecutorImpl) updateDeployStatus(ctx context.Context, event *ty
 	if len(event.Instances) > 0 {
 		deploy.Instances = event.Instances
 	}
+	if event.Status == common.Stopped {
+		deploy.Instances = []types.Instance{}
+	}
 	err = k.deployTaskStore.UpdateDeploy(ctx, deploy)
 	if err != nil {
 		return fmt.Errorf("failed to update deploy %s status %d in webhook error: %w", event.ServiceName, event.Status, err)

--- a/component/executors/webhook_executor_kservice_test.go
+++ b/component/executors/webhook_executor_kservice_test.go
@@ -2,8 +2,11 @@ package executors
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -33,7 +36,7 @@ func TestWebHookExecutorKService_ProcessEvent(t *testing.T) {
 
 	event := &types.ServiceEvent{
 		ServiceName: "svcn",
-		Status:      20,
+		Status:      common.Deploying,
 		Message:     "msg",
 		Reason:      "test",
 		ClusterNode: "node1",
@@ -72,6 +75,621 @@ func TestWebHookExecutorKService_ProcessEvent(t *testing.T) {
 
 	err = exec.updateDeployStatus(ctx, event)
 	require.Nil(t, err)
+}
+
+func TestKServiceExecutor_updateDeployStatus_success(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Deploying,
+		Message:     "deploying",
+		Reason:      "triggered",
+		TaskID:      100,
+		Endpoint:    "http://svc-test.example.com",
+		QueueName:   "queue-1",
+		ClusterNode: "node1",
+		Instances: []types.Instance{
+			{Name: "inst1", Status: "running"},
+		},
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(&database.Deploy{
+		ID:         int64(1),
+		SvcName:    event.ServiceName,
+		Status:     common.Deploying,
+		ClusterNode: "",
+	}, nil)
+
+	dts.EXPECT().UpdateDeploy(ctx, mock.MatchedBy(func(d *database.Deploy) bool {
+		return d.ID == int64(1) &&
+			d.Status == event.Status &&
+			d.Message == event.Message &&
+			d.Reason == event.Reason &&
+			d.Endpoint == event.Endpoint &&
+			d.QueueName == event.QueueName &&
+			len(d.Instances) == 1 &&
+			d.Instances[0].Name == "inst1" &&
+			!d.StatusUpdateAt.IsZero()
+	})).Return(nil)
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.NoError(t, err)
+}
+
+func TestKServiceExecutor_updateDeployStatus_skipWhenLastTaskDiffers(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Running,
+		TaskID:      100,
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	// Last task has a different ID, so update should be skipped
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(999),
+	}, nil)
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.NoError(t, err)
+}
+
+func TestKServiceExecutor_updateDeployStatus_skipWhenDeployStoppedAndEventFailed(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.DeployFailed,
+		TaskID:      100,
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	// Deploy is already stopped, event says DeployFailed -> should be skipped
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(&database.Deploy{
+		ID:      int64(1),
+		Status:  common.Stopped,
+		SvcName: event.ServiceName,
+	}, nil)
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.NoError(t, err)
+}
+
+func TestKServiceExecutor_updateDeployStatus_skipWhenDeployDeleted(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Running,
+		TaskID:      100,
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	// Deploy is deleted -> should be skipped
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(&database.Deploy{
+		ID:      int64(1),
+		Status:  common.Deleted,
+		SvcName: event.ServiceName,
+	}, nil)
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.NoError(t, err)
+}
+
+func TestKServiceExecutor_updateDeployStatus_skipWhenNoDeployFound(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-nonexistent",
+		Status:      common.Running,
+		TaskID:      100,
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	// No deploy found by svc name (sql.ErrNoRows)
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(nil, sql.ErrNoRows)
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.NoError(t, err)
+}
+
+func TestKServiceExecutor_updateDeployStatus_clearInstancesOnStopped(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Stopped,
+		TaskID:      100,
+		Instances: []types.Instance{
+			{Name: "inst1", Status: "running"},
+		},
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(&database.Deploy{
+		ID:      int64(1),
+		Status:  common.Running,
+		SvcName: event.ServiceName,
+		Instances: []types.Instance{
+			{Name: "old-inst", Status: "running"},
+		},
+	}, nil)
+
+	dts.EXPECT().UpdateDeploy(ctx, mock.MatchedBy(func(d *database.Deploy) bool {
+		return d.ID == int64(1) &&
+			d.Status == common.Stopped &&
+			len(d.Instances) == 0 // instances should be cleared on Stopped
+	})).Return(nil)
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.NoError(t, err)
+}
+
+func TestKServiceExecutor_updateDeployStatus_updateEndpointAndQueueName(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Deploying,
+		TaskID:      100,
+		Endpoint:    "http://new-endpoint.example.com",
+		QueueName:   "new-queue",
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(&database.Deploy{
+		ID:      int64(1),
+		Status:  common.Deploying,
+		SvcName: event.ServiceName,
+	}, nil)
+
+	dts.EXPECT().UpdateDeploy(ctx, mock.MatchedBy(func(d *database.Deploy) bool {
+		return d.ID == int64(1) &&
+			d.Endpoint == "http://new-endpoint.example.com" &&
+			d.QueueName == "new-queue"
+	})).Return(nil)
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.NoError(t, err)
+}
+
+func TestKServiceExecutor_updateDeployStatus_getDeployTaskError(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Running,
+		TaskID:      100,
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(nil, errors.New("db error"))
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get deploy task by task id")
+}
+
+func TestKServiceExecutor_updateDeployStatus_getLastTaskError(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Running,
+		TaskID:      100,
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(nil, errors.New("db error"))
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get last deploy task")
+}
+
+func TestKServiceExecutor_updateDeployStatus_getDeployBySvcNameError(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Running,
+		TaskID:      100,
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	// Return a non-sql.ErrNoRows error
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(nil, errors.New("db error"))
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get deploy by service name")
+}
+
+func TestKServiceExecutor_updateDeployStatus_updateDeployError(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Running,
+		TaskID:      100,
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(&database.Deploy{
+		ID:      int64(1),
+		Status:  common.Deploying,
+		SvcName: event.ServiceName,
+	}, nil)
+
+	dts.EXPECT().UpdateDeploy(ctx, mock.Anything).Return(errors.New("update error"))
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to update deploy")
+}
+
+func TestKServiceExecutor_updateDeployStatus_triggerHandleDeployRunning(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Running,
+		TaskID:      100,
+	}
+
+	mockNotificationRpc := mockrpc.NewMockNotificationSvcClient(t)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	mockNotificationRpc.EXPECT().Send(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *types.MessageRequest) error {
+		defer wg.Done()
+		return nil
+	})
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(&database.Deploy{
+		ID:         int64(1),
+		Status:     common.Deploying, // old status is Deploying, event status is Running -> should trigger
+		SvcName:    event.ServiceName,
+		UserUUID:   "user1",
+		DeployName: "deploy1",
+		Type:       types.SpaceType,
+		GitPath:    "ns/n",
+	}, nil)
+
+	dts.EXPECT().UpdateDeploy(ctx, mock.Anything).Return(nil)
+
+	executor := &kserviceExecutorImpl{
+		cfg:                   cfg,
+		deployTaskStore:       dts,
+		notificationSvcClient: mockNotificationRpc,
+	}
+
+	err = executor.updateDeployStatus(ctx, event)
+	require.NoError(t, err)
+	// Wait for the goroutine handleDeployRunning to complete
+	wg.Wait()
+}
+
+func TestKServiceExecutor_updateDeployStatus_noHandleDeployRunningWhenAlreadyRunning(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Running,
+		TaskID:      100,
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	// Deploy is already Running, event is also Running -> should NOT trigger handleDeployRunning
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(&database.Deploy{
+		ID:      int64(1),
+		Status:  common.Running, // already running
+		SvcName: event.ServiceName,
+	}, nil)
+
+	dts.EXPECT().UpdateDeploy(ctx, mock.Anything).Return(nil)
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.NoError(t, err)
+}
+
+func TestKServiceExecutor_updateDeployStatus_appendClusterNode(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Deploying,
+		TaskID:      100,
+		ClusterNode: "node2",
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(&database.Deploy{
+		ID:          int64(1),
+		Status:      common.Deploying,
+		SvcName:     event.ServiceName,
+		ClusterNode: "node1",
+	}, nil)
+
+	dts.EXPECT().UpdateDeploy(ctx, mock.MatchedBy(func(d *database.Deploy) bool {
+		return d.ID == int64(1) &&
+			d.ClusterNode != "" &&
+			containsClusterNode(d.ClusterNode, "node1") &&
+			containsClusterNode(d.ClusterNode, "node2")
+	})).Return(nil)
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.NoError(t, err)
+}
+
+func TestKServiceExecutor_updateDeployStatus_skipDuplicateClusterNode(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Deploying,
+		TaskID:      100,
+		ClusterNode: "node1",
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(&database.Deploy{
+		ID:          int64(1),
+		Status:      common.Deploying,
+		SvcName:     event.ServiceName,
+		ClusterNode: "node1",
+	}, nil)
+
+	dts.EXPECT().UpdateDeploy(ctx, mock.MatchedBy(func(d *database.Deploy) bool {
+		return d.ID == int64(1) && d.ClusterNode == "node1"
+	})).Return(nil)
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.NoError(t, err)
+}
+
+func TestKServiceExecutor_updateDeployStatus_emptyClusterNodeNotAppended(t *testing.T) {
+	ctx := context.TODO()
+	cfg, err := config.LoadConfig()
+	require.Nil(t, err)
+
+	event := &types.ServiceEvent{
+		ServiceName: "svc-test",
+		Status:      common.Deploying,
+		TaskID:      100,
+		ClusterNode: "",
+	}
+
+	dts := mockdb.NewMockDeployTaskStore(t)
+
+	dts.EXPECT().GetDeployTask(ctx, event.TaskID).Return(&database.DeployTask{
+		ID:       int64(100),
+		DeployID: int64(1),
+		TaskType: common.TaskTypeDeploy,
+	}, nil)
+
+	dts.EXPECT().GetLastTaskByType(ctx, int64(1), common.TaskTypeDeploy).Return(&database.DeployTask{
+		ID: int64(100),
+	}, nil)
+
+	dts.EXPECT().GetDeployBySvcName(ctx, event.ServiceName).Return(&database.Deploy{
+		ID:          int64(1),
+		Status:      common.Deploying,
+		SvcName:     event.ServiceName,
+		ClusterNode: "node1",
+	}, nil)
+
+	dts.EXPECT().UpdateDeploy(ctx, mock.MatchedBy(func(d *database.Deploy) bool {
+		return d.ID == int64(1) && d.ClusterNode == "node1"
+	})).Return(nil)
+
+	exec := NewTestKServiceExecutor(cfg, dts)
+	err = exec.updateDeployStatus(ctx, event)
+	require.NoError(t, err)
+}
+
+// containsClusterNode checks if a node exists in a comma-separated cluster_node string
+func containsClusterNode(clusterNode string, node string) bool {
+	for _, n := range strings.Split(clusterNode, ",") {
+		if n == node {
+			return true
+		}
+	}
+	return false
 }
 
 func TestKServiceExecutor_sendNotification(t *testing.T) {


### PR DESCRIPTION
Summary:
- Cleans the `instances` field in deploy records by setting it to an empty array when a Knative Service deletion event (Stopped status) is received, preventing stale instance data from persisting after manual k8s deletions.
- Updates `updateDeployStatus` logic in `webhook_executor_kservice.go` to specifically handle Stopped events and adds comprehensive unit tests covering various state transitions and edge cases.