### PR TITLE
[Manual Sync Required] feat(llm config): support multiple types per model config

### DIFF
--- a/aigateway/component/openai.go
+++ b/aigateway/component/openai.go
@@ -386,13 +386,13 @@ func (c *openaiComponentImpl) getCSGHubModels(ctx context.Context, userID int64)
 }
 
 func (m *openaiComponentImpl) getExternalModels(c context.Context) []types.Model {
-	search := &commontypes.SearchLLMConfig{}
-	searchType := 16
-	search.Type = &searchType
 	enabled := true
-	search.Enabled = &enabled
-	search.SortBy = "model_size_b"
-	search.SortOrder = "desc"
+	search := &commontypes.SearchLLMConfig{
+		Types:     []int{database.LLMTypeAigatewayExternal},
+		Enabled:   &enabled,
+		SortBy:    "model_size_b",
+		SortOrder: "desc",
+	}
 
 	per := 50
 	page := 1

--- a/aigateway/component/openai_ce_test.go
+++ b/aigateway/component/openai_ce_test.go
@@ -369,7 +369,7 @@ func TestOpenAIComponent_ListModels_CacheUsesOriginalID(t *testing.T) {
 	searchType := 16
 	enabled := true
 	search := &commontypes.SearchLLMConfig{
-		Type:      &searchType,
+		Types:     []int{searchType},
 		Enabled:   &enabled,
 		SortBy:    "model_size_b",
 		SortOrder: "desc",
@@ -542,7 +542,7 @@ func TestOpenAIComponent_GetModelByID(t *testing.T) {
 		searchType := 16
 		enabled := true
 		search := &commontypes.SearchLLMConfig{
-			Type:      &searchType,
+			Types:     []int{searchType},
 			Enabled:   &enabled,
 			SortBy:    "model_size_b",
 			SortOrder: "desc",
@@ -693,7 +693,7 @@ func TestOpenAIComponent_GetModelByID(t *testing.T) {
 		searchType := 16
 		enabled := true
 		search := &commontypes.SearchLLMConfig{
-			Type:      &searchType,
+			Types:     []int{searchType},
 			Enabled:   &enabled,
 			SortBy:    "model_size_b",
 			SortOrder: "desc",
@@ -848,7 +848,7 @@ func TestOpenAIComponent_ExtGetAvailableModels_Error(t *testing.T) {
 	searchType := 16
 	enabled := true
 	search := &commontypes.SearchLLMConfig{
-		Type:      &searchType,
+		Types:     []int{searchType},
 		Enabled:   &enabled,
 		SortBy:    "model_size_b",
 		SortOrder: "desc",
@@ -912,7 +912,7 @@ func TestOpenAIComponent_ExtGetAvailableModels_SinglePage(t *testing.T) {
 	searchType := 16
 	enabled := true
 	search := &commontypes.SearchLLMConfig{
-		Type:      &searchType,
+		Types:     []int{searchType},
 		Enabled:   &enabled,
 		SortBy:    "model_size_b",
 		SortOrder: "desc",
@@ -949,7 +949,7 @@ func TestOpenAIComponent_GetExternalModelsWithoutRepoOmitsRepoPath(t *testing.T)
 	searchType := 16
 	enabled := true
 	search := &commontypes.SearchLLMConfig{
-		Type:      &searchType,
+		Types:     []int{searchType},
 		Enabled:   &enabled,
 		SortBy:    "model_size_b",
 		SortOrder: "desc",

--- a/builder/store/database/llm_config.go
+++ b/builder/store/database/llm_config.go
@@ -51,6 +51,46 @@ const (
 	LLMTypeAigatewayExternal = 16
 )
 
+// LLMTypeFlags is the canonical list of single-bit LLM type flags.
+// When adding a new LLM type, add its power-of-two constant here so validation and response splitting stay in sync.
+var LLMTypeFlags = []int{
+	LLMTypeOptimization,
+	LLMTypeComparison,
+	LLMTypeSummaryReadme,
+	LLMTypeMCPScanner,
+	LLMTypeAigatewayExternal,
+}
+
+var llmTypeMask = CombineLLMTypes(LLMTypeFlags)
+
+// IsValidLLMType reports whether t is a non-empty bitmask composed only of known LLM type flags.
+func IsValidLLMType(t int) bool {
+	return t > 0 && t&^llmTypeMask == 0
+}
+
+// CombineLLMTypes folds a slice of individual LLM type flags into a single bitmask.
+func CombineLLMTypes(types []int) int {
+	mask := 0
+	for _, typ := range types {
+		mask |= typ
+	}
+	return mask
+}
+
+// SplitLLMType expands a type bitmask into the individual flags it contains.
+func SplitLLMType(t int) []int {
+	if t <= 0 {
+		return nil
+	}
+	var result []int
+	for _, bit := range LLMTypeFlags {
+		if t&bit == bit {
+			result = append(result, bit)
+		}
+	}
+	return result
+}
+
 type LLMConfigStore interface {
 	GetOptimization(ctx context.Context) (*LLMConfig, error)
 	GetModelForSummaryReadme(ctx context.Context) (*LLMConfig, error)
@@ -210,9 +250,12 @@ func buildSearchLLMConfigQuery(
 	if search.Keyword != "" {
 		q.Where("LOWER(llm_config.model_name) LIKE LOWER(?)", "%"+search.Keyword+"%")
 	}
-	// Filter by Type if provided
-	if search.Type != nil {
-		q.Where("llm_config.type = ?", *search.Type)
+	// Filter by Types if provided
+	if len(search.Types) > 0 {
+		mask := CombineLLMTypes(search.Types)
+		if mask > 0 {
+			q.Where("(llm_config.type & ?) > 0", mask)
+		}
 	}
 	// Filter by Enabled if provided
 	if search.Enabled != nil {

--- a/builder/store/database/llm_config_test.go
+++ b/builder/store/database/llm_config_test.go
@@ -131,7 +131,7 @@ func TestLLMConfigStore_CRUD(t *testing.T) {
 
 	searchType := 5
 	search := &types.SearchLLMConfig{
-		Type: &searchType,
+		Types: []int{searchType},
 	}
 	cfgs, total, err := store.Index(ctx, 1, 1, search)
 	require.Nil(t, err)
@@ -141,6 +141,57 @@ func TestLLMConfigStore_CRUD(t *testing.T) {
 
 	err = store.Delete(ctx, res.ID)
 	require.Nil(t, err)
+}
+
+func TestLLMConfigStore_Index_MultiType(t *testing.T) {
+	db := tests.InitTestDB()
+	defer db.Close()
+	ctx := context.TODO()
+	config, err := config.LoadConfig()
+	require.Nil(t, err)
+	store := database.NewLLMConfigStoreWithDB(db, config)
+
+	// Create a config that supports both optimization (1) and summary readme (4)
+	_, err = store.Create(ctx, database.LLMConfig{
+		Type:      database.LLMTypeOptimization | database.LLMTypeSummaryReadme,
+		Enabled:   true,
+		ModelName: "multi-type-model",
+	})
+	require.Nil(t, err)
+
+	// Create a config that supports only comparison (2)
+	_, err = store.Create(ctx, database.LLMConfig{
+		Type:      database.LLMTypeComparison,
+		Enabled:   true,
+		ModelName: "comparison-only-model",
+	})
+	require.Nil(t, err)
+
+	// Searching by optimization should find the multi-type config
+	cfgs, total, err := store.Index(ctx, 10, 1, &types.SearchLLMConfig{
+		Types: []int{database.LLMTypeOptimization},
+	})
+	require.Nil(t, err)
+	require.Equal(t, 1, total)
+	require.Len(t, cfgs, 1)
+	require.Equal(t, "multi-type-model", cfgs[0].ModelName)
+
+	// Searching by summary readme should also find the multi-type config
+	cfgs, total, err = store.Index(ctx, 10, 1, &types.SearchLLMConfig{
+		Types: []int{database.LLMTypeSummaryReadme},
+	})
+	require.Nil(t, err)
+	require.Equal(t, 1, total)
+	require.Len(t, cfgs, 1)
+	require.Equal(t, "multi-type-model", cfgs[0].ModelName)
+
+	// Searching by both optimization and comparison should find both configs
+	cfgs, total, err = store.Index(ctx, 10, 1, &types.SearchLLMConfig{
+		Types: []int{database.LLMTypeOptimization, database.LLMTypeComparison},
+	})
+	require.Nil(t, err)
+	require.Equal(t, 2, total)
+	require.Len(t, cfgs, 2)
 }
 
 func TestLLMConfigStore_Search(t *testing.T) {
@@ -259,7 +310,7 @@ func TestLLMConfigStore_Index_EnabledFilter(t *testing.T) {
 	enabledFalse := false
 
 	cfgsOn, totalOn, err := store.Index(ctx, 20, 1, &types.SearchLLMConfig{
-		Type:    &searchType,
+		Types:   []int{searchType},
 		Enabled: &enabledTrue,
 	})
 	require.Nil(t, err)
@@ -269,7 +320,7 @@ func TestLLMConfigStore_Index_EnabledFilter(t *testing.T) {
 	require.True(t, cfgsOn[0].Enabled)
 
 	cfgsOff, totalOff, err := store.Index(ctx, 20, 1, &types.SearchLLMConfig{
-		Type:    &searchType,
+		Types:   []int{searchType},
 		Enabled: &enabledFalse,
 	})
 	require.Nil(t, err)
@@ -279,7 +330,7 @@ func TestLLMConfigStore_Index_EnabledFilter(t *testing.T) {
 	require.False(t, cfgsOff[0].Enabled)
 
 	cfgsBoth, totalBoth, err := store.Index(ctx, 20, 1, &types.SearchLLMConfig{
-		Type: &searchType,
+		Types: []int{searchType},
 	})
 	require.Nil(t, err)
 	require.Equal(t, 2, totalBoth)
@@ -352,7 +403,7 @@ func TestLLMConfigStore_IndexWithRepo(t *testing.T) {
 
 	// Test IndexWithRepo
 	search := &types.SearchLLMConfig{
-		Type:    &llmType,
+		Types:   []int{llmType},
 		Enabled: &enabled,
 	}
 	cfgs, total, err := store.IndexWithRepo(ctx, 10, 1, search)
@@ -392,7 +443,7 @@ func TestLLMConfigStore_IndexWithRepo_Empty(t *testing.T) {
 
 	llmType := 16
 	search := &types.SearchLLMConfig{
-		Type: &llmType,
+		Types: []int{llmType},
 	}
 	cfgs, total, err := store.IndexWithRepo(ctx, 10, 1, search)
 	require.Nil(t, err)
@@ -432,7 +483,7 @@ func TestLLMConfigStore_Index_SortByModelSizeB(t *testing.T) {
 	require.Nil(t, err)
 
 	cfgsAsc, _, err := store.Index(ctx, 10, 1, &types.SearchLLMConfig{
-		Type:      &llmType,
+		Types:     []int{llmType},
 		SortBy:    "model_size_b",
 		SortOrder: "ASC",
 	})
@@ -443,7 +494,7 @@ func TestLLMConfigStore_Index_SortByModelSizeB(t *testing.T) {
 	require.Equal(t, "size-large", cfgsAsc[2].ModelName)
 
 	cfgsDesc, _, err := store.Index(ctx, 10, 1, &types.SearchLLMConfig{
-		Type:      &llmType,
+		Types:     []int{llmType},
 		SortBy:    "model_size_b",
 		SortOrder: "DESC",
 	})

--- a/common/types/llm_service.go
+++ b/common/types/llm_service.go
@@ -79,7 +79,8 @@ type LLMConfig struct {
 	OfficialName       string           `json:"-"`    // deprecated: derived from upstream
 	ApiEndpoint        string           `json:"-"`    // deprecated: derived from upstream
 	AuthHeader         string           `json:"-"`    // deprecated: moved to upstream
-	Type               int              `json:"type"` // 1: optimization, 2: comparison, 4: summary readme
+	Type               int              `json:"-"`    // internal bitmask, use Types for the API
+	Types              []int            `json:"types"` // individual type flags derived from Type
 	Enabled            bool             `json:"enabled"`
 	Provider           string           `json:"-"` // deprecated: moved to upstream
 	Upstreams          []UpstreamConfig `json:"upstreams"`
@@ -104,7 +105,7 @@ type PromptPrefix struct {
 
 type SearchLLMConfig struct {
 	Keyword   string `json:"keyword"`    // Search keyword
-	Type      *int   `json:"type"`       // Type of search
+	Types     []int  `json:"types"`      // Type flags to match (configs that include any of these flags are returned)
 	Enabled   *bool  `json:"enabled"`    // Enabled filter
 	SortBy    string `json:"sort_by"`    // Sortable field: model_size_b | updated_at
 	SortOrder string `json:"sort_order"` // ASC | DESC
@@ -119,7 +120,7 @@ type UpdateLLMConfigReq struct {
 	ID                 int64             `json:"id"`
 	ModelName          *string           `json:"model_name"`
 	Upstreams          *[]UpstreamConfig `json:"upstreams"`
-	Type               *int              `json:"type"` // 1: optimization, 2: comparison, 4: summary readme
+	Types              *[]int            `json:"types"` // individual type flags, combined into a bitmask on update
 	Enabled            *bool             `json:"enabled"`
 	RoutingPolicy      *RoutingPolicy    `json:"routing_policy"`
 	Metadata           *map[string]any   `json:"metadata"` // tasks stored as: {"tasks": ["text-generation", "text-to-image"]}
@@ -138,7 +139,7 @@ type UpdatePromptPrefixReq struct {
 type CreateLLMConfigReq struct {
 	ModelName          string           `json:"model_name" binding:"required"`
 	Upstreams          []UpstreamConfig `json:"upstreams,omitempty"`
-	Type               int              `json:"type" binding:"required,oneof=1 2 4 8 16"` // 1: optimization, 2: comparison, 4: summary readme, 8: mcp scan, 16: for aigateway call external llm
+	Types              []int            `json:"types" binding:"required,min=1,dive,oneof=1 2 4 8 16"` // individual type flags, combined into a bitmask on create
 	Enabled            bool             `json:"enabled"`
 	RoutingPolicy      RoutingPolicy    `json:"routing_policy"`
 	Metadata           map[string]any   `json:"metadata"` // tasks stored as: {"tasks": ["text-generation", "text-to-image"]}

--- a/component/llm_service.go
+++ b/component/llm_service.go
@@ -80,6 +80,11 @@ func NewLLMServiceComponent(config *config.Config) (LLMServiceComponent, error) 
 }
 
 func (s *llmServiceComponentImpl) IndexLLMConfig(ctx context.Context, per, page int, search *types.SearchLLMConfig) ([]*types.LLMConfig, int, error) {
+	if search != nil {
+		if err := validateOptionalLLMTypes(search.Types); err != nil {
+			return nil, 0, err
+		}
+	}
 	dbLLMConfigs, total, err := s.llmConfigStore.Index(ctx, per, page, search)
 	if err != nil {
 		return nil, 0, err
@@ -95,6 +100,7 @@ func (s *llmServiceComponentImpl) IndexLLMConfig(ctx context.Context, per, page 
 			OfficialName:       cfg.PrimaryOfficialName(),
 			Upstreams:          upstreams,
 			Type:               cfg.Type,
+			Types:              database.SplitLLMType(cfg.Type),
 			Enabled:            cfg.Enabled,
 			RoutingPolicy:      cfg.RoutingPolicy,
 			Metadata:           cfg.Metadata,
@@ -132,6 +138,7 @@ func (s *llmServiceComponentImpl) ShowLLMConfig(ctx context.Context, id int64) (
 		ModelName:          dbLlmConfig.ModelName,
 		Upstreams:          upstreams,
 		Type:               dbLlmConfig.Type,
+		Types:              database.SplitLLMType(dbLlmConfig.Type),
 		Enabled:            dbLlmConfig.Enabled,
 		RoutingPolicy:      dbLlmConfig.RoutingPolicy,
 		Metadata:           dbLlmConfig.Metadata,
@@ -185,8 +192,11 @@ func (s *llmServiceComponentImpl) UpdateLLMConfig(ctx context.Context, req *type
 		}
 		llmConfig.ModelName = modelName
 	}
-	if req.Type != nil {
-		llmConfig.Type = *req.Type
+	if req.Types != nil {
+		if err := validateLLMTypes(*req.Types); err != nil {
+			return nil, err
+		}
+		llmConfig.Type = database.CombineLLMTypes(*req.Types)
 	}
 	if req.Enabled != nil {
 		llmConfig.Enabled = *req.Enabled
@@ -221,6 +231,7 @@ func (s *llmServiceComponentImpl) UpdateLLMConfig(ctx context.Context, req *type
 		ModelName:          updatedConfig.ModelName,
 		Upstreams:          upstreams,
 		Type:               updatedConfig.Type,
+		Types:              database.SplitLLMType(updatedConfig.Type),
 		Enabled:            updatedConfig.Enabled,
 		RoutingPolicy:      updatedConfig.RoutingPolicy,
 		Metadata:           updatedConfig.Metadata,
@@ -275,9 +286,12 @@ func (s *llmServiceComponentImpl) CreateLLMConfig(ctx context.Context, req *type
 	if err := s.validateLLMEndpointConfig(req.Upstreams); err != nil {
 		return nil, err
 	}
+	if err := validateLLMTypes(req.Types); err != nil {
+		return nil, err
+	}
 	dbLLMConfig := database.LLMConfig{
 		ModelName:          modelName,
-		Type:               req.Type,
+		Type:               database.CombineLLMTypes(req.Types),
 		Enabled:            req.Enabled,
 		RoutingPolicy:      req.RoutingPolicy,
 		Metadata:           req.Metadata,
@@ -324,6 +338,7 @@ func (s *llmServiceComponentImpl) CreateLLMConfig(ctx context.Context, req *type
 		ModelName:          dbRes.ModelName,
 		Upstreams:          upstreams,
 		Type:               dbRes.Type,
+		Types:              database.SplitLLMType(dbRes.Type),
 		Enabled:            dbRes.Enabled,
 		RoutingPolicy:      dbRes.RoutingPolicy,
 		Metadata:           dbRes.Metadata,
@@ -345,6 +360,22 @@ func normalizeRequiredLLMModelName(modelName string) (string, error) {
 		return "", fmt.Errorf("%w: model_name cannot be empty", ErrInvalidLLMConfig)
 	}
 	return trimmed, nil
+}
+
+func validateLLMTypes(types []int) error {
+	if len(types) == 0 {
+		return fmt.Errorf("%w: types cannot be empty", ErrInvalidLLMConfig)
+	}
+	return validateOptionalLLMTypes(types)
+}
+
+func validateOptionalLLMTypes(types []int) error {
+	for _, typ := range types {
+		if !database.IsValidLLMType(typ) {
+			return fmt.Errorf("%w: invalid llm type %d", ErrInvalidLLMConfig, typ)
+		}
+	}
+	return nil
 }
 
 func (s *llmServiceComponentImpl) CreatePromptPrefix(ctx context.Context, req *types.CreatePromptPrefixReq) (*types.PromptPrefix, error) {
@@ -424,10 +455,9 @@ func (s *llmServiceComponentImpl) validateLLMEndpointConfig(upstreams []types.Up
 }
 
 func (s *llmServiceComponentImpl) ListExternalLLMs(ctx context.Context) ([]*types.LLMConfig, error) {
-	typeVal := database.LLMTypeAigatewayExternal
 	enabled := true
 	search := &types.SearchLLMConfig{
-		Type:    &typeVal,
+		Types:   []int{database.LLMTypeAigatewayExternal},
 		Enabled: &enabled,
 	}
 	configs, _, err := s.llmConfigStore.IndexWithRepo(ctx, math.MaxInt, 1, search)
@@ -441,6 +471,7 @@ func (s *llmServiceComponentImpl) ListExternalLLMs(ctx context.Context) ([]*type
 			ModelName:    cfg.ModelName,
 			OfficialName: cfg.PrimaryOfficialName(),
 			Type:         cfg.Type,
+			Types:        database.SplitLLMType(cfg.Type),
 			Enabled:      cfg.Enabled,
 			Provider:     cfg.Provider,
 			RepoID:       cfg.RepoID,

--- a/component/llm_service_test.go
+++ b/component/llm_service_test.go
@@ -28,7 +28,7 @@ func TestLLMServiceComponent_CreateLLMConfig(t *testing.T) {
 	}
 	req := &types.CreateLLMConfigReq{
 		ModelName: "new-model",
-		Type:      16,
+		Types:     []int{16},
 		Enabled:   true,
 		Upstreams: []types.UpstreamConfig{
 			{URL: "http://upstream.example.com/v1", Enabled: true, Weight: 1},
@@ -93,7 +93,7 @@ func TestLLMServiceComponent_CreateLLMConfig_TrimsWhitespace(t *testing.T) {
 	}
 	req := &types.CreateLLMConfigReq{
 		ModelName: "  new-model  ",
-		Type:      16,
+		Types:     []int{16},
 		Enabled:   true,
 		Upstreams: []types.UpstreamConfig{
 			{
@@ -125,7 +125,7 @@ func TestLLMServiceComponent_CreateLLMConfig_RejectsBlankModelName(t *testing.T)
 	}
 	req := &types.CreateLLMConfigReq{
 		ModelName: "   ",
-		Type:      16,
+		Types:     []int{16},
 		Enabled:   true,
 		Upstreams: []types.UpstreamConfig{
 			{URL: "http://upstream.example.com/v1", Enabled: true, Weight: 1},
@@ -136,6 +136,84 @@ func TestLLMServiceComponent_CreateLLMConfig_RejectsBlankModelName(t *testing.T)
 	require.Nil(t, res)
 	require.ErrorIs(t, err, ErrInvalidLLMConfig)
 	require.Contains(t, err.Error(), "model_name cannot be empty")
+}
+
+func TestLLMServiceComponent_CreateLLMConfig_MultiType(t *testing.T) {
+	ctx := context.TODO()
+	stores := tests.NewMockStores(t)
+	upstreamStore := mockdatabase.NewMockUpstreamStore(t)
+	upstreamStore.EXPECT().Create(ctx, mock.Anything).Return(nil).Maybe()
+	mc := &llmServiceComponentImpl{
+		llmConfigStore:    stores.LLMConfig,
+		promptPrefixStore: stores.PromptPrefix,
+		upstreamStore:     upstreamStore,
+	}
+	req := &types.CreateLLMConfigReq{
+		ModelName: "multi-type-model",
+		Types:     []int{database.LLMTypeSummaryReadme, database.LLMTypeAigatewayExternal},
+		Enabled:   true,
+		Upstreams: []types.UpstreamConfig{
+			{URL: "http://upstream.example.com/v1", Enabled: true, Weight: 1},
+		},
+	}
+	dbLLMConfig := &database.LLMConfig{
+		ID:        123,
+		ModelName: "multi-type-model",
+		Type:      database.LLMTypeSummaryReadme | database.LLMTypeAigatewayExternal,
+		Enabled:   true,
+	}
+	stores.LLMConfigMock().EXPECT().Create(ctx, database.LLMConfig{
+		ModelName: "multi-type-model",
+		Type:      database.LLMTypeSummaryReadme | database.LLMTypeAigatewayExternal,
+		Enabled:   true,
+	}).Return(dbLLMConfig, nil)
+	res, err := mc.CreateLLMConfig(ctx, req)
+	require.Nil(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, int64(123), res.ID)
+	require.Equal(t, []int{database.LLMTypeSummaryReadme, database.LLMTypeAigatewayExternal}, res.Types)
+}
+
+func TestLLMServiceComponent_CreateLLMConfig_RejectsInvalidTypes(t *testing.T) {
+	ctx := context.TODO()
+	stores := tests.NewMockStores(t)
+	mc := &llmServiceComponentImpl{
+		llmConfigStore:    stores.LLMConfig,
+		promptPrefixStore: stores.PromptPrefix,
+	}
+	req := &types.CreateLLMConfigReq{
+		ModelName: "bad-types-model",
+		Types:     []int{32},
+		Enabled:   true,
+		Upstreams: []types.UpstreamConfig{
+			{URL: "http://upstream.example.com/v1", Enabled: true, Weight: 1},
+		},
+	}
+	res, err := mc.CreateLLMConfig(ctx, req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, ErrInvalidLLMConfig)
+	require.Contains(t, err.Error(), "invalid llm type")
+}
+
+func TestLLMServiceComponent_CreateLLMConfig_RejectsEmptyTypes(t *testing.T) {
+	ctx := context.TODO()
+	stores := tests.NewMockStores(t)
+	mc := &llmServiceComponentImpl{
+		llmConfigStore:    stores.LLMConfig,
+		promptPrefixStore: stores.PromptPrefix,
+	}
+	req := &types.CreateLLMConfigReq{
+		ModelName: "no-types-model",
+		Types:     []int{},
+		Enabled:   true,
+		Upstreams: []types.UpstreamConfig{
+			{URL: "http://upstream.example.com/v1", Enabled: true, Weight: 1},
+		},
+	}
+	res, err := mc.CreateLLMConfig(ctx, req)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, ErrInvalidLLMConfig)
+	require.Contains(t, err.Error(), "types cannot be empty")
 }
 
 func TestLLMServiceComponent_CreatePromptPrefix(t *testing.T) {
@@ -188,8 +266,26 @@ func TestLLMServiceComponent_IndexLLMConfig(t *testing.T) {
 	res, total, err := mc.IndexLLMConfig(ctx, per, page, search)
 	require.Nil(t, err)
 	require.NotNil(t, res)
-	require.Equal(t, []*types.LLMConfig{{ID: 123, ModelName: "new-model", OfficialName: "new-model", Type: 666, Enabled: true, IsAvailable: true, Upstreams: []types.UpstreamConfig{}}}, res)
+	require.Equal(t, []*types.LLMConfig{{ID: 123, ModelName: "new-model", OfficialName: "new-model", Type: 666, Types: []int{2, 8, 16}, Enabled: true, IsAvailable: true, Upstreams: []types.UpstreamConfig{}}}, res)
 	require.Equal(t, total, 1)
+}
+
+func TestLLMServiceComponent_IndexLLMConfig_RejectsInvalidTypes(t *testing.T) {
+	ctx := context.TODO()
+	stores := tests.NewMockStores(t)
+	mc := &llmServiceComponentImpl{
+		llmConfigStore:    stores.LLMConfig,
+		promptPrefixStore: stores.PromptPrefix,
+	}
+	search := &types.SearchLLMConfig{
+		Types: []int{0},
+	}
+
+	res, total, err := mc.IndexLLMConfig(ctx, 1, 1, search)
+	require.Nil(t, res)
+	require.Zero(t, total)
+	require.ErrorIs(t, err, ErrInvalidLLMConfig)
+	require.Contains(t, err.Error(), "invalid llm type 0")
 }
 
 func TestLLMServiceComponent_IndexPromptPrefix(t *testing.T) {
@@ -260,6 +356,43 @@ func TestLLMServiceComponent_UpdateLLMConfig(t *testing.T) {
 	require.Equal(t, res.ID, int64(123))
 	require.Equal(t, res.ModelName, "new-model")
 	require.Equal(t, 13.0, res.ModelSizeB)
+}
+
+func TestLLMServiceComponent_UpdateLLMConfig_Types(t *testing.T) {
+	ctx := context.TODO()
+	stores := tests.NewMockStores(t)
+	upstreamStore := mockdatabase.NewMockUpstreamStore(t)
+	upstreamStore.EXPECT().ListByLLMConfigID(ctx, int64(123)).Return([]*database.Upstream{}, nil).Maybe()
+	mc := &llmServiceComponentImpl{
+		llmConfigStore:    stores.LLMConfig,
+		promptPrefixStore: stores.PromptPrefix,
+		upstreamStore:     upstreamStore,
+	}
+	newTypes := []int{database.LLMTypeOptimization, database.LLMTypeAigatewayExternal}
+	req := &types.UpdateLLMConfigReq{
+		ID:    123,
+		Types: &newTypes,
+	}
+	dbLLMConfig := &database.LLMConfig{
+		ID:        123,
+		ModelName: "existing-model",
+		Type:      database.LLMTypeComparison,
+	}
+	updatedLLMConfig := &database.LLMConfig{
+		ID:        123,
+		ModelName: "existing-model",
+		Type:      database.LLMTypeOptimization | database.LLMTypeAigatewayExternal,
+	}
+	stores.LLMConfigMock().EXPECT().GetByID(ctx, int64(123)).Return(dbLLMConfig, nil)
+	stores.LLMConfigMock().EXPECT().Update(ctx, database.LLMConfig{
+		ID:        123,
+		ModelName: "existing-model",
+		Type:      database.LLMTypeOptimization | database.LLMTypeAigatewayExternal,
+	}).Return(updatedLLMConfig, nil)
+	res, err := mc.UpdateLLMConfig(ctx, req)
+	require.Nil(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, []int{database.LLMTypeOptimization, database.LLMTypeAigatewayExternal}, res.Types)
 }
 
 func TestLLMServiceComponent_UpdateLLMConfig_TrimsWhitespace(t *testing.T) {
@@ -624,7 +757,7 @@ func TestLLMServiceComponent_ListExternalLLMs(t *testing.T) {
 
 	// Mock search params
 	search := &types.SearchLLMConfig{
-		Type:    &typeVal,
+		Types:   []int{typeVal},
 		Enabled: &enabled,
 	}
 
@@ -673,7 +806,7 @@ func TestLLMServiceComponent_ListExternalLLMs_NoRepo(t *testing.T) {
 	}
 
 	search := &types.SearchLLMConfig{
-		Type:    &typeVal,
+		Types:   []int{typeVal},
 		Enabled: &enabled,
 	}
 
@@ -699,7 +832,7 @@ func TestLLMServiceComponent_ListExternalLLMs_Error(t *testing.T) {
 	typeVal := database.LLMTypeAigatewayExternal
 	enabled := true
 	search := &types.SearchLLMConfig{
-		Type:    &typeVal,
+		Types:   []int{typeVal},
 		Enabled: &enabled,
 	}
 


### PR DESCRIPTION
Summary:
- Enables a single LLM model configuration to serve multiple scenarios (e.g., summary and aigateway) by replacing the single `type` field with a `types` array in API requests and responses.
- Internally retains the `type` column as a bitmask for storage, introducing utility functions to convert between arrays and bitmasks, and updating search filters to use bitwise matching for multi-type support.

Manual handling required:
- Dev-agent failed to cherry-pick this GitLab MR: Git克隆命令执行失败: Command '['git', '--git-dir', '/root/gitlab-to-github/dev-agent/agent/.cache/mirrors/csghub-server.git', 'fetch', '--prune', 'origin']' returned non-zero exit status 128.
错误输出: error: RPC failed; curl 16 Error in the HTTP2 framing layer
fatal: expected flush after ref listing

- Source GitLab MR: !2744
- Source ref: abb048b31483d7a9c8954e54b7d492960cdd4a31
- Files in sync scope: 7
- The GitLab MR patch was applied with git's 3-way apply. Please review before merging.