### PR TITLE
Make flag ALLOW_CPU_RESOURCE_SCHEDULE_TO_GPU_NODE only depend on db value report from runner

### DIFF
--- a/builder/deploy/deployer_ce.go
+++ b/builder/deploy/deployer_ce.go
@@ -99,7 +99,7 @@ func (d *deployer) startAccounting() {
 }
 
 func checkNodeResource(node types.NodeResourceInfo, hardware *types.HardWare,
-	config *config.Config, VXPUConfig map[string]string) types.ResourceAvailableStatus {
+	VXPUConfig map[string]string) types.ResourceAvailableStatus {
 	if node.NodeStatus == string(types.NodeStatusOffline) {
 		return types.ResourceAvailableStatus{
 			Available: false,
@@ -108,7 +108,7 @@ func checkNodeResource(node types.NodeResourceInfo, hardware *types.HardWare,
 		}
 	}
 
-	if !config.Cluster.AllowCPUResScheduleToGPUNode && isCPUOnlyWorkload(hardware) && isXPUNode(node) {
+	if !isAllowCPUResScheduleToGPUNode(VXPUConfig) && isCPUOnlyWorkload(hardware) && isXPUNode(node) {
 		return types.ResourceAvailableStatus{
 			Available: false,
 			NodeName:  node.NodeName,

--- a/builder/deploy/deployer_ce_test.go
+++ b/builder/deploy/deployer_ce_test.go
@@ -140,7 +140,6 @@ func TestDeployer_updateEvaluationEnvHardware(t *testing.T) {
 }
 
 func Test_CheckNodeResource(t *testing.T) {
-	config := &config.Config{}
 
 	baseNode := types.NodeResourceInfo{
 		NodeHardware: types.NodeHardware{
@@ -225,7 +224,7 @@ func Test_CheckNodeResource(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := checkNodeResource(tc.node, tc.hardware, config, map[string]string{})
+			got := checkNodeResource(tc.node, tc.hardware, map[string]string{})
 			if got.Available != tc.want {
 				t.Errorf("checkNodeResource() = %v, want %v", got.Available, tc.want)
 			}
@@ -249,28 +248,25 @@ func Test_CheckNodeResource_AllowCPUScheduleToGPUNode(t *testing.T) {
 	}
 
 	t.Run("AllowCPUScheduleToGPUNode=true allows CPU-only workload on GPU node", func(t *testing.T) {
-		config := &config.Config{}
-		config.Cluster.AllowCPUResScheduleToGPUNode = true
 
 		hardware := &types.HardWare{
 			Cpu:    types.CPU{Num: "8"},
 			Memory: "4Gi",
 		}
 
-		got := checkNodeResource(baseNode, hardware, config, map[string]string{})
+		vxpuConfig := map[string]string{types.ClusterCFGAllowCPUResScheduleToGPUNode: "true"}
+		got := checkNodeResource(baseNode, hardware, vxpuConfig)
 		require.True(t, got.Available, "Expected CPU-only workload to be allowed on GPU node when flag is enabled")
 	})
 
 	t.Run("AllowCPUScheduleToGPUNode=false (default) blocks CPU-only workload on GPU node", func(t *testing.T) {
-		config := &config.Config{}
-		config.Cluster.AllowCPUResScheduleToGPUNode = false
 
 		hardware := &types.HardWare{
 			Cpu:    types.CPU{Num: "8"},
 			Memory: "4Gi",
 		}
 
-		got := checkNodeResource(baseNode, hardware, config, map[string]string{})
+		got := checkNodeResource(baseNode, hardware, map[string]string{})
 		require.False(t, got.Available, "Expected CPU-only workload to be blocked on GPU node when flag is disabled")
 	})
 }

--- a/builder/deploy/deployer_resource.go
+++ b/builder/deploy/deployer_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 
 	"opencsg.com/csghub-server/common/config"
 	"opencsg.com/csghub-server/common/errorx"
@@ -128,17 +129,17 @@ func CheckResource(clusterResources *types.ClusterRes, hardware *types.HardWare,
 		}
 	}
 	if hardware.Replicas > 1 {
-		return checkMultiNodeResource(clusterResources, hardware, config)
+		return checkMultiNodeResource(clusterResources, hardware)
 	} else {
-		return checkSingleNodeResource(clusterResources, hardware, config)
+		return checkSingleNodeResource(clusterResources, hardware)
 	}
 }
 
 // check resource for sigle node
-func checkSingleNodeResource(clusterResources *types.ClusterRes, hardware *types.HardWare, config *config.Config) (bool, []types.ResourceAvailableStatus) {
+func checkSingleNodeResource(clusterResources *types.ClusterRes, hardware *types.HardWare) (bool, []types.ResourceAvailableStatus) {
 	var availableStatusList []types.ResourceAvailableStatus
 	for _, node := range clusterResources.Resources {
-		availableStatus := checkNodeResource(node, hardware, config, clusterResources.VXPUConfig)
+		availableStatus := checkNodeResource(node, hardware, clusterResources.VXPUConfig)
 		availableStatusList = append(availableStatusList, availableStatus)
 		if availableStatus.Available {
 			// if true return, otherwise continue check next node
@@ -148,11 +149,11 @@ func checkSingleNodeResource(clusterResources *types.ClusterRes, hardware *types
 	return false, availableStatusList
 }
 
-func checkMultiNodeResource(clusterResources *types.ClusterRes, hardware *types.HardWare, config *config.Config) (bool, []types.ResourceAvailableStatus) {
+func checkMultiNodeResource(clusterResources *types.ClusterRes, hardware *types.HardWare) (bool, []types.ResourceAvailableStatus) {
 	var availableStatusList []types.ResourceAvailableStatus
 	ready := 0
 	for _, node := range clusterResources.Resources {
-		availableStatus := checkNodeResource(node, hardware, config, clusterResources.VXPUConfig)
+		availableStatus := checkNodeResource(node, hardware, clusterResources.VXPUConfig)
 		availableStatusList = append(availableStatusList, availableStatus)
 		if availableStatus.Available {
 			ready++
@@ -180,4 +181,13 @@ func isCPUOnlyWorkload(hardware *types.HardWare) bool {
 
 func isXPUNode(node types.NodeResourceInfo) bool {
 	return node.HasXPU()
+}
+
+func isAllowCPUResScheduleToGPUNode(vxpuConfig map[string]string) bool {
+	val, ok := vxpuConfig[types.ClusterCFGAllowCPUResScheduleToGPUNode]
+	if !ok {
+		return false
+	}
+	b, _ := strconv.ParseBool(val)
+	return b
 }

--- a/builder/deploy/deployer_resource_ce_test.go
+++ b/builder/deploy/deployer_resource_ce_test.go
@@ -548,7 +548,6 @@ func TestCheckResourceAvailable(t *testing.T) {
 }
 
 func TestCheckSingleNodeResource(t *testing.T) {
-	cfg := &config.Config{}
 
 	testCases := []struct {
 		name           string
@@ -666,14 +665,13 @@ func TestCheckSingleNodeResource(t *testing.T) {
 				ClusterID: "c1",
 				Resources: tc.resources,
 			}
-			result, _ := checkSingleNodeResource(clusterRes, tc.hardware, cfg)
+			result, _ := checkSingleNodeResource(clusterRes, tc.hardware)
 			require.Equal(t, tc.expectedResult, result)
 		})
 	}
 }
 
 func TestCheckMultiNodeResource(t *testing.T) {
-	cfg := &config.Config{}
 
 	testCases := []struct {
 		name           string
@@ -801,7 +799,7 @@ func TestCheckMultiNodeResource(t *testing.T) {
 				ClusterID: "c1",
 				Resources: tc.resources,
 			}
-			result, _ := checkMultiNodeResource(clusterRes, tc.hardware, cfg)
+			result, _ := checkMultiNodeResource(clusterRes, tc.hardware)
 			require.Equal(t, tc.expectedResult, result)
 		})
 	}

--- a/common/types/cluster.go
+++ b/common/types/cluster.go
@@ -13,7 +13,8 @@ const (
 	ClusterCFGVGPUPodResourceNameKey  = "vgpu_pod_resource_name"
 	ClusterCFGVGPUResourceReqKey      = "vgpu_resource_req"
 	ClusterCFGVGPUMemoryReqKey        = "vgpu_memory_req"
-	ClusterCFGVGPUMemoryScalingFactor = "vgpu_memory_scaling_factor"
+	ClusterCFGVGPUMemoryScalingFactor     = "vgpu_memory_scaling_factor"
+	ClusterCFGAllowCPUResScheduleToGPUNode = "allow_cpu_res_schedule_to_gpu_node"
 )
 
 type ClusterRequest struct {

--- a/runner/component/cluster.go
+++ b/runner/component/cluster.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"strconv"
 	"time"
 
 	"opencsg.com/csghub-server/builder/deploy/cluster"
@@ -181,13 +182,14 @@ func (c *clusterComponentImpl) collectResourceByID(ctx context.Context, clusterI
 	}
 	clusterInfo.ResourceStatus = availabilityStatus
 	clusterInfo.VXPUConfig = map[string]string{
-		types.ClusterCFGKubeSchedulerKey:        c.cfg.Runner.KubeScheduler,
-		types.ClusterCFGVolcanoQueueKey:         c.cfg.Runner.Volcano.Queue,
-		types.ClusterCFGVGPUNodeResourceNameKey: c.cfg.Runner.VGPUNodeResourceName,
-		types.ClusterCFGVGPUPodResourceNameKey:  c.cfg.Runner.VGPUPodResourceName,
-		types.ClusterCFGVGPUResourceReqKey:      c.cfg.Runner.VGPUResourceReqKey,
-		types.ClusterCFGVGPUMemoryReqKey:        c.cfg.Runner.VGPUMemoryReqKey,
-		types.ClusterCFGVGPUMemoryScalingFactor: fmt.Sprintf("%d", c.cfg.Runner.VGPUMemoryScalingFactor),
+		types.ClusterCFGKubeSchedulerKey:            c.cfg.Runner.KubeScheduler,
+		types.ClusterCFGVolcanoQueueKey:             c.cfg.Runner.Volcano.Queue,
+		types.ClusterCFGVGPUNodeResourceNameKey:     c.cfg.Runner.VGPUNodeResourceName,
+		types.ClusterCFGVGPUPodResourceNameKey:      c.cfg.Runner.VGPUPodResourceName,
+		types.ClusterCFGVGPUResourceReqKey:          c.cfg.Runner.VGPUResourceReqKey,
+		types.ClusterCFGVGPUMemoryReqKey:            c.cfg.Runner.VGPUMemoryReqKey,
+		types.ClusterCFGVGPUMemoryScalingFactor:     fmt.Sprintf("%d", c.cfg.Runner.VGPUMemoryScalingFactor),
+		types.ClusterCFGAllowCPUResScheduleToGPUNode: strconv.FormatBool(c.cfg.Cluster.AllowCPUResScheduleToGPUNode),
 	}
 	return &clusterInfo, nil
 }


### PR DESCRIPTION
Summary:
- Refactored the `AllowCPUResScheduleToGPUNode` flag to be reported by the Runner via heartbeat and stored in the `vxpu_config` JSONB field, ensuring the Server's scheduling logic reflects the actual cluster state rather than a static configuration.
- Updated the Server-side deployment logic to read this flag directly from the database `VXPUConfig` map, removing dependencies on the local `config.Cluster` structure and eliminating the need for database migrations.