### PR TITLE
Fix wrong check evaluation permission

### DIFF
--- a/api/handler/monitor.go
+++ b/api/handler/monitor.go
@@ -248,7 +248,7 @@ func getEvaluationParameters(ctx *gin.Context) (*types.MonitorReq, error) {
 		CurrentUser:  currentUser,
 		RepoType:     repoType,
 		DeployID:     deployID,
-		DeployType:   "evaluation",
+		DeployType:   string(types.TaskTypeEvaluation),
 		Instance:     instance,
 		LastDuration: lastDuration,
 		TimeRange:    timeRange,

--- a/component/monitor.go
+++ b/component/monitor.go
@@ -13,6 +13,7 @@ import (
 	"opencsg.com/csghub-server/builder/rpc"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 	rtypes "opencsg.com/csghub-server/runner/types"
 )
@@ -29,6 +30,7 @@ type monitorComponentImpl struct {
 	userSvcClient   rpc.UserSvcClient
 	deployTaskStore database.DeployTaskStore
 	repoStore       database.RepoStore
+	workflowStore   database.ArgoWorkFlowStore
 	k8sNameSpace    string
 	deployer        deploy.Deployer
 	metrics         metricNames
@@ -53,6 +55,7 @@ func NewMonitorComponent(cfg *config.Config) (MonitorComponent, error) {
 		userSvcClient:   usc,
 		deployTaskStore: database.NewDeployTaskStore(),
 		repoStore:       database.NewRepoStore(),
+		workflowStore:   database.NewArgoWorkFlowStore(),
 		deployer:        deploy.NewDeployer(),
 		metrics: metricNames{
 			cpuUsage:       cfg.Prometheus.CPUUsageMetric,
@@ -356,7 +359,7 @@ func (m *monitorComponentImpl) getMetrics(metrics map[string]string) map[string]
 }
 
 func (m *monitorComponentImpl) hasPermission(ctx context.Context, req *types.MonitorReq) (bool, error, string, string) {
-	if req.DeployType == "evaluation" {
+	if req.DeployType == string(types.TaskTypeEvaluation) {
 		return m.hasPermissionForEval(ctx, req)
 	} else {
 		return m.hasPermissionForDeploy(ctx, req)
@@ -404,30 +407,15 @@ func (m *monitorComponentImpl) hasPermissionForDeploy(ctx context.Context, req *
 }
 
 func (m *monitorComponentImpl) hasPermissionForEval(ctx context.Context, req *types.MonitorReq) (bool, error, string, string) {
-	user, err := m.userSvcClient.GetUserInfo(ctx, req.CurrentUser, req.CurrentUser)
+	wf, err := m.workflowStore.FindByID(ctx, req.DeployID)
 	if err != nil {
-		return false, fmt.Errorf("failed to get user %s info error: %w", req.CurrentUser, err), "", ""
+		return false, fmt.Errorf("failed to get argo workflow by id %d, error: %w", req.DeployID, err), "", ""
 	}
-	if user == nil {
-		return false, fmt.Errorf("user %s not found", req.CurrentUser), "", ""
-	}
-	dbUser := &database.User{
-		RoleMask: strings.Join(user.Roles, ","),
-	}
-	isAdmin := dbUser.CanAdmin()
-	req2 := types.EvaluationGetReq{
-		ID:       req.DeployID,
-		Username: req.CurrentUser,
-	}
-	wf, err := m.deployer.GetEvaluation(ctx, req2)
+
+	_, err = checkOwnerOrOrgMemberPermission(ctx, m.userSvcClient, req.CurrentUser, wf.UserUUID)
 	if err != nil {
-		return false, fmt.Errorf("fail to get evaluation result, %w", err), "", ""
+		return false, errorx.ErrForbidden, "", ""
 	}
-	if isAdmin {
-		return true, nil, wf.Namespace, "main"
-	}
-	if wf.Username != user.Username {
-		return false, nil, "", ""
-	}
-	return true, nil, wf.Namespace, "main"
+
+	return true, nil, wf.Namespace, rtypes.MainContainerName
 }

--- a/component/monitor_test.go
+++ b/component/monitor_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/deploy"
 	prometheus_mock "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/prometheus"
 	mock_rpc "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/rpc"
 	mockdb "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/store/database"
@@ -144,6 +143,7 @@ func NewTestMonitorComponent(cfg *config.Config,
 	usc rpc.UserSvcClient,
 	deployTaskStore database.DeployTaskStore,
 	repoStore database.RepoStore,
+	workflowStore database.ArgoWorkFlowStore,
 	deployer deployer.Deployer,
 	metrics metricNames,
 ) (MonitorComponent, error) {
@@ -153,6 +153,7 @@ func NewTestMonitorComponent(cfg *config.Config,
 		userSvcClient:   usc,
 		deployTaskStore: deployTaskStore,
 		repoStore:       repoStore,
+		workflowStore:   workflowStore,
 		deployer:        deployer,
 		metrics:         metrics,
 	}, nil
@@ -215,7 +216,7 @@ func TestMonitor_RequestLatency(t *testing.T) {
 		},
 	}, nil)
 
-	mon, err := NewTestMonitorComponent(cfg, client, usc, deployTaskStore, repoStore, nil, defaultTestMetrics)
+	mon, err := NewTestMonitorComponent(cfg, client, usc, deployTaskStore, repoStore, nil, nil, defaultTestMetrics)
 	require.Nil(t, err)
 
 	resp, err := mon.RequestLatency(ctx, req)
@@ -295,7 +296,7 @@ func TestMonitor_RequestCount(t *testing.T) {
 		},
 	}, nil)
 
-	mon, err := NewTestMonitorComponent(cfg, client, usc, deployTaskStore, repoStore, nil, defaultTestMetrics)
+	mon, err := NewTestMonitorComponent(cfg, client, usc, deployTaskStore, repoStore, nil, nil, defaultTestMetrics)
 	require.Nil(t, err)
 
 	resp, err := mon.RequestCount(ctx, req)
@@ -379,7 +380,7 @@ func TestMonitor_MemoryUsage(t *testing.T) {
 		},
 	}, nil)
 
-	mon, err := NewTestMonitorComponent(cfg, client, usc, deployTaskStore, repoStore, nil, defaultTestMetrics)
+	mon, err := NewTestMonitorComponent(cfg, client, usc, deployTaskStore, repoStore, nil, nil, defaultTestMetrics)
 	require.Nil(t, err)
 
 	resp, err := mon.MemoryUsage(ctx, req)
@@ -423,28 +424,23 @@ func TestMonitor_MemoryUsage_Evaluation(t *testing.T) {
 	client := prometheus_mock.NewMockPrometheusClient(t)
 	deployTaskStore := mockdb.NewMockDeployTaskStore(t)
 	repoStore := mockdb.NewMockRepoStore(t)
-	mockDeployer := deploy.NewMockDeployer(t)
+	mockWorkflowStore := mockdb.NewMockArgoWorkFlowStore(t)
 
-	usc.EXPECT().GetUserInfo(ctx, req.CurrentUser, req.CurrentUser).Return(&rpc.User{
+	usc.EXPECT().GetUserByName(ctx, req.CurrentUser).Return(&types.User{
 		ID:       1,
 		Username: req.CurrentUser,
+		UUID:     "user-uuid-1",
 		Roles:    []string{"person"},
 	}, nil)
-	req2 := types.EvaluationGetReq{
-		ID:       1,
-		Username: "user",
-	}
-	mockDeployer.EXPECT().GetEvaluation(ctx, req2).Return(&types.ArgoWorkFlowRes{
+	mockWorkflowStore.EXPECT().FindByID(ctx, req.DeployID).Return(database.ArgoWorkflow{
 		ID:        1,
-		RepoIds:   []string{"Rowan/hellaswag"},
-		Datasets:  []string{"Rowan/hellaswag"},
-		RepoType:  "model",
 		Username:  "user",
-		TaskName:  "test",
-		TaskId:    "test",
-		TaskType:  "evaluation",
-		Status:    "Succeed",
+		UserUUID:  "user-uuid-1",
 		Namespace: "",
+	}, nil)
+	usc.EXPECT().GetNameSpaceInfoByUUID(ctx, "user-uuid-1").Return(&rpc.Namespace{
+		Path:   "user",
+		NSType: "user",
 	}, nil)
 
 	query := fmt.Sprintf("avg_over_time(container_memory_usage_bytes{pod='%s',namespace='%s',container='main'}[%s:])[%s:%s]",
@@ -469,7 +465,7 @@ func TestMonitor_MemoryUsage_Evaluation(t *testing.T) {
 		},
 	}, nil)
 
-	mon, err := NewTestMonitorComponent(cfg, client, usc, deployTaskStore, repoStore, mockDeployer, defaultTestMetrics)
+	mon, err := NewTestMonitorComponent(cfg, client, usc, deployTaskStore, repoStore, mockWorkflowStore, nil, defaultTestMetrics)
 	require.Nil(t, err)
 
 	resp, err := mon.MemoryUsage(ctx, req)
@@ -570,7 +566,7 @@ func TestMonitor_CPUUsage(t *testing.T) {
 		},
 	}, nil)
 
-	mon, err := NewTestMonitorComponent(cfg, client, usc, deployTaskStore, repoStore, nil, defaultTestMetrics)
+	mon, err := NewTestMonitorComponent(cfg, client, usc, deployTaskStore, repoStore, nil, nil, defaultTestMetrics)
 	require.Nil(t, err)
 
 	resp, err := mon.CPUUsage(ctx, req)


### PR DESCRIPTION
Summary:
- Refactored `hasPermissionForEval` to query the local `argo_workflows` table directly, eliminating unnecessary HTTP RPC calls and reducing latency.
- Enhanced permission logic to support admin, owner, and organization member scenarios via `checkOwnerOrOrgMemberPermission`, replacing the previous username-only check.
- Updated `DeployType` checks and container name references to use typed constants instead of hardcoded strings for consistency.