### PR TITLE
fix: detect tool calling support from engine_args JSON in aigateway

### DIFF
--- a/aigateway/component/openai.go
+++ b/aigateway/component/openai.go
@@ -349,8 +349,7 @@ func (c *openaiComponentImpl) getCSGHubModels(ctx context.Context, userID int64)
 			slog.WarnContext(ctx, "skip deploy with empty model id", "deploy_id", deploy.ID, "svc_name", deploy.SvcName, "deploy_type", deploy.Type)
 			continue
 		}
-		// Check if engine_args contains tool-call-parser parameter
-		supportFunctionCall := strings.Contains(deploy.EngineArgs, "tool-call-parser")
+		supportFunctionCall := commontypes.EngineArgToolCallingEnabled(deploy.EngineArgs, deploy.RuntimeFramework)
 		m := types.Model{
 			BaseModel: types.BaseModel{
 				Object:              "model",

--- a/aigateway/component/openai_test.go
+++ b/aigateway/component/openai_test.go
@@ -326,6 +326,78 @@ func TestSanitizeMeteringEventForLog(t *testing.T) {
 	require.True(t, strings.Contains(sanitized.Extra, `"completion_token_num":"8"`))
 }
 
+func TestOpenAIComponentImpl_getCSGHubModels_SetsSupportFunctionCallFromEngineArgs(t *testing.T) {
+	mockDeployStore := mockdb.NewMockDeployTaskStore(t)
+	comp := &openaiComponentImpl{
+		deployStore: mockDeployStore,
+	}
+
+	now := time.Now()
+	deploys := []database.Deploy{
+		{
+			ID:               1,
+			SvcName:          "vllm-svc",
+			Type:             commontypes.InferenceType,
+			RuntimeFramework: "vllm",
+			EngineArgs:       `{"enable-tool-calling":"enable"}`,
+			Repository: &database.Repository{
+				Name: "tool-model",
+				Path: "namespace/tool-model",
+			},
+			User: &database.User{
+				Username: "owner",
+				UUID:     "owner-uuid",
+			},
+			Endpoint: "vllm-endpoint",
+		},
+		{
+			ID:               2,
+			SvcName:          "plain-svc",
+			Type:             commontypes.InferenceType,
+			RuntimeFramework: "vllm",
+			EngineArgs:       `{"max-model-len":"8192"}`,
+			Repository: &database.Repository{
+				Name: "plain-model",
+				Path: "namespace/plain-model",
+			},
+			User: &database.User{
+				Username: "owner",
+				UUID:     "owner-uuid",
+			},
+			Endpoint: "plain-endpoint",
+		},
+		{
+			ID:               3,
+			SvcName:          "custom-options-svc",
+			Type:             commontypes.InferenceType,
+			RuntimeFramework: "vllm",
+			EngineArgs:       `{"max-model-len":"160000","custom-options":"--enable-auto-tool-choice --tool-call-parser deepseek_v31"}`,
+			Repository: &database.Repository{
+				Name: "custom-options-model",
+				Path: "namespace/custom-options-model",
+			},
+			User: &database.User{
+				Username: "owner",
+				UUID:     "owner-uuid",
+			},
+			Endpoint: "custom-options-endpoint",
+		},
+	}
+	for i := range deploys {
+		deploys[i].CreatedAt = now
+	}
+
+	mockDeployStore.EXPECT().RunningVisibleToUser(mock.Anything, int64(1)).
+		Return(deploys, nil).Once()
+
+	models, err := comp.getCSGHubModels(context.Background(), 1)
+	require.NoError(t, err)
+	require.Len(t, models, 3)
+	assert.True(t, models[0].SupportFunctionCall)
+	assert.False(t, models[1].SupportFunctionCall)
+	assert.True(t, models[2].SupportFunctionCall)
+}
+
 func TestOpenAIComponentImpl_getCSGHubModels_SkipsDeploysWithMissingRelations(t *testing.T) {
 	mockDeployStore := mockdb.NewMockDeployTaskStore(t)
 	comp := &openaiComponentImpl{

--- a/common/types/deploy.go
+++ b/common/types/deploy.go
@@ -1,14 +1,59 @@
 package types
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	"encoding/json"
+	"strings"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
-	// EngineArgEnableToolCalling is the engine argument for enabling tool calling
-	EngineArgEnableToolCalling = "--enable-tool-calling"
+	// EngineArgEnableToolCalling is the JSON key for enabling tool calling in engine_args.
+	EngineArgEnableToolCalling = "enable-tool-calling"
+	// EngineArgCustomOptions is the JSON key for extra CLI flags in engine_args.
+	EngineArgCustomOptions = "custom-options"
 )
+
+func engineArgCLIIndicatesToolCalling(engineArgs string) bool {
+	return strings.Contains(engineArgs, "--enable-auto-tool-choice") ||
+		strings.Contains(engineArgs, "tool-call-parser")
+}
+
+// EngineArgToolCallingEnabled reports whether tool calling is enabled in deploy engine_args.
+// engine_args are stored as JSON; vLLM uses "disable" as the default sentinel while
+// SGLang uses "enable" as the default sentinel.
+func EngineArgToolCallingEnabled(engineArgs, runtimeFramework string) bool {
+	engineArgs = strings.TrimSpace(engineArgs)
+	if engineArgs == "" {
+		return false
+	}
+
+	var argValuesMap map[string]string
+	if err := json.Unmarshal([]byte(engineArgs), &argValuesMap); err != nil {
+		// Legacy CLI-style engine args.
+		return engineArgCLIIndicatesToolCalling(engineArgs)
+	}
+
+	if value, ok := argValuesMap[EngineArgEnableToolCalling]; ok {
+		switch value {
+		case "false", "0", "", "disable":
+			return false
+		}
+
+		defaultSentinel := "disable"
+		if strings.Contains(strings.ToLower(runtimeFramework), "sglang") {
+			defaultSentinel = "enable"
+		}
+		return value != defaultSentinel
+	}
+
+	if customOptions, ok := argValuesMap[EngineArgCustomOptions]; ok {
+		return engineArgCLIIndicatesToolCalling(customOptions)
+	}
+
+	return false
+}
 
 type DeployReq struct {
 	CurrentUser string `json:"current_user"`

--- a/common/types/deploy_tool_calling_test.go
+++ b/common/types/deploy_tool_calling_test.go
@@ -1,0 +1,95 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEngineArgToolCallingEnabled(t *testing.T) {
+	tests := []struct {
+		name             string
+		engineArgs       string
+		runtimeFramework string
+		want             bool
+	}{
+		{
+			name:             "empty engine args",
+			engineArgs:       "",
+			runtimeFramework: "vllm",
+			want:             false,
+		},
+		{
+			name:             "vllm tool calling enabled",
+			engineArgs:       `{"enable-tool-calling":"enable"}`,
+			runtimeFramework: "vllm",
+			want:             true,
+		},
+		{
+			name:             "vllm tool calling disabled by default sentinel",
+			engineArgs:       `{"enable-tool-calling":"disable"}`,
+			runtimeFramework: "vllm",
+			want:             false,
+		},
+		{
+			name:             "nvidia vllm tool calling enabled",
+			engineArgs:       `{"enable-tool-calling":"true"}`,
+			runtimeFramework: "nvidia-vllm",
+			want:             true,
+		},
+		{
+			name:             "sglang tool calling disabled by default sentinel",
+			engineArgs:       `{"enable-tool-calling":"enable"}`,
+			runtimeFramework: "sglang",
+			want:             false,
+		},
+		{
+			name:             "sglang tool calling enabled with non-default value",
+			engineArgs:       `{"enable-tool-calling":"true"}`,
+			runtimeFramework: "sglang",
+			want:             true,
+		},
+		{
+			name:             "missing enable-tool-calling key",
+			engineArgs:       `{"max-model-len":"8192"}`,
+			runtimeFramework: "vllm",
+			want:             false,
+		},
+		{
+			name:             "tool calling enabled via custom-options",
+			engineArgs:       `{"max-model-len":"160000","custom-options":"--enable-auto-tool-choice --tool-call-parser deepseek_v31"}`,
+			runtimeFramework: "vllm",
+			want:             true,
+		},
+		{
+			name:             "custom-options without tool calling flags",
+			engineArgs:       `{"max-model-len":"8192","custom-options":"--enforce-eager"}`,
+			runtimeFramework: "vllm",
+			want:             false,
+		},
+		{
+			name:             "legacy cli vllm engine args",
+			engineArgs:       "--max-model-len 8192 --enable-auto-tool-choice --tool-call-parser qwen",
+			runtimeFramework: "vllm",
+			want:             true,
+		},
+		{
+			name:             "legacy cli sglang engine args",
+			engineArgs:       "--context-length 8192 --tool-call-parser auto",
+			runtimeFramework: "sglang",
+			want:             true,
+		},
+		{
+			name:             "legacy cli without tool calling flags",
+			engineArgs:       "--max-model-len 8192",
+			runtimeFramework: "vllm",
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, EngineArgToolCallingEnabled(tt.engineArgs, tt.runtimeFramework))
+		})
+	}
+}


### PR DESCRIPTION
Summary:
- Fixes incorrect detection of tool calling support in aigateway by parsing `enable-tool-calling` from the `engine_args` JSON instead of scanning for legacy CLI flags.
- Introduces a new helper to correctly identify tool calling capabilities for models like vLLM, including fallback checks for `custom-options` CLI flags.