### PR TITLE
[Manual Sync Required] Make mirror sync timeout configurable

### DIFF
--- a/builder/git/gitserver/gitaly/client.go
+++ b/builder/git/gitserver/gitaly/client.go
@@ -35,6 +35,7 @@ type Client struct {
 	timeout             time.Duration
 	treeTimeout         time.Duration
 	repoStore           database.RepoStore
+	gitFetchTimeout     time.Duration
 }
 
 func NewClient(config *config.Config) (*Client, error) {
@@ -93,6 +94,7 @@ func NewClient(config *config.Config) (*Client, error) {
 
 	timeoutTime := time.Duration(config.Git.OperationTimeout) * time.Second
 	treeTimeoutTime := time.Duration(config.Git.TreeOperationTimeout) * time.Second
+	gitFetchTimeout := time.Duration(config.Git.FetchTimeout) * time.Second
 	return &Client{
 		config:              config,
 		sidechannelRegistry: sidechannelRegistry,
@@ -107,5 +109,6 @@ func NewClient(config *config.Config) (*Client, error) {
 		timeout:             timeoutTime,
 		repoStore:           database.NewRepoStore(),
 		treeTimeout:         treeTimeoutTime,
+		gitFetchTimeout:     gitFetchTimeout,
 	}, nil
 }

--- a/builder/git/gitserver/gitaly/mirror.go
+++ b/builder/git/gitserver/gitaly/mirror.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"time"
 
 	"gitlab.com/gitlab-org/gitaly/v16/proto/go/gitalypb"
 	"opencsg.com/csghub-server/builder/git/gitserver"
@@ -111,7 +110,7 @@ func (c *Client) GetMirrorTaskInfo(ctx context.Context, taskId int64) (*gitserve
 
 func (c *Client) MirrorSync(ctx context.Context, req gitserver.MirrorSyncReq) error {
 	stagingPrefix := "refs/staging"
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, c.gitFetchTimeout)
 	defer cancel()
 
 	relativePath, err := c.BuildRelativePath(ctx, req.RepoType, req.Namespace, req.Name)

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -483,6 +483,7 @@ type Config struct {
 		RepoDataMigrateEnable  bool   `env:"STARHUB_SERVER_GIT_REPO_DATA_MIGRATE_ENABLE" default:"false"`
 		LimitLfsFileUploadSize bool   `env:"STARHUB_SERVER_GIT_LIMIT_LFS_FILE_UPLOAD_SIZE " default:"true"`
 		TreeOperationTimeout   int    `env:"STARHUB_SERVER_GIT_TREE_OPERATION_TIMEOUT" default:"3"`
+		FetchTimeout           int    `env:"STARHUB_SERVER_GIT_FETCH_TIMEOUT" default:"240"`
 		MaxArchiveSizeMB       int64  `env:"STARHUB_SERVER_GIT_MAX_ARCHIVE_SIZE_MB" default:"50"`
 		// Welcome message displayed after git push
 		WelcomeMessage string `env:"STARHUB_SERVER_GIT_WELCOME_MESSAGE" default:"Welcome to OpenCSG!"`


### PR DESCRIPTION
Summary:
- Configured the repository sync timeout as a tunable parameter to prevent failures when syncing large repositories over low-bandwidth connections.
- Resolves the default 60-second timeout limitation that previously caused syncs of repositories around 38MB to fail in staging and production environments.

Manual handling required:
- Dev-agent failed to cherry-pick this GitLab MR: Git克隆命令执行失败: Command '['git', '--git-dir', '/root/gitlab-to-github/dev-agent/agent/.cache/mirrors/csghub-server.git', 'fetch', '--prune', 'origin']' returned non-zero exit status 128.
错误输出: fatal: unable to access 'https://github.com/OpenCSGs/csghub-server.git/': Failed to connect to github.com port 443 after 129629 ms: Connection timed out

- Source GitLab MR: !2731
- Source ref: 474f921156fb0dddc338e22330e94f83f8f5a752
- Files in sync scope: 3
- The GitLab MR patch was applied with git's 3-way apply. Please review before merging.