### PR TITLE
[Manual Sync Required] Remove sync version check before path change and insert new sync version after path change

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoStore.go
@@ -2595,6 +2595,7 @@ func (_c *MockRepoStore_UpdateRepo_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+
 // UpdateRepoCloneDownloads provides a mock function with given fields: ctx, repo, date, cloneCount
 func (_m *MockRepoStore) UpdateRepoCloneDownloads(ctx context.Context, repo *database.Repository, date time.Time, cloneCount int64) error {
 	ret := _m.Called(ctx, repo, date, cloneCount)

--- a/builder/store/database/repository.go
+++ b/builder/store/database/repository.go
@@ -370,9 +370,63 @@ func (s *repoStoreImpl) CreateRepo(ctx context.Context, input Repository) (*Repo
 }
 
 func (s *repoStoreImpl) UpdateRepo(ctx context.Context, input Repository) (*Repository, error) {
-	_, err := s.db.Core.NewUpdate().Model(&input).WherePK().Exec(ctx)
-	err = errorx.HandleDBError(err, errorx.Ctx().Set("path", input.Path))
-	return &input, err
+	err := s.db.RunInTx(ctx, func(ctx context.Context, tx Operator) error {
+		// Fetch the existing repo within the tx to detect path changes
+		var existing Repository
+		err := tx.Core.NewSelect().Model(&existing).Where("id = ?", input.ID).For("UPDATE").Scan(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to find existing repo: %w", err)
+		}
+
+		// If path changed and new path is not empty, migrate sync version records
+		if existing.Path != input.Path && input.Path != "" {
+			if err := s.migrateSyncVersion(ctx, tx, existing.Path, input); err != nil {
+				return err
+			}
+		}
+
+		// Update the repository
+		_, err = tx.Core.NewUpdate().Model(&input).WherePK().Exec(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to update repo: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errorx.HandleDBError(err, errorx.Ctx().Set("path", input.Path))
+	}
+	return &input, nil
+}
+
+// migrateSyncVersion copies the latest sync_version record from oldPath to newPath
+// within an existing transaction.
+func (s *repoStoreImpl) migrateSyncVersion(ctx context.Context, tx Operator, oldPath string, input Repository) error {
+	var latest SyncVersion
+	err := tx.Core.NewSelect().
+		Model(&latest).
+		Where("repo_path = ? AND repo_type = ?", oldPath, input.RepositoryType).
+		Order("version DESC").
+		Limit(1).
+		Scan(ctx)
+	if err != nil && err != sql.ErrNoRows {
+		return fmt.Errorf("failed to find sync_version for old path: %w", err)
+	}
+
+	if err != sql.ErrNoRows {
+		newSyncVersion := SyncVersion{
+			SourceID:       latest.SourceID,
+			RepoPath:       input.Path,
+			RepoType:       input.RepositoryType,
+			LastModifiedAt: latest.LastModifiedAt,
+			ChangeLog:      latest.ChangeLog,
+			Completed:      latest.Completed,
+		}
+		_, err = tx.Core.NewInsert().Model(&newSyncVersion).Exec(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to insert sync_version for new path: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *repoStoreImpl) DeleteRepo(ctx context.Context, input Repository) error {

--- a/component/repo.go
+++ b/component/repo.go
@@ -2974,16 +2974,6 @@ func (c *repoComponentImpl) checkChangePathDependencies(ctx context.Context, rep
 		return blocker
 	}
 	blocker = checkOne(func() (bool, error) {
-		_, err := c.syncVersionStore.FindByRepoTypeAndPath(ctx, repo.Path, repo.RepositoryType)
-		if errors.Is(err, sql.ErrNoRows) {
-			return false, nil
-		}
-		return err == nil, err
-	}, "sync versions", repo)
-	if blocker != nil {
-		return blocker
-	}
-	blocker = checkOne(func() (bool, error) {
 		cnt, err := c.argoWorkFlowStore.CountByRepoPath(ctx, repo.Path)
 		return cnt > 0, err
 	}, "argo workflows", repo)

--- a/component/repo_test.go
+++ b/component/repo_test.go
@@ -3373,8 +3373,6 @@ func TestRepoComponent_ChangePath(t *testing.T) {
 
 	// Dependency checks
 	repoComp.mocks.stores.DeployTaskMock().EXPECT().CountByRepoID(ctx, int64(1)).Return(0, nil)
-	repoComp.mocks.stores.SyncVersionMock().EXPECT().FindByRepoTypeAndPath(ctx, "namespace/name", types.ModelRepo).
-		Return(nil, sql.ErrNoRows)
 	repoComp.mocks.stores.WorkflowMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(0, nil)
 	repoComp.mocks.stores.ViewerMock().EXPECT().GetViewerByRepoID(ctx, int64(1)).Return(nil, sql.ErrNoRows)
 	repoComp.mocks.stores.AccountSyncQuotaStatementMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(0, nil)
@@ -3403,8 +3401,6 @@ func TestRepoComponent_ChangePath_RepoHashed(t *testing.T) {
 
 	// Dependency checks - no blocking entities
 	repoComp.mocks.stores.DeployTaskMock().EXPECT().CountByRepoID(ctx, int64(1)).Return(0, nil)
-	repoComp.mocks.stores.SyncVersionMock().EXPECT().FindByRepoTypeAndPath(ctx, "namespace/name", types.ModelRepo).
-		Return(nil, sql.ErrNoRows)
 	repoComp.mocks.stores.WorkflowMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(0, nil)
 	repoComp.mocks.stores.ViewerMock().EXPECT().GetViewerByRepoID(ctx, int64(1)).Return(nil, sql.ErrNoRows)
 	repoComp.mocks.stores.AccountSyncQuotaStatementMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(0, nil)
@@ -3416,7 +3412,13 @@ func TestRepoComponent_ChangePath_RepoHashed(t *testing.T) {
 		GitPath:        "models_new/path",
 		Hashed:         true,
 		RepositoryType: types.ModelRepo,
-	}).Return(nil, nil)
+	}).Return(&database.Repository{
+		ID:             1,
+		Path:           "new/path",
+		GitPath:        "models_new/path",
+		Hashed:         true,
+		RepositoryType: types.ModelRepo,
+	}, nil)
 
 	err := repoComp.ChangePath(ctx, types.ChangePathReq{
 		RepoType:  types.ModelRepo,
@@ -3489,9 +3491,8 @@ func TestRepoComponent_ChangePath_DependencyShortCircuits(t *testing.T) {
 
 	// Deploy passes
 	repoComp.mocks.stores.DeployTaskMock().EXPECT().CountByRepoID(ctx, int64(1)).Return(0, nil)
-	// Sync blocks - should return immediately, skipping remaining checks
-	repoComp.mocks.stores.SyncVersionMock().EXPECT().FindByRepoTypeAndPath(ctx, "namespace/name", types.ModelRepo).
-		Return(&database.SyncVersion{}, nil)
+		// Argo workflows block - should return immediately, skipping remaining checks
+		repoComp.mocks.stores.WorkflowMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(5, nil)
 
 	err := repoComp.ChangePath(ctx, types.ChangePathReq{
 		RepoType:  types.ModelRepo,
@@ -3502,7 +3503,7 @@ func TestRepoComponent_ChangePath_DependencyShortCircuits(t *testing.T) {
 
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "cannot change path")
-	require.Contains(t, err.Error(), "the following dependent entities exist: sync versions")
+	require.Contains(t, err.Error(), "the following dependent entities exist: argo workflows")
 	require.True(t, errors.Is(err, errorx.ErrChangePathBlocked))
 }
 


### PR DESCRIPTION
Summary:
- Removed the blocking check that prevented repository path updates when a sync version existed.
- Changed the logic to regenerate the sync version immediately after the path is updated, ensuring consistency.

Manual handling required:
- Dev-agent failed to cherry-pick this GitLab MR: PR创建失败: PR 创建失败: Validation Failed: 422 {"message": "Validation Failed", "errors": [{"resource": "PullRequest", "code": "custom", "message": "A pull request already exists for OpenCSGs:sync_mr_2745_35c0739."}], "documentation_url": "https://docs.github.com/rest/pulls/pulls#create-a-pull-request", "status": "422"}
- Source GitLab MR: !2745
- Source ref: 7c6f438919d9769fd422d33bd71d4c14f3819753
- Files in sync scope: 4
- The GitLab MR patch was applied with git's 3-way apply. Please review before merging.