### PR TITLE
Use custom gpu labels definition first when admin define in runner env

### DIFF
--- a/builder/deploy/cluster/cluster_manager.go
+++ b/builder/deploy/cluster/cluster_manager.go
@@ -491,7 +491,7 @@ func collectNodeResource(node v1.Node, config *config.Config) types.NodeResource
 	allocatableCPU := node.Status.Allocatable.Cpu().DeepCopy()
 	totalXPU := resource.Quantity{}
 	allocatableXPU := resource.Quantity{}
-	xpuCapacityLabel, xpuTypeLabel, xpuMemLabel := getXPULabel(node.Labels, config)
+	xpuCapacityLabel, xpuTypeLabel, xpuMemLabel := getXPULabel(node.Labels, config, node.Name)
 	if xpuCapacityLabel != "" {
 		totalXPU = node.Status.Capacity[v1.ResourceName(xpuCapacityLabel)]
 		allocatableXPU = node.Status.Allocatable[v1.ResourceName(xpuCapacityLabel)]
@@ -594,7 +594,26 @@ func getGpuTypeAndVendor(vendorType string, label string) (string, string) {
 }
 
 // the first label is the xpu capacity label, the second is the gpu model label
-func getXPULabel(labels map[string]string, config *config.Config) (string, string, []string) {
+func getXPULabel(labels map[string]string, config *config.Config, nodeName string) (string, string, []string) {
+	//check custom gpu model labels first
+	if len(config.Runner.GPUModelLabel) > 0 {
+		var gpuLabels []types.GPUModel
+		err := json.Unmarshal([]byte(config.Runner.GPUModelLabel), &gpuLabels)
+		if err == nil {
+			for _, gpuModel := range gpuLabels {
+				if _, found := labels[gpuModel.TypeLabel]; found {
+					slog.Info("use custom GPUModelLabel", slog.Any("nodeName", nodeName), slog.Any("GPUModelLabel", gpuModel.TypeLabel))
+					return gpuModel.CapacityLabel, gpuModel.TypeLabel, []string{gpuModel.MemLabel}
+				}
+			}
+			slog.Warn("no gpu model label found in custom GPUModelLabel and fallback to default GPUModelLabel",
+				slog.Any("nodeName", nodeName), slog.Any("GPUModelLabel", config.Runner.GPUModelLabel))
+		} else {
+			slog.Warn("failed to parse custom GPUModelLabel from config and fallback to default GPUModelLabel",
+				slog.Any("error", err), slog.Any("GPUModelLabel", config.Runner.GPUModelLabel))
+		}
+	}
+
 	if _, found := labels["aliyun.accelerator/nvidia_name"]; found {
 		//for default cluster
 		return "nvidia.com/gpu", "aliyun.accelerator/nvidia_name", []string{"aliyun.accelerator/nvidia_mem"}
@@ -646,20 +665,6 @@ func getXPULabel(labels map[string]string, config *config.Config) (string, strin
 	if _, found := labels["chipltech.com/tpu.product"]; found {
 		//for chipltech tpu
 		return "chipltech.com/dlc-lyp", "chipltech.com/tpu.product", []string{"chipltech.com/tpu.mem"}
-	}
-	//check custom gpu model label
-	if config.Space.GPUModelLabel != "" {
-		var gpuLabels []types.GPUModel
-		err := json.Unmarshal([]byte(config.Space.GPUModelLabel), &gpuLabels)
-		if err != nil {
-			slog.Warn("failed to parse custom GPUModelLabel from config", slog.Any("error", err))
-			return "", "", []string{}
-		}
-		for _, gpuModel := range gpuLabels {
-			if _, found := labels[gpuModel.TypeLabel]; found {
-				return gpuModel.CapacityLabel, gpuModel.TypeLabel, []string{gpuModel.MemLabel}
-			}
-		}
 	}
 	return "", "", []string{}
 }

--- a/builder/deploy/cluster/cluster_manager_test.go
+++ b/builder/deploy/cluster/cluster_manager_test.go
@@ -263,7 +263,7 @@ func TestGetXPULabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCapacity, gotTypeLabel, _ := getXPULabel(tt.labels, tt.config)
+			gotCapacity, gotTypeLabel, _ := getXPULabel(tt.labels, tt.config, "")
 			assert.Equal(t, tt.wantCapacity, gotCapacity)
 			assert.Equal(t, tt.wantTypeLabel, gotTypeLabel)
 		})

--- a/builder/deploy/cluster/resource_namespace.go
+++ b/builder/deploy/cluster/resource_namespace.go
@@ -39,7 +39,7 @@ func (cluster *Cluster) GetResourceInNamespace(namespace string, quotaName strin
 		available.Sub(usedAmount)
 		return available
 	}
-	xpuCapacityLabel, xpuTypeLabel, _ := getXPULabel(quota.Labels, config)
+	xpuCapacityLabel, xpuTypeLabel, _ := getXPULabel(quota.Labels, config, quotaName)
 	gpuModelVendor, gpuModel := getGpuTypeAndVendor(quota.Labels[xpuTypeLabel], xpuCapacityLabel)
 	var totalXPU int64 = 0
 	var availableXPU int64 = 0

--- a/builder/deploy/cluster/resource_namespace_test.go
+++ b/builder/deploy/cluster/resource_namespace_test.go
@@ -20,7 +20,7 @@ func TestGetNameSpaceResourcesQuota(t *testing.T) {
 	testQuotaName := "compute-quota"
 	customGPUConfigJSON := `[{"type_label": "my-custom.com/gpu-model", "capacity_label": "my-custom.com/gpu-count"}]`
 	cfg := &config.Config{}
-	cfg.Space.GPUModelLabel = customGPUConfigJSON
+	cfg.Runner.GPUModelLabel = customGPUConfigJSON
 	testCases := []struct {
 		name           string
 		namespace      string

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -202,11 +202,9 @@ type Config struct {
 		// reverse proxy listening port
 		RProxyServerPort int `env:"STARHUB_SERVER_SPACE_RPROXY_SERVER_PORT" default:"8083"`
 		// secret key for session encryption
-		SessionSecretKey   string `env:"STARHUB_SERVER_SPACE_SESSION_SECRET_KEY" default:"secret"`
-		DeployTimeoutInMin int    `env:"STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES" default:"30"`
-		BuildTimeoutInMin  int    `env:"STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES" default:"30"`
-		// gpu model label
-		GPUModelLabel             string `env:"STARHUB_SERVER_GPU_MODEL_LABEL"`
+		SessionSecretKey          string `env:"STARHUB_SERVER_SPACE_SESSION_SECRET_KEY" default:"secret"`
+		DeployTimeoutInMin        int    `env:"STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES" default:"30"`
+		BuildTimeoutInMin         int    `env:"STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES" default:"30"`
 		ReadinessDelaySeconds     int    `env:"STARHUB_SERVER_READINESS_DELAY_SECONDS" default:"120"`
 		ReadinessPeriodSeconds    int    `env:"STARHUB_SERVER_READINESS_PERIOD_SECONDS" default:"10"`
 		ReadinessFailureThreshold int    `env:"STARHUB_SERVER_READINESS_FAILURE_THRESHOLD" default:"3"`
@@ -660,6 +658,7 @@ type Config struct {
 		VGPUResourceReqKey      string `env:"STARHUB_SERVER_RUNNER_VGPU_RESOURCE_REQ_KEY" default:"nvidia.com/vgpu"`
 		VGPUMemoryReqKey        string `env:"STARHUB_SERVER_RUNNER_VGPU_MEMORY_REQ_KEY" default:"nvidia.com/vgpumem"`
 		VGPUMemoryScalingFactor int64  `env:"STARHUB_SERVER_RUNNER_VGPU_MEMORY_SCING_FACTOR" default:"10"`
+		GPUModelLabel           string `env:"STARHUB_SERVER_RUNNER_GPU_MODEL_LABEL" default:""`
 		PD                      struct {
 			// EPPImage is the image ID for the Endpoint Picker deployment. Only the short image ID is configured;
 			// it will be resolved to a full image path via resolveContainerImage at runtime.

--- a/common/config/config.toml.example
+++ b/common/config/config.toml.example
@@ -141,7 +141,6 @@ image_pull_secret = "opencsg-pull-secret"
 rproxy_server_port = 8083
 session_secret_key = "secret"
 deploy_timeout_in_min = 30
-gpu_model_label = "aliyun.accelerator/nvidia_name"
 readiness_delay_seconds = 120
 readiness_period_seconds = 10
 readiness_failure_threshold = 3
@@ -266,7 +265,6 @@ image_builder_status_ttl = 300
 # --skip-tls-verify : Disable TLS certificate validation for registries.
 # Uncomment the following line to enable pull images from a private registry without https
 # image_builder_kaniko_args = ["--insecure", "--skip-tls-verify"]
-STARHUB_SERVER_GPU_MODEL_LABEL = '[{"type_label": "aliyun.accelerator/nvidia_name", "capacity_label": "nvidia.com/gpu"}]'
 system_cuda_version = ""
 webhook_endpoint = "http://localhost:8080"
 watch_configmap_name = "spaces-runner-config"
@@ -274,6 +272,7 @@ watch_configmap_interval_in_sec = 60
 runner_namespace = "csghub"
 public_docker_reg_base = "opencsg-registry.cn-beijing.cr.aliyuncs.com"
 vgpu_memory_scaling_factor = 10
+gpu_model_label = '[{"type_label":"aliyun.accelerator/nvidia_name","capacity_label":"nvidia.com/gpu","mem_label":"aliyun.accelerator/nvidia_mem"}]'
 
 [cluster]
 cluster_id = ""


### PR DESCRIPTION
Summary:
- Relocated `GPUModelLabel` configuration from `Space` to `Runner` and updated the corresponding environment variable to `STARHUB_SERVER_RUNNER_GPU_MODEL_LABEL`.
- Prioritized custom GPU label matching over hardcoded defaults in `getXPULabel` to allow administrators to override default behavior, with improved logging for node identification.
- Updated `config.toml.example` to reflect the new configuration structure and corrected the `gpu_model_label` value format to a valid JSON array.