### PR TITLE
Support AMD HF runtime for AIGateway image generation

### DIFF
--- a/aigateway/component/adapter/text2image/hf_inference_toolkit.go
+++ b/aigateway/component/adapter/text2image/hf_inference_toolkit.go
@@ -18,7 +18,10 @@ import (
 	"opencsg.com/csghub-server/common/utils/common"
 )
 
-const frameworkHFInferenceToolkit = "hf-inference-toolkit"
+const (
+	frameworkHFInferenceToolkit    = "hf-inference-toolkit"
+	frameworkAMDHfInferenceToolkit = "amd-hf-inference-toolkit"
+)
 
 var hfProviders = []string{"opencsg"}
 
@@ -43,7 +46,16 @@ func (a *HFInferenceToolkitAdapter) CanHandle(model *types.Model) bool {
 	if model.CSGHubModelID == "" {
 		return false
 	}
-	return model.Task == string(commonTypes.Text2Image) && model.RuntimeFramework == frameworkHFInferenceToolkit
+	return model.Task == string(commonTypes.Text2Image) && isHFInferenceToolkitFramework(model.RuntimeFramework)
+}
+
+func isHFInferenceToolkitFramework(runtimeFramework string) bool {
+	switch strings.ToLower(strings.TrimSpace(runtimeFramework)) {
+	case frameworkHFInferenceToolkit, frameworkAMDHfInferenceToolkit:
+		return true
+	default:
+		return false
+	}
 }
 
 func (a *HFInferenceToolkitAdapter) TransformRequest(ctx context.Context, openaiReq types.ImageGenerationRequest) ([]byte, error) {

--- a/aigateway/component/adapter/text2image/hf_inference_toolkit_test.go
+++ b/aigateway/component/adapter/text2image/hf_inference_toolkit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"opencsg.com/csghub-server/aigateway/types"
+	commonTypes "opencsg.com/csghub-server/common/types"
 )
 
 // mockStorage implements types.Storage for tests
@@ -22,6 +23,68 @@ func (m *mockStorage) PutAndPresignGet(ctx context.Context, bucket, key string, 
 		return m.putAndPresignGet(ctx, bucket, key, data, contentType)
 	}
 	return "https://example.com/presigned/" + key, nil
+}
+
+func TestHFInferenceToolkitAdapter_CanHandle(t *testing.T) {
+	adapter := NewHFInferenceToolkitAdapter()
+
+	tests := []struct {
+		name  string
+		model *types.Model
+		want  bool
+	}{
+		{
+			name: "hf inference toolkit self-hosted text to image",
+			model: &types.Model{
+				BaseModel:         types.BaseModel{Task: string(commonTypes.Text2Image)},
+				InternalModelInfo: types.InternalModelInfo{CSGHubModelID: "namespace/model", RuntimeFramework: frameworkHFInferenceToolkit},
+			},
+			want: true,
+		},
+		{
+			name: "amd hf inference toolkit self-hosted text to image",
+			model: &types.Model{
+				BaseModel:         types.BaseModel{Task: string(commonTypes.Text2Image)},
+				InternalModelInfo: types.InternalModelInfo{CSGHubModelID: "namespace/model", RuntimeFramework: frameworkAMDHfInferenceToolkit},
+			},
+			want: true,
+		},
+		{
+			name: "runtime framework matching is normalized",
+			model: &types.Model{
+				BaseModel:         types.BaseModel{Task: string(commonTypes.Text2Image)},
+				InternalModelInfo: types.InternalModelInfo{CSGHubModelID: "namespace/model", RuntimeFramework: " AMD-HF-Inference-Toolkit "},
+			},
+			want: true,
+		},
+		{
+			name: "reject non text to image task",
+			model: &types.Model{
+				BaseModel:         types.BaseModel{Task: string(commonTypes.TextGeneration)},
+				InternalModelInfo: types.InternalModelInfo{CSGHubModelID: "namespace/model", RuntimeFramework: frameworkAMDHfInferenceToolkit},
+			},
+			want: false,
+		},
+		{
+			name: "reject missing csghub model id",
+			model: &types.Model{
+				BaseModel:         types.BaseModel{Task: string(commonTypes.Text2Image)},
+				InternalModelInfo: types.InternalModelInfo{RuntimeFramework: frameworkAMDHfInferenceToolkit},
+			},
+			want: false,
+		},
+		{
+			name:  "reject nil model",
+			model: nil,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, adapter.CanHandle(tt.model))
+		})
+	}
 }
 
 func TestHFInferenceToolkitAdapter_TransformResponse_responseFormatURL(t *testing.T) {


### PR DESCRIPTION
Summary:
- Extends `HFInferenceToolkitAdapter` to recognize the `amd-hf-inference-toolkit` runtime, resolving `unsupported_model` errors for AMD ROCm-based text-to-image models.
- Reuses existing request/response logic without introducing new API parameters or separate adapters, ensuring seamless compatibility with the current HF toolkit.