### PR TITLE
Add dataflow trigger to LLM log sync

### DIFF
--- a/builder/store/database/space_resource_test.go
+++ b/builder/store/database/space_resource_test.go
@@ -244,6 +244,14 @@ func TestSpaceResourceStore_Filter(t *testing.T) {
 		Name:      "r1",
 		ClusterID: "c1",
 		Resources: `{"cpu": { "type": "Intel","num": "200m"}}`,
+		Scenarios: int64(types.ScenarioWfDataflow),
+	})
+	require.Nil(t, err)
+	_, err = store.Create(ctx, database.SpaceResource{
+		Name:      "r2",
+		ClusterID: "c1",
+		Resources: `{"cpu": { "type": "Intel","num": "200m"}}`,
+		Scenarios: int64(types.ScenarioFinetune),
 	})
 	require.Nil(t, err)
 	sr := &database.SpaceResource{}
@@ -255,7 +263,12 @@ func TestSpaceResourceStore_Filter(t *testing.T) {
 		ResourceType: types.ResourceTypeCPU,
 	}, 50, 1)
 	require.Nil(t, err)
-	require.Equal(t, 1, len(srs))
-	require.Equal(t, 1, total)
+	require.Equal(t, 2, len(srs))
+	require.Equal(t, 2, total)
 	require.Equal(t, "c1", srs[0].ClusterID)
+
+	srs, err = store.FindByScenarios(ctx, int64(types.ScenarioWfDataflow))
+	require.Nil(t, err)
+	require.Equal(t, 1, len(srs))
+	require.Equal(t, "r1", srs[0].Name)
 }

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -537,6 +537,18 @@ type Config struct {
 			DatasetNamespace  string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATASET_NAMESPACE" default:""`
 			DatasetName       string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATASET_NAME" default:""`
 			MaxShardSizeBytes int64  `env:"STARHUB_SERVER_LLMLOG_SYNC_MAX_SHARD_SIZE_BYTES" default:"67108864"` // 64 MiB
+			Dataflow          struct {
+				Enable           bool   `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_ENABLE" default:"false"`
+				ResourceScenario string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_RESOURCE_SCENARIO" default:"wf_dataflow"`
+				DatasetNamespace string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_DATASET_NAMESPACE" default:""`
+				DatasetName      string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_DATASET_NAME" default:"Runtime_data_curated"`
+				StorageSize      string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_STORAGE_SIZE" default:"1Gi"`
+				Image            string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_IMAGE" default:"opencsghq/runtime-data-curated:latest"`
+				OpenAIAPIKey     string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_OPENAI_API_KEY" default:""`
+				OpenAIBaseURL    string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_OPENAI_BASE_URL" default:""`
+				OpenAIModel      string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_OPENAI_MODEL" default:""`
+				LLMConcurrency   int    `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_LLM_CONCURRENCY" default:"5"`
+			}
 		}
 	}
 


### PR DESCRIPTION
Summary:
- Adds an optional final step to the LLM log sync workflow to trigger a platform dataflow Argo workflow after logs are synced, preventing execution when no files are generated.
- Encapsulates dataflow creation logic within `LLMLogSyncComponent` and introduces a `--dataflow` flag to override configuration, allowing dynamic control over resource selection and payload generation.
- Introduces new configuration flags (`llm_log.sync.dataflow.enable` and `encoded_request`) to manage dataflow activation and payload encoding, defaulting to disabled to ensure backward compatibility.