### PR TITLE
[Manual Sync Required] Do not allow public repo unless sensitive check passed

### DIFF
--- a/component/repo_test.go
+++ b/component/repo_test.go
@@ -3787,7 +3787,9 @@ func TestRepoComponent_UpdateRepo_PermissionChecks(t *testing.T) {
 				Private:   tea.Bool(false),
 			},
 			setupMocks: func(repo *testRepoWithMocks, req types.UpdateRepoReq) {
-				repo.mocks.stores.RepoMock().EXPECT().Find(ctx, req.Namespace, string(req.RepoType), req.Name).Return(&database.Repository{}, nil)
+				repo.mocks.stores.RepoMock().EXPECT().Find(ctx, req.Namespace, string(req.RepoType), req.Name).Return(&database.Repository{
+					SensitiveCheckStatus: types.SensitiveCheckPass,
+				}, nil)
 				repo.mocks.stores.NamespaceMock().EXPECT().FindByPath(ctx, req.Namespace).Return(database.Namespace{Path: "test-user", NamespaceType: database.UserNamespace}, nil)
 				repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, req.Username).Return(database.User{Username: "test-user"}, nil)
 				// Mock allowPublic to return true


### PR DESCRIPTION
Summary:
- Prevents users from setting a repository to public if the sensitive word check has not passed, addressing security compliance gaps.
- Restricts public visibility changes to only successful sensitive checks or admin operations, ensuring controlled access.

Manual handling required:
- Dev-agent failed to cherry-pick this GitLab MR: PR创建失败: 分支推送失败: fatal: unable to access 'https://github.com/OpenCSGs/csghub-server.git/': Failed to connect to github.com port 443 after 129729 ms: Connection timed out

- Source GitLab MR: !2734
- Source ref: 0839cf39ef36afb2046c5d184f8b52c9710257b3
- Files in sync scope: 1
- The GitLab MR patch was applied with git's 3-way apply. Please review before merging.