### PR TITLE
Add pre check for mirror namespace and name

### DIFF
--- a/_mocks/opencsg.com/csghub-server/component/mock_MirrorComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_MirrorComponent.go
@@ -572,6 +572,65 @@ func (_c *MockMirrorComponent_Repos_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
+// ResolveNamespace provides a mock function with given fields: ctx, req
+func (_m *MockMirrorComponent) ResolveNamespace(ctx context.Context, req types.ResolveNamespaceReq) (*types.ResolveNamespaceResp, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveNamespace")
+	}
+
+	var r0 *types.ResolveNamespaceResp
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.ResolveNamespaceReq) (*types.ResolveNamespaceResp, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, types.ResolveNamespaceReq) *types.ResolveNamespaceResp); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.ResolveNamespaceResp)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, types.ResolveNamespaceReq) error); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockMirrorComponent_ResolveNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveNamespace'
+type MockMirrorComponent_ResolveNamespace_Call struct {
+	*mock.Call
+}
+
+// ResolveNamespace is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req types.ResolveNamespaceReq
+func (_e *MockMirrorComponent_Expecter) ResolveNamespace(ctx interface{}, req interface{}) *MockMirrorComponent_ResolveNamespace_Call {
+	return &MockMirrorComponent_ResolveNamespace_Call{Call: _e.mock.On("ResolveNamespace", ctx, req)}
+}
+
+func (_c *MockMirrorComponent_ResolveNamespace_Call) Run(run func(ctx context.Context, req types.ResolveNamespaceReq)) *MockMirrorComponent_ResolveNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.ResolveNamespaceReq))
+	})
+	return _c
+}
+
+func (_c *MockMirrorComponent_ResolveNamespace_Call) Return(_a0 *types.ResolveNamespaceResp, _a1 error) *MockMirrorComponent_ResolveNamespace_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockMirrorComponent_ResolveNamespace_Call) RunAndReturn(run func(context.Context, types.ResolveNamespaceReq) (*types.ResolveNamespaceResp, error)) *MockMirrorComponent_ResolveNamespace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Schedule provides a mock function with given fields: ctx
 func (_m *MockMirrorComponent) Schedule(ctx context.Context) error {
 	ret := _m.Called(ctx)

--- a/api/handler/mirror.go
+++ b/api/handler/mirror.go
@@ -220,3 +220,34 @@ func (h *MirrorHandler) Delete(ctx *gin.Context) {
 
 	httpbase.OK(ctx, nil)
 }
+
+// ResolveNamespace godoc
+// @Security     ApiKey
+// @Summary      Resolve target namespace and name from source
+// @Tags         Mirror
+// @Accept       json
+// @Produce      json
+// @Param        source_namespace query string true "source namespace"
+// @Param        source_name query string true "source name"
+// @Param        repo_type query string true "repo type (model, dataset, code)"
+// @Success      200  {object}  types.Response{data=types.ResolveNamespaceResp} "OK"
+// @Failure      400  {object}  types.APIBadRequest "Bad request"
+// @Failure      500  {object}  types.APIInternalServerError "Internal server error"
+// @Router       /mirror/namespace/resolve [get]
+func (h *MirrorHandler) ResolveNamespace(ctx *gin.Context) {
+	var req types.ResolveNamespaceReq
+	err := ctx.ShouldBindQuery(&req)
+	if err != nil {
+		httpbase.BadRequest(ctx, err.Error())
+		return
+	}
+
+	resp, err := h.mirror.ResolveNamespace(ctx.Request.Context(), req)
+	if err != nil {
+		slog.ErrorContext(ctx.Request.Context(), "failed to resolve namespace", slog.Any("error", err))
+		httpbase.ServerError(ctx, err)
+		return
+	}
+
+	httpbase.OK(ctx, resp)
+}

--- a/common/types/mirror.go
+++ b/common/types/mirror.go
@@ -82,6 +82,18 @@ type CreateMirrorRepoReq struct {
 	ForkName      string `json:"fork_name"`
 }
 
+type ResolveNamespaceReq struct {
+	SourceNamespace string         `json:"source_namespace" form:"source_namespace" binding:"required"`
+	SourceName      string         `json:"source_name" form:"source_name" binding:"required"`
+	RepoType        RepositoryType `json:"repo_type" form:"repo_type" binding:"required"`
+}
+
+type ResolveNamespaceResp struct {
+	TargetNamespace string `json:"target_namespace"`
+	TargetName      string `json:"target_name"`
+	Exists          bool   `json:"exists"`
+}
+
 type MCPServerAttributes struct {
 	StarCount     int       `json:"star_count"`
 	Tools         []MCPTool `json:"tools"`

--- a/component/mirror.go
+++ b/component/mirror.go
@@ -65,6 +65,7 @@ type MirrorComponent interface {
 	Schedule(ctx context.Context) error
 	PublicModelRepo(ctx context.Context) error
 	Delete(ctx context.Context, id int64) error
+	ResolveNamespace(ctx context.Context, req types.ResolveNamespaceReq) (*types.ResolveNamespaceResp, error)
 }
 
 func NewMirrorComponent(config *config.Config) (MirrorComponent, error) {

--- a/component/mirror_ce.go
+++ b/component/mirror_ce.go
@@ -4,6 +4,9 @@ package component
 
 import (
 	"context"
+	"errors"
+
+	"opencsg.com/csghub-server/common/types"
 )
 
 func (m *mirrorComponentImpl) Schedule(ctx context.Context) error {
@@ -12,4 +15,8 @@ func (m *mirrorComponentImpl) Schedule(ctx context.Context) error {
 
 func (m *mirrorComponentImpl) PublicModelRepo(ctx context.Context) error {
 	return nil
+}
+
+func (m *mirrorComponentImpl) ResolveNamespace(ctx context.Context, req types.ResolveNamespaceReq) (*types.ResolveNamespaceResp, error) {
+	return nil, errors.New("not implemented in CE version")
 }


### PR DESCRIPTION
Summary:
- Added a pre-check interface to validate source namespace and name before creating a mirror, preventing unexpected target configurations.
- Displays the calculated target namespace and name to users during the creation process to ensure alignment with expectations.