### PR TITLE
Fix PublicToUser bug

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoStore.go
@@ -2036,9 +2036,9 @@ func (_c *MockRepoStore_ListRepoByDeployType_Call) RunAndReturn(run func(context
 	return _c
 }
 
-// PublicToUser provides a mock function with given fields: ctx, repoType, userIDs, filter, per, page, isAdmin
-func (_m *MockRepoStore) PublicToUser(ctx context.Context, repoType types.RepositoryType, userIDs []int64, filter *types.RepoFilter, per int, page int, isAdmin bool) ([]*database.Repository, int, error) {
-	ret := _m.Called(ctx, repoType, userIDs, filter, per, page, isAdmin)
+// PublicToUser provides a mock function with given fields: ctx, repoType, ownerNamespaces, filter, per, page, isAdmin
+func (_m *MockRepoStore) PublicToUser(ctx context.Context, repoType types.RepositoryType, ownerNamespaces []string, filter *types.RepoFilter, per int, page int, isAdmin bool) ([]*database.Repository, int, error) {
+	ret := _m.Called(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PublicToUser")
@@ -2047,25 +2047,25 @@ func (_m *MockRepoStore) PublicToUser(ctx context.Context, repoType types.Reposi
 	var r0 []*database.Repository
 	var r1 int
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int, bool) ([]*database.Repository, int, error)); ok {
-		return rf(ctx, repoType, userIDs, filter, per, page, isAdmin)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, []string, *types.RepoFilter, int, int, bool) ([]*database.Repository, int, error)); ok {
+		return rf(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int, bool) []*database.Repository); ok {
-		r0 = rf(ctx, repoType, userIDs, filter, per, page, isAdmin)
+	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, []string, *types.RepoFilter, int, int, bool) []*database.Repository); ok {
+		r0 = rf(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*database.Repository)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int, bool) int); ok {
-		r1 = rf(ctx, repoType, userIDs, filter, per, page, isAdmin)
+	if rf, ok := ret.Get(1).(func(context.Context, types.RepositoryType, []string, *types.RepoFilter, int, int, bool) int); ok {
+		r1 = rf(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
 	} else {
 		r1 = ret.Get(1).(int)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int, bool) error); ok {
-		r2 = rf(ctx, repoType, userIDs, filter, per, page, isAdmin)
+	if rf, ok := ret.Get(2).(func(context.Context, types.RepositoryType, []string, *types.RepoFilter, int, int, bool) error); ok {
+		r2 = rf(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -2081,18 +2081,18 @@ type MockRepoStore_PublicToUser_Call struct {
 // PublicToUser is a helper method to define mock.On call
 //   - ctx context.Context
 //   - repoType types.RepositoryType
-//   - userIDs []int64
+//   - ownerNamespaces []string
 //   - filter *types.RepoFilter
 //   - per int
 //   - page int
 //   - isAdmin bool
-func (_e *MockRepoStore_Expecter) PublicToUser(ctx interface{}, repoType interface{}, userIDs interface{}, filter interface{}, per interface{}, page interface{}, isAdmin interface{}) *MockRepoStore_PublicToUser_Call {
-	return &MockRepoStore_PublicToUser_Call{Call: _e.mock.On("PublicToUser", ctx, repoType, userIDs, filter, per, page, isAdmin)}
+func (_e *MockRepoStore_Expecter) PublicToUser(ctx interface{}, repoType interface{}, ownerNamespaces interface{}, filter interface{}, per interface{}, page interface{}, isAdmin interface{}) *MockRepoStore_PublicToUser_Call {
+	return &MockRepoStore_PublicToUser_Call{Call: _e.mock.On("PublicToUser", ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)}
 }
 
-func (_c *MockRepoStore_PublicToUser_Call) Run(run func(ctx context.Context, repoType types.RepositoryType, userIDs []int64, filter *types.RepoFilter, per int, page int, isAdmin bool)) *MockRepoStore_PublicToUser_Call {
+func (_c *MockRepoStore_PublicToUser_Call) Run(run func(ctx context.Context, repoType types.RepositoryType, ownerNamespaces []string, filter *types.RepoFilter, per int, page int, isAdmin bool)) *MockRepoStore_PublicToUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(types.RepositoryType), args[2].([]int64), args[3].(*types.RepoFilter), args[4].(int), args[5].(int), args[6].(bool))
+		run(args[0].(context.Context), args[1].(types.RepositoryType), args[2].([]string), args[3].(*types.RepoFilter), args[4].(int), args[5].(int), args[6].(bool))
 	})
 	return _c
 }
@@ -2102,7 +2102,7 @@ func (_c *MockRepoStore_PublicToUser_Call) Return(repos []*database.Repository, 
 	return _c
 }
 
-func (_c *MockRepoStore_PublicToUser_Call) RunAndReturn(run func(context.Context, types.RepositoryType, []int64, *types.RepoFilter, int, int, bool) ([]*database.Repository, int, error)) *MockRepoStore_PublicToUser_Call {
+func (_c *MockRepoStore_PublicToUser_Call) RunAndReturn(run func(context.Context, types.RepositoryType, []string, *types.RepoFilter, int, int, bool) ([]*database.Repository, int, error)) *MockRepoStore_PublicToUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2594,7 +2594,6 @@ func (_c *MockRepoStore_UpdateRepo_Call) RunAndReturn(run func(context.Context, 
 	_c.Call.Return(run)
 	return _c
 }
-
 
 // UpdateRepoCloneDownloads provides a mock function with given fields: ctx, repo, date, cloneCount
 func (_m *MockRepoStore) UpdateRepoCloneDownloads(ctx context.Context, repo *database.Repository, date time.Time, cloneCount int64) error {

--- a/builder/store/database/mcp_server.go
+++ b/builder/store/database/mcp_server.go
@@ -167,8 +167,16 @@ func (m *mcpServerStoreImpl) ListProperties(ctx context.Context, req *types.MCPP
 	q := m.db.Operator.Core.NewSelect().Model(&mcpProps).Relation("MCPServer").Relation("MCPServer.Repository").Where("kind = ?", req.Kind)
 
 	if !req.IsAdmin {
-		if len(req.UserIDs) > 0 {
-			q.Where("mcp_server__repository.private = ? or mcp_server__repository.user_id in (?)", false, bun.In(req.UserIDs))
+		if len(req.OwnerNamespaces) > 0 {
+			// public repos, or private repos under the user's own namespace
+			// and the namespaces of orgs the user belongs to
+			q.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
+				q = q.Where("mcp_server__repository.private = ?", false)
+				for _, namespace := range req.OwnerNamespaces {
+					q = q.WhereOr("mcp_server__repository.path LIKE ? ESCAPE '\\'", fmt.Sprintf("%s/%%", escapeLikePattern(namespace)))
+				}
+				return q
+			})
 		} else {
 			q.Where("mcp_server__repository.private = ?", false)
 		}

--- a/builder/store/database/repository.go
+++ b/builder/store/database/repository.go
@@ -77,7 +77,7 @@ type RepoStore interface {
 	// TagIDs get tag ids by repo id, if category is not empty, return only tags of the category
 	TagIDs(ctx context.Context, repoID int64, category string) (tagIDs []int64, err error)
 	SetUpdateTimeByPath(ctx context.Context, repoType types.RepositoryType, namespace, name string, update time.Time) error
-	PublicToUser(ctx context.Context, repoType types.RepositoryType, userIDs []int64, filter *types.RepoFilter, per, page int, isAdmin bool) (repos []*Repository, count int, err error)
+	PublicToUser(ctx context.Context, repoType types.RepositoryType, ownerNamespaces []string, filter *types.RepoFilter, per, page int, isAdmin bool) (repos []*Repository, count int, err error)
 	IsMirrorRepo(ctx context.Context, repoType types.RepositoryType, namespace, name string) (bool, error)
 	ListRepoByDeployType(ctx context.Context, repoType types.RepositoryType, userID int64, search, sort string, deployType, per, page int) (repos []*Repository, count int, err error)
 	WithMirror(ctx context.Context, per, page int) (repos []Repository, count int, err error)
@@ -730,9 +730,9 @@ func (s *repoStoreImpl) SetUpdateTimeByPath(ctx context.Context, repoType types.
 	return err
 }
 
-func (s *repoStoreImpl) PublicToUser(ctx context.Context, repoType types.RepositoryType, userIDs []int64, filter *types.RepoFilter, per, page int, isAdmin bool) (repos []*Repository, count int, err error) {
+func (s *repoStoreImpl) PublicToUser(ctx context.Context, repoType types.RepositoryType, ownerNamespaces []string, filter *types.RepoFilter, per, page int, isAdmin bool) (repos []*Repository, count int, err error) {
 	if filter.Sort == "trending" && strings.TrimSpace(filter.Search) == "" {
-		return s.publicToUserTrending(ctx, repoType, userIDs, filter, per, page, isAdmin)
+		return s.publicToUserTrending(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
 	}
 
 	q := s.db.Operator.Core.
@@ -764,8 +764,16 @@ func (s *repoStoreImpl) PublicToUser(ctx context.Context, repoType types.Reposit
 	}
 
 	if !isAdmin {
-		if len(userIDs) > 0 {
-			q.Where("repository.private = ? or repository.user_id in (?)", false, bun.In(userIDs))
+		if len(ownerNamespaces) > 0 {
+			// public repos, or private repos under the user's own namespace
+			// and the namespaces of orgs the user belongs to
+			q.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
+				q = q.Where("repository.private = ?", false)
+				for _, namespace := range ownerNamespaces {
+					q = q.WhereOr("repository.path LIKE ? ESCAPE '\\'", fmt.Sprintf("%s/%%", escapeLikePattern(namespace)))
+				}
+				return q
+			})
 		} else {
 			q.Where("repository.private = ?", false)
 		}
@@ -888,7 +896,7 @@ func (s *repoStoreImpl) PublicToUser(ctx context.Context, repoType types.Reposit
 	return
 }
 
-func (s *repoStoreImpl) publicToUserTrending(ctx context.Context, repoType types.RepositoryType, userIDs []int64, filter *types.RepoFilter, per, page int, isAdmin bool) (repos []*Repository, count int, err error) {
+func (s *repoStoreImpl) publicToUserTrending(ctx context.Context, repoType types.RepositoryType, ownerNamespaces []string, filter *types.RepoFilter, per, page int, isAdmin bool) (repos []*Repository, count int, err error) {
 	repoTypeTable := map[types.RepositoryType]string{
 		types.ModelRepo:     "models",
 		types.DatasetRepo:   "datasets",
@@ -953,8 +961,16 @@ func (s *repoStoreImpl) publicToUserTrending(ctx context.Context, repoType types
 		Where(fmt.Sprintf("EXISTS (SELECT 1 FROM %s m WHERE m.repository_id = r.id)", bizTable))
 
 	if !isAdmin {
-		if len(userIDs) > 0 {
-			q.Where("r.private = ? OR r.user_id IN (?)", false, bun.In(userIDs))
+		if len(ownerNamespaces) > 0 {
+			// public repos, or private repos under the user's own namespace
+			// and the namespaces of orgs the user belongs to
+			q.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
+				q = q.Where("r.private = ?", false)
+				for _, namespace := range ownerNamespaces {
+					q = q.WhereOr("r.path LIKE ? ESCAPE '\\'", fmt.Sprintf("%s/%%", escapeLikePattern(namespace)))
+				}
+				return q
+			})
 		} else {
 			q.Where("r.private = ?", false)
 		}

--- a/builder/store/database/repository_test.go
+++ b/builder/store/database/repository_test.go
@@ -347,7 +347,7 @@ func TestRepoStore_PublicToUserSimple(t *testing.T) {
 		Sort: "recently_update",
 	}
 	// case 1: one tag
-	repos, _, err := rs.PublicToUser(ctx, repo.RepositoryType, []int64{1}, filter, 20, 1, true)
+	repos, _, err := rs.PublicToUser(ctx, repo.RepositoryType, []string{"user1"}, filter, 20, 1, true)
 	require.Nil(t, err)
 	require.NotNil(t, repos)
 
@@ -360,7 +360,7 @@ func TestRepoStore_PublicToUserSimple(t *testing.T) {
 		Sort: "recently_update",
 	}
 	// case 2: two tag
-	repos, _, err = rs.PublicToUser(ctx, repo.RepositoryType, []int64{1}, filter, 20, 1, true)
+	repos, _, err = rs.PublicToUser(ctx, repo.RepositoryType, []string{"user1"}, filter, 20, 1, true)
 	require.Nil(t, err)
 	require.NotNil(t, repos)
 }
@@ -587,7 +587,7 @@ func TestRepoStore_PublicToUserSearch_Sqlite(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%+v", c), func(t *testing.T) {
-			rs, count, err := store.PublicToUser(ctx, c.repoType, []int64{123}, &types.RepoFilter{
+			rs, count, err := store.PublicToUser(ctx, c.repoType, []string{"user123"}, &types.RepoFilter{
 				Tags:   c.tags,
 				Sort:   c.sort,
 				Search: c.search,
@@ -627,7 +627,7 @@ func TestRepoStore_PublicToUserSearch(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%+v", c), func(t *testing.T) {
-			rs, count, err := store.PublicToUser(ctx, c.repoType, []int64{123}, &types.RepoFilter{
+			rs, count, err := store.PublicToUser(ctx, c.repoType, []string{"user123"}, &types.RepoFilter{
 				Tags:   c.tags,
 				Sort:   c.sort,
 				Search: c.search,
@@ -706,31 +706,31 @@ func TestRepoStore_PublicToUser(t *testing.T) {
 
 			repos := []*database.Repository{
 				{
-					Name: "rp1", Path: "rp1", UserID: 123, RepositoryType: types.CodeRepo,
+					Name: "rp1", Path: "user123/rp1", UserID: 123, RepositoryType: types.CodeRepo,
 					DownloadCount: 11,
 				},
 				{
-					Name: "rp2", Path: "rp2", UserID: 123, RepositoryType: types.CodeRepo,
+					Name: "rp2", Path: "user123/rp2", UserID: 123, RepositoryType: types.CodeRepo,
 					Private: true, Source: types.HuggingfaceSource,
 					DownloadCount: 12,
 				},
 				{
-					Name: "rp3", Path: "rp3", UserID: 456, RepositoryType: types.CodeRepo,
+					Name: "rp3", Path: "user456/rp3", UserID: 456, RepositoryType: types.CodeRepo,
 					Private:       true,
 					DownloadCount: 15,
 				},
 				{
-					Name: "rp4", Path: "rp4", UserID: 456, RepositoryType: types.CodeRepo,
+					Name: "rp4", Path: "user456/rp4", UserID: 456, RepositoryType: types.CodeRepo,
 					Private: false, Tags: []database.Tag{{Name: "foo"}},
 					DownloadCount: 13,
 				},
 				{
-					Name: "rp5", Path: "rp5", UserID: 789, RepositoryType: types.CodeRepo,
+					Name: "rp5", Path: "user789/rp5", UserID: 789, RepositoryType: types.CodeRepo,
 					Private: false, Tags: []database.Tag{{Name: "bar"}},
 					DownloadCount: 14,
 				},
 				{
-					Name: "rp6", Path: "rp6", UserID: 789, RepositoryType: types.CodeRepo,
+					Name: "rp6", Path: "user789/rp6", UserID: 789, RepositoryType: types.CodeRepo,
 					Private: false, Description: "rp4desc",
 					DownloadCount: 16,
 				},
@@ -763,8 +763,8 @@ func TestRepoStore_PublicToUser(t *testing.T) {
 				}
 
 				// Extract number from repo name (e.g., "rp4" -> 4) and multiply by 100
-				if strings.HasPrefix(repo.Path, "rp") {
-					if numStr := strings.TrimPrefix(repo.Path, "rp"); numStr != "" {
+				if strings.HasPrefix(repo.Name, "rp") {
+					if numStr := strings.TrimPrefix(repo.Name, "rp"); numStr != "" {
 						if num, err := strconv.Atoi(numStr); err == nil {
 							// insert recom repo score
 							err := recomStore.UpsertScore(ctx, []*database.RecomRepoScore{
@@ -780,7 +780,7 @@ func TestRepoStore_PublicToUser(t *testing.T) {
 				}
 			}
 
-			rs, count, err := store.PublicToUser(ctx, c.repoType, []int64{123}, &types.RepoFilter{
+			rs, count, err := store.PublicToUser(ctx, c.repoType, []string{"user123"}, &types.RepoFilter{
 				Tags:   c.tags,
 				Sort:   c.sort,
 				Search: c.search,
@@ -817,7 +817,7 @@ func TestRepoStore_PublicToUserOwnerFilter(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	rs, count, err := store.PublicToUser(ctx, types.CodeRepo, []int64{123}, &types.RepoFilter{
+	rs, count, err := store.PublicToUser(ctx, types.CodeRepo, []string{"user123"}, &types.RepoFilter{
 		Owner: "owner",
 		Sort:  "recently_update",
 	}, 10, 1, false)
@@ -826,7 +826,7 @@ func TestRepoStore_PublicToUserOwnerFilter(t *testing.T) {
 	require.Len(t, rs, 1)
 	require.Equal(t, "owner/match", rs[0].Path)
 
-	rs, count, err = store.PublicToUser(ctx, types.CodeRepo, []int64{123}, &types.RepoFilter{
+	rs, count, err = store.PublicToUser(ctx, types.CodeRepo, []string{"user123"}, &types.RepoFilter{
 		Owner: "own_er",
 		Sort:  "recently_update",
 	}, 10, 1, false)
@@ -879,7 +879,7 @@ func TestRepoStore_PublicToUserRangeFilters(t *testing.T) {
 
 	modelParamsMin := 2.0
 	modelParamsMax := 8.0
-	repos, count, err := store.PublicToUser(ctx, types.ModelRepo, []int64{123}, &types.RepoFilter{
+	repos, count, err := store.PublicToUser(ctx, types.ModelRepo, []string{"user123"}, &types.RepoFilter{
 		Sort:           "recently_update",
 		ModelParamsMin: &modelParamsMin,
 		ModelParamsMax: &modelParamsMax,
@@ -944,7 +944,7 @@ func TestRepoStore_PublicToUserRangeFilters(t *testing.T) {
 
 	repoSizeMin := int64(1000)
 	repoSizeMax := int64(20000)
-	repos, count, err = store.PublicToUser(ctx, types.DatasetRepo, []int64{123}, &types.RepoFilter{
+	repos, count, err = store.PublicToUser(ctx, types.DatasetRepo, []string{"user123"}, &types.RepoFilter{
 		Sort:        "recently_update",
 		RepoSizeMin: &repoSizeMin,
 		RepoSizeMax: &repoSizeMax,
@@ -1899,7 +1899,7 @@ func TestRepoStore_PublicToUserMirror(t *testing.T) {
 		Source: "local",
 	}
 	// case 1: one tag
-	repos, _, err := rs.PublicToUser(ctx, repo.RepositoryType, []int64{1}, filter, 20, 1, true)
+	repos, _, err := rs.PublicToUser(ctx, repo.RepositoryType, []string{"user1"}, filter, 20, 1, true)
 	require.Nil(t, err)
 	require.NotNil(t, repos)
 	require.Equal(t, 2, len(repos))
@@ -1981,7 +1981,7 @@ func TestRepoStore_PublicToUserWithCacheFailed(t *testing.T) {
 		search:   "billionaire",
 		expected: []string{"ChineseBlue", "ChineseMedicalBooksCollection"},
 	}
-	rs, count, err := store.PublicToUser(ctx, c.repoType, []int64{123}, &types.RepoFilter{
+	rs, count, err := store.PublicToUser(ctx, c.repoType, []string{"user123"}, &types.RepoFilter{
 		Tags:   c.tags,
 		Sort:   c.sort,
 		Search: c.search,

--- a/common/types/mcp.go
+++ b/common/types/mcp.go
@@ -77,13 +77,13 @@ type MCPServer struct {
 }
 
 type MCPPropertyFilter struct {
-	CurrentUser string          `json:"-"`
-	Kind        MCPPropertyKind `json:"kind"`
-	Search      string          `json:"search"`
-	Per         int             `json:"per"`
-	Page        int             `json:"page"`
-	IsAdmin     bool            `json:"-"`
-	UserIDs     []int64         `json:"-"`
+	CurrentUser      string          `json:"-"`
+	Kind             MCPPropertyKind `json:"kind"`
+	Search           string          `json:"search"`
+	Per              int             `json:"per"`
+	Page             int             `json:"page"`
+	IsAdmin          bool            `json:"-"`
+	OwnerNamespaces  []string        `json:"-"`
 }
 
 type MCPServerProperties struct {

--- a/component/mcp_server.go
+++ b/component/mcp_server.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"opencsg.com/csghub-server/builder/git"
@@ -482,35 +481,21 @@ func (m *mcpServerComponentImpl) Index(ctx context.Context, filter *types.RepoFi
 
 func (m *mcpServerComponentImpl) Properties(ctx context.Context, req *types.MCPPropertyFilter) ([]types.MCPServerProperties, int, error) {
 	var (
-		isAdmin      bool
-		repoOwnerIDs []int64
+		isAdmin          bool
+		ownerNamespaces []string
 	)
 	if len(req.CurrentUser) > 0 {
-		// get user orgs from user service
 		user, err := m.userSvcClient.GetUserInfo(ctx, req.CurrentUser, req.CurrentUser)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to get user info for list mcp tools, error: %w", err)
 		}
-
-		dbUser := &database.User{
-			RoleMask: strings.Join(user.Roles, ","),
-		}
-
-		isAdmin = dbUser.CanAdmin()
-
-		if !isAdmin {
-			repoOwnerIDs = append(repoOwnerIDs, user.ID)
-			//get user's orgs
-			for _, org := range user.Orgs {
-				repoOwnerIDs = append(repoOwnerIDs, org.UserID)
-			}
-		}
+		ownerNamespaces, isAdmin = buildAccessibleNamespaces(user)
 	}
 
 	req.IsAdmin = isAdmin
-	req.UserIDs = repoOwnerIDs
+	req.OwnerNamespaces = ownerNamespaces
 
-	slog.Debug("get user info to list tools", slog.Any("req", req), slog.Any("isadmin", req.IsAdmin), slog.Any("userids", req.UserIDs))
+	slog.Debug("get user info to list tools", slog.Any("req", req), slog.Any("isadmin", req.IsAdmin), slog.Any("ownerNamespaces", req.OwnerNamespaces))
 	res, total, err := m.mcpServerStore.ListProperties(ctx, req)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to list mcp tools, error: %w", err)

--- a/component/repo.go
+++ b/component/repo.go
@@ -666,33 +666,35 @@ func (c *repoComponentImpl) copyLfsObjects(ctx context.Context, sourceRepoID, ta
 	return nil
 }
 
+// buildAccessibleNamespaces returns the namespace paths a user can read
+// private repos from, and whether the user is an admin (who can read all repos).
+func buildAccessibleNamespaces(u *rpc.User) (namespaces []string, isAdmin bool) {
+	dbUser := &database.User{RoleMask: strings.Join(u.Roles, ",")}
+	if dbUser.CanAdmin() {
+		return nil, true
+	}
+	// private repos under the user's own namespace and the namespaces
+	// of orgs the user belongs to are visible
+	namespaces = append(namespaces, u.Username)
+	for _, org := range u.Orgs {
+		namespaces = append(namespaces, org.Name)
+	}
+	return namespaces, false
+}
+
 // PublicToUser gets visible repos of the given user and user's orgs
 func (c *repoComponentImpl) PublicToUser(ctx context.Context, repoType types.RepositoryType, userName string, filter *types.RepoFilter, per, page int) (repos []*database.Repository, count int, err error) {
-	var repoOwnerIDs []int64
+	var ownerNamespaces []string
 	var isAdmin bool
 
 	if len(userName) > 0 {
-		// get user orgs from user service
 		user, err := c.userSvcClient.GetUserInfo(ctx, userName, userName)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to get user info, error: %w", err)
 		}
-
-		dbUser := &database.User{
-			RoleMask: strings.Join(user.Roles, ","),
-		}
-
-		isAdmin = dbUser.CanAdmin()
-
-		if !isAdmin {
-			repoOwnerIDs = append(repoOwnerIDs, user.ID)
-			// get user's orgs
-			for _, org := range user.Orgs {
-				repoOwnerIDs = append(repoOwnerIDs, org.UserID)
-			}
-		}
+		ownerNamespaces, isAdmin = buildAccessibleNamespaces(user)
 	}
-	repos, count, err = c.repoStore.PublicToUser(ctx, repoType, repoOwnerIDs, filter, per, page, isAdmin)
+	repos, count, err = c.repoStore.PublicToUser(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get user public repos, error: %w", err)
 	}
@@ -3149,20 +3151,19 @@ func (c *repoComponentImpl) BatchGetRepoExtra(ctx context.Context, repoIDs []int
 
 	// Determine which repos the user can read — same approach as PublicToUser:
 	// fetch user info once, then check ownership + privacy in-memory.
-	isAdmin := false
-	accessibleIDs := make(map[int64]bool)
+	var isAdmin bool
+	var accessibleNamespaces map[string]bool
 	if currentUser != "" {
 		user, err := c.userSvcClient.GetUserInfo(ctx, currentUser, currentUser)
 		if err != nil {
 			return nil, errorx.BatchGetRepoExtraFailed(fmt.Errorf("failed to get user info, error: %w", err))
 		}
-		dbUser := &database.User{RoleMask: strings.Join(user.Roles, ",")}
-		if dbUser.CanAdmin() {
-			isAdmin = true
-		} else {
-			accessibleIDs[user.ID] = true
-			for _, org := range user.Orgs {
-				accessibleIDs[org.UserID] = true
+		ns, admin := buildAccessibleNamespaces(user)
+		isAdmin = admin
+		if !isAdmin {
+			accessibleNamespaces = make(map[string]bool, len(ns))
+			for _, n := range ns {
+				accessibleNamespaces[n] = true
 			}
 		}
 	}
@@ -3170,7 +3171,9 @@ func (c *repoComponentImpl) BatchGetRepoExtra(ctx context.Context, repoIDs []int
 	// Filter repos to those the user has read permission for
 	readableRepos := make([]*database.Repository, 0, len(repos))
 	for _, repo := range repos {
-		if isAdmin || !repo.Private || accessibleIDs[repo.UserID] {
+		if isAdmin || !repo.Private {
+			readableRepos = append(readableRepos, repo)
+		} else if namespace, _, ok := strings.Cut(repo.Path, "/"); ok && accessibleNamespaces[namespace] {
 			readableRepos = append(readableRepos, repo)
 		}
 	}

--- a/component/repo_test.go
+++ b/component/repo_test.go
@@ -201,11 +201,12 @@ func TestRepoComponent_PublicToUser(t *testing.T) {
 	repo := initializeTestRepoComponent(ctx, t)
 
 	repo.mocks.userSvcClient.EXPECT().GetUserInfo(ctx, "user", "user").Return(&rpc.User{
-		ID:    1,
-		Roles: []string{"a", "b"},
+		ID:       1,
+		Username: "user",
+		Roles:    []string{"a", "b"},
 		Orgs: []rpc.Organization{
-			{UserID: 2},
-			{UserID: 3},
+			{Name: "org1", UserID: 2},
+			{Name: "org2", UserID: 3},
 		},
 	}, nil)
 
@@ -213,7 +214,7 @@ func TestRepoComponent_PublicToUser(t *testing.T) {
 	mrepos := []*database.Repository{
 		{Name: "foo"},
 	}
-	repo.mocks.stores.RepoMock().EXPECT().PublicToUser(ctx, types.ModelRepo, []int64{1, 2, 3}, filter, 10, 1, false).Return(mrepos, 100, nil)
+	repo.mocks.stores.RepoMock().EXPECT().PublicToUser(ctx, types.ModelRepo, []string{"user", "org1", "org2"}, filter, 10, 1, false).Return(mrepos, 100, nil)
 
 	repos, count, err := repo.PublicToUser(ctx, types.ModelRepo, "user", &types.RepoFilter{}, 10, 1)
 	require.Equal(t, mrepos, repos)
@@ -2539,21 +2540,60 @@ func TestRepoComponent_BatchGetRepoExtra(t *testing.T) {
 		repoComp := initializeTestRepoComponent(ctx, t)
 
 		repoComp.mocks.userSvcClient.EXPECT().GetUserInfo(ctx, "user1", "user1").Return(&rpc.User{
-			ID:    1,
-			Roles: []string{},
-			Orgs:  []rpc.Organization{{UserID: 3}},
+			ID:       1,
+			Username: "user1",
+			Roles:    []string{},
+			Orgs:     []rpc.Organization{{Name: "org1", UserID: 3}},
 		}, nil)
 
-		// Own repo (UserID=1), org repo (UserID=3), public repo (UserID=99), private unrelated repo (UserID=99)
+		// Own repo, org repo, public repo, private unrelated repo
 		repos := []*database.Repository{
-			{ID: 1, UserID: 1, Private: true, DefaultBranch: "main"},
-			{ID: 2, UserID: 3, Private: true, DefaultBranch: "main"},
-			{ID: 3, UserID: 99, Private: false, DefaultBranch: "main"},
-			{ID: 4, UserID: 99, Private: true, DefaultBranch: "main"},
+			{ID: 1, UserID: 1, Path: "user1/repo1", Private: true, DefaultBranch: "main"},
+			{ID: 2, UserID: 3, Path: "org1/repo2", Private: true, DefaultBranch: "main"},
+			{ID: 3, UserID: 99, Path: "other/repo3", Private: false, DefaultBranch: "main"},
+			{ID: 4, UserID: 99, Path: "other/repo4", Private: true, DefaultBranch: "main"},
 		}
 		repoComp.mocks.stores.RepoMock().EXPECT().FindByIds(ctx, []int64{1, 2, 3, 4}).Return(repos, nil)
 
 		// Only repos 1, 2, 3 are readable
+		stats := []*database.RepositoryStatistics{
+			{RepositoryID: 1, Branch: "main", TotalSize: 100},
+			{RepositoryID: 2, Branch: "main", TotalSize: 200},
+			{RepositoryID: 3, Branch: "main", TotalSize: 300},
+		}
+		repoComp.mocks.stores.RepositoryStatisticsMock().EXPECT().FindByRepositoryIDs(ctx, []int64{1, 2, 3}).Return(stats, nil)
+
+		result, err := repoComp.BatchGetRepoExtra(ctx, []int64{1, 2, 3, 4}, "user1")
+		require.Nil(t, err)
+		require.Equal(t, []types.RepoExtraItem{{RepoID: 1, Size: 100}, {RepoID: 2, Size: 200}, {RepoID: 3, Size: 300}}, result)
+	})
+
+	t.Run("org member cannot read org creator personal private repos", func(t *testing.T) {
+		ctx := context.TODO()
+		repoComp := initializeTestRepoComponent(ctx, t)
+
+		// User "user1" belongs to org "org1" whose creator has UserID=3.
+		// A private repo under the creator's personal namespace "creator"
+		// (UserID=3, Path="creator/personal") must NOT be visible to the
+		// org member, even though its UserID matches the org's UserID.
+		repoComp.mocks.userSvcClient.EXPECT().GetUserInfo(ctx, "user1", "user1").Return(&rpc.User{
+			ID:       1,
+			Username: "user1",
+			Roles:    []string{},
+			Orgs:     []rpc.Organization{{Name: "org1", UserID: 3}},
+		}, nil)
+
+		repos := []*database.Repository{
+			{ID: 1, UserID: 1, Path: "user1/repo1", Private: true, DefaultBranch: "main"},
+			{ID: 2, UserID: 3, Path: "org1/repo2", Private: true, DefaultBranch: "main"},
+			{ID: 3, UserID: 99, Path: "other/repo3", Private: false, DefaultBranch: "main"},
+			{ID: 4, UserID: 3, Path: "creator/personal", Private: true, DefaultBranch: "main"},
+		}
+		repoComp.mocks.stores.RepoMock().EXPECT().FindByIds(ctx, []int64{1, 2, 3, 4}).Return(repos, nil)
+
+		// Only repos 1, 2, 3 are readable. Repo 4 has UserID=3 (matches
+		// org's UserID) but lives under namespace "creator", which is NOT
+		// in the user's accessible namespaces {"user1", "org1"}.
 		stats := []*database.RepositoryStatistics{
 			{RepositoryID: 1, Branch: "main", TotalSize: 100},
 			{RepositoryID: 2, Branch: "main", TotalSize: 200},
@@ -2591,13 +2631,14 @@ func TestRepoComponent_BatchGetRepoExtra(t *testing.T) {
 		repoComp := initializeTestRepoComponent(ctx, t)
 
 		repoComp.mocks.userSvcClient.EXPECT().GetUserInfo(ctx, "user1", "user1").Return(&rpc.User{
-			ID:    1,
-			Roles: []string{},
-			Orgs:  []rpc.Organization{},
+			ID:       1,
+			Username: "user1",
+			Roles:    []string{},
+			Orgs:     []rpc.Organization{},
 		}, nil)
 
 		repos := []*database.Repository{
-			{ID: 1, UserID: 1, Private: true, DefaultBranch: ""},
+			{ID: 1, UserID: 1, Path: "user1/repo1", Private: true, DefaultBranch: ""},
 		}
 		repoComp.mocks.stores.RepoMock().EXPECT().FindByIds(ctx, []int64{1}).Return(repos, nil)
 
@@ -2611,13 +2652,14 @@ func TestRepoComponent_BatchGetRepoExtra(t *testing.T) {
 		repoComp := initializeTestRepoComponent(ctx, t)
 
 		repoComp.mocks.userSvcClient.EXPECT().GetUserInfo(ctx, "user1", "user1").Return(&rpc.User{
-			ID:    1,
-			Roles: []string{},
-			Orgs:  []rpc.Organization{},
+			ID:       1,
+			Username: "user1",
+			Roles:    []string{},
+			Orgs:     []rpc.Organization{},
 		}, nil)
 
 		repos := []*database.Repository{
-			{ID: 1, UserID: 1, Private: true, DefaultBranch: "main"},
+			{ID: 1, UserID: 1, Path: "user1/repo1", Private: true, DefaultBranch: "main"},
 		}
 		repoComp.mocks.stores.RepoMock().EXPECT().FindByIds(ctx, []int64{1}).Return(repos, nil)
 
@@ -2636,13 +2678,14 @@ func TestRepoComponent_BatchGetRepoExtra(t *testing.T) {
 		repoComp := initializeTestRepoComponent(ctx, t)
 
 		repoComp.mocks.userSvcClient.EXPECT().GetUserInfo(ctx, "user1", "user1").Return(&rpc.User{
-			ID:    1,
-			Roles: []string{},
-			Orgs:  []rpc.Organization{},
+			ID:       1,
+			Username: "user1",
+			Roles:    []string{},
+			Orgs:     []rpc.Organization{},
 		}, nil)
 
 		repos := []*database.Repository{
-			{ID: 1, UserID: 99, Private: true, DefaultBranch: "main"},
+			{ID: 1, UserID: 99, Path: "other/repo1", Private: true, DefaultBranch: "main"},
 		}
 		repoComp.mocks.stores.RepoMock().EXPECT().FindByIds(ctx, []int64{1}).Return(repos, nil)
 
@@ -2681,13 +2724,14 @@ func TestRepoComponent_BatchGetRepoExtra(t *testing.T) {
 		repoComp := initializeTestRepoComponent(ctx, t)
 
 		repoComp.mocks.userSvcClient.EXPECT().GetUserInfo(ctx, "user1", "user1").Return(&rpc.User{
-			ID:    1,
-			Roles: []string{},
-			Orgs:  []rpc.Organization{},
+			ID:       1,
+			Username: "user1",
+			Roles:    []string{},
+			Orgs:     []rpc.Organization{},
 		}, nil)
 
 		repos := []*database.Repository{
-			{ID: 1, UserID: 1, Private: true, DefaultBranch: "main"},
+			{ID: 1, UserID: 1, Path: "user1/repo1", Private: true, DefaultBranch: "main"},
 		}
 		repoComp.mocks.stores.RepoMock().EXPECT().FindByIds(ctx, []int64{1}).Return(repos, nil)
 		repoComp.mocks.stores.RepositoryStatisticsMock().EXPECT().FindByRepositoryIDs(ctx, []int64{1}).Return(nil, errors.New("db error"))


### PR DESCRIPTION
Summary:
- Fixed a `PublicToUser` bug where users in the same organization could incorrectly view each other's private projects in model and dataset lists.
- Resolved issue #2393 by ensuring proper access control enforcement for private resources within shared organizations.