### PR TITLE
feat(space-resource): /space_resources/scenarios Return scenario constraint fields

### DIFF
--- a/common/types/space_resource.go
+++ b/common/types/space_resource.go
@@ -233,11 +233,19 @@ const (
 //   - I18nKey: i18n key (e.g. "scenario.finetune") resolved by the frontend
 //     via $t; the localized text lives in the frontend locale files.
 //   - Category: "deploy" or "workflow".
+//   - RequiredHardware/ExcludeHardware/MaxReplica: the scenario's hardware
+//     constraints, exposed so the frontend can pre-validate a resource's
+//     hardware against the scenario (e.g. grey out sandbox for a CPU+GPU
+//     resource) before submitting. Semantics match HardwareSatisfiesConstraint
+//     and ReplicaSatisfiesConstraint.
 type ScenarioInfo struct {
-	Code     int             `json:"code"`
-	Name     string          `json:"name"`
-	I18nKey  string          `json:"i18n_key"`
-	Category ScenarioCategory `json:"category"`
+	Code             int              `json:"code"`
+	Name             string           `json:"name"`
+	I18nKey          string           `json:"i18n_key"`
+	Category         ScenarioCategory `json:"category"`
+	RequiredHardware int64            `json:"required_hardware"`
+	ExcludeHardware  int64            `json:"exclude_hardware"`
+	MaxReplica       int              `json:"max_replica"`
 }
 
 func ResourceTypeValid(resourceType ResourceType) bool {

--- a/component/space_resource.go
+++ b/component/space_resource.go
@@ -230,13 +230,38 @@ func (c *spaceResourceComponentImpl) Update(ctx context.Context, req *types.Upda
 	sr.Name = req.Name
 	sr.Resources = req.Resources
 
+	// Determine the scenarios that will be in effect after this update:
+	//   - req.Scenarios != nil: the caller is setting a new scenario list.
+	//   - req.Scenarios == nil: keep the existing DB scenarios (but the hardware
+	//     may have changed via req.Resources, so we still must validate the
+	//     existing scenarios against the new hardware — otherwise a resource
+	//     tagged "sandbox" (excludes accelerators) could be silently turned
+	//     into an inconsistent GPU+sandbox state by a Resources-only update).
+	catalog, err := c.scenarioConstraintStore.FindAllOrdered(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to load scenario catalog", slog.Any("error", err))
+		return nil, fmt.Errorf("load scenario catalog failed: %w", err)
+	}
+	var effectiveScenarios []string
 	if req.Scenarios != nil {
-		catalog, err := c.scenarioConstraintStore.FindAllOrdered(ctx)
-		if err != nil {
-			slog.ErrorContext(ctx, "failed to load scenario catalog", slog.Any("error", err))
-			return nil, fmt.Errorf("load scenario catalog failed: %w", err)
-		}
-		mask, err := scenarioNamesToMask(catalog, sanitizeScenarios(req.Scenarios))
+		effectiveScenarios = sanitizeScenarios(req.Scenarios)
+	} else {
+		effectiveScenarios = maskToScenarioNames(catalog, sr.Scenarios)
+	}
+	// Parse the (possibly updated) Resources so the check reflects the hardware
+	// being saved, not the old one.
+	var hardware types.HardWare
+	if err := json.Unmarshal([]byte(req.Resources), &hardware); err != nil {
+		return nil, errorx.BadRequest(err, errorx.Ctx().Set("field", "resources"))
+	}
+	// Reject if any in-effect scenario's hardware/replica constraints are not
+	// satisfied by the new hardware (server-side enforcement of the frontend
+	// grey-out rule, covering both "new scenarios" and "kept scenarios" cases).
+	if err := validateScenariosAgainstHardware(catalog, effectiveScenarios, hardware); err != nil {
+		return nil, err
+	}
+	if req.Scenarios != nil {
+		mask, err := scenarioNamesToMask(catalog, effectiveScenarios)
 		if err != nil {
 			return nil, err
 		}
@@ -249,11 +274,6 @@ func (c *spaceResourceComponentImpl) Update(ctx context.Context, req *types.Upda
 		return nil, err
 	}
 
-	catalog, err := c.scenarioConstraintStore.FindAllOrdered(ctx)
-	if err != nil {
-		slog.ErrorContext(ctx, "failed to load scenario catalog", slog.Any("error", err))
-		return nil, fmt.Errorf("load scenario catalog failed: %w", err)
-	}
 	scenarios := maskToScenarioNames(catalog, sr.Scenarios)
 	result := &types.SpaceResource{
 		ID:        sr.ID,
@@ -269,17 +289,27 @@ func (c *spaceResourceComponentImpl) Create(ctx context.Context, req *types.Crea
 	if err := validateResources(req.Resources); err != nil {
 		return nil, err
 	}
+	var hardware types.HardWare
+	if err := json.Unmarshal([]byte(req.Resources), &hardware); err != nil {
+		return nil, errorx.BadRequest(err, errorx.Ctx().Set("field", "resources"))
+	}
 	catalog, err := c.scenarioConstraintStore.FindAllOrdered(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to load scenario catalog", slog.Any("error", err))
 		return nil, fmt.Errorf("load scenario catalog failed: %w", err)
+	}
+	scenarios := sanitizeScenarios(req.Scenarios)
+	// Reject scenarios whose hardware/replica constraints the resource does not
+	// satisfy (server-side enforcement of the frontend grey-out rule).
+	if err := validateScenariosAgainstHardware(catalog, scenarios, hardware); err != nil {
+		return nil, err
 	}
 	sr := database.SpaceResource{
 		Name:      req.Name,
 		Resources: req.Resources,
 		ClusterID: req.ClusterID,
 	}
-	mask, err := scenarioNamesToMask(catalog, sanitizeScenarios(req.Scenarios))
+	mask, err := scenarioNamesToMask(catalog, scenarios)
 	if err != nil {
 		return nil, err
 	}
@@ -375,10 +405,13 @@ func (c *spaceResourceComponentImpl) ListScenarios(ctx context.Context) ([]types
 	result := make([]types.ScenarioInfo, 0, len(rows))
 	for _, r := range rows {
 		result = append(result, types.ScenarioInfo{
-			Code:     r.Code,
-			Name:     r.Scenario,
-			I18nKey:  r.I18nKey,
-			Category: types.ScenarioCategory(r.Category),
+			Code:             r.Code,
+			Name:             r.Scenario,
+			I18nKey:          r.I18nKey,
+			Category:         types.ScenarioCategory(r.Category),
+			RequiredHardware: r.RequiredHardware,
+			ExcludeHardware:  r.ExcludeHardware,
+			MaxReplica:       r.MaxReplica,
 		})
 	}
 	return result, nil
@@ -426,4 +459,36 @@ func scenarioNamesToMask(catalog []database.ScenarioConstraint, scenarios []stri
 		mask |= int64(1) << uint(code)
 	}
 	return mask, nil
+}
+
+// validateScenariosAgainstHardware checks that every selected scenario's
+// hardware/replica constraints are satisfied by the resource's hardware spec.
+// This is the server-side enforcement of the same rule the frontend greys out
+// (so a caller that bypasses the UI is still rejected). A scenario failing its
+// required_hardware / exclude_hardware / max_replica returns a BadRequest naming
+// the offending scenario. Uses the shared HardwareSatisfiesConstraint /
+// ReplicaSatisfiesConstraint so the rule stays identical to the Index query.
+//
+// `scenarios` is the list of scenario machine names the caller wants to bind;
+// `catalog` is the full scenario catalog (loaded once via FindAllOrdered).
+func validateScenariosAgainstHardware(catalog []database.ScenarioConstraint, scenarios []string, hardware types.HardWare) error {
+	byName := make(map[string]*database.ScenarioConstraint, len(catalog))
+	for i := range catalog {
+		byName[catalog[i].Scenario] = &catalog[i]
+	}
+	for _, name := range scenarios {
+		c, ok := byName[name]
+		if !ok {
+			// unknown names are reported by scenarioNamesToMask; skip here to
+			// avoid a duplicate, less-specific error.
+			continue
+		}
+		if !types.HardwareSatisfiesConstraint(c.RequiredHardware, c.ExcludeHardware, hardware) {
+			return errorx.BadRequest(fmt.Errorf("scenario %q is not compatible with the resource hardware", name), errorx.Ctx().Set("field", "scenarios").Set("scenario", name))
+		}
+		if !types.ReplicaSatisfiesConstraint(c.MaxReplica, hardware.Replicas) {
+			return errorx.BadRequest(fmt.Errorf("scenario %q exceeds max_replica (%d) with replicas %d", name, c.MaxReplica, hardware.Replicas), errorx.Ctx().Set("field", "scenarios").Set("scenario", name))
+		}
+	}
+	return nil
 }

--- a/component/space_resource_test.go
+++ b/component/space_resource_test.go
@@ -90,6 +90,33 @@ func TestSpaceResourceComponent_Update_InvalidResources(t *testing.T) {
 	require.True(t, errors.Is(err, errorx.ErrBadRequest))
 }
 
+// TestSpaceResourceComponent_Update_ResourcesOnly_HardwareConflict verifies that
+// a Resources-only update (req.Scenarios == nil) still validates the EXISTING
+// scenarios against the new hardware. A resource tagged "sandbox" (excludes
+// accelerators) must be rejected when the update adds a GPU — otherwise the
+// resource ends up in an inconsistent GPU+sandbox state.
+func TestSpaceResourceComponent_Update_ResourcesOnly_HardwareConflict(t *testing.T) {
+	ctx := context.TODO()
+	sc := initializeTestSpaceResourceComponent(ctx, t)
+
+	// existing resource is sandbox-tagged (bit7 = 128)
+	sc.mocks.stores.SpaceResourceMock().EXPECT().FindByID(ctx, int64(1)).Return(
+		&database.SpaceResource{ID: 1, Scenarios: int64(types.ScenarioSandbox)}, nil)
+	// catalog knows sandbox with exclude = HardwareMaskGraphic (no accelerator)
+	sc.mocks.stores.ScenarioConstraintMock().EXPECT().FindAllOrdered(ctx).Return(
+		[]database.ScenarioConstraint{{Scenario: "sandbox", Code: types.SandboxType, ExcludeHardware: int64(types.HardwareMaskGraphic)}}, nil)
+
+	// update adds a GPU but does NOT pass Scenarios — existing sandbox must be
+	// validated against the new hardware and rejected.
+	_, err := sc.Update(ctx, &types.UpdateSpaceResourceReq{
+		ID:        1,
+		Name:      "n",
+		Resources: `{"cpu":{"num":"2","type":"intel"},"memory":"8G","gpu":{"num":"1","type":"nvidia"}}`,
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errorx.ErrBadRequest))
+}
+
 func TestSpaceResourceComponent_Create(t *testing.T) {
 	ctx := context.TODO()
 	sc := initializeTestSpaceResourceComponent(ctx, t)
@@ -160,6 +187,49 @@ func TestSpaceResourceComponent_Create_UnknownScenario(t *testing.T) {
 		Resources: validResourcesJSON,
 		ClusterID: "c",
 		Scenarios: []string{"finetune", "bogus"},
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errorx.ErrBadRequest))
+}
+
+// TestSpaceResourceComponent_Create_ScenarioHardwareMismatch verifies that a
+// scenario whose required_hardware is not satisfied by the resource hardware
+// is rejected with BadRequest (server-side enforcement of the frontend grey-out).
+// A pure-CPU resource selecting finetune (requires a graphic accelerator) fails.
+func TestSpaceResourceComponent_Create_ScenarioHardwareMismatch(t *testing.T) {
+	ctx := context.TODO()
+	sc := initializeTestSpaceResourceComponent(ctx, t)
+
+	sc.mocks.stores.ScenarioConstraintMock().EXPECT().FindAllOrdered(ctx).Return(
+		[]database.ScenarioConstraint{{Scenario: "finetune", Code: types.FinetuneType, RequiredHardware: int64(types.HardwareMaskGraphic)}}, nil)
+
+	// validResourcesJSON is pure CPU (no accelerator) — finetune requires one.
+	_, err := sc.Create(ctx, &types.CreateSpaceResourceReq{
+		Name:      "n",
+		Resources: validResourcesJSON,
+		ClusterID: "c",
+		Scenarios: []string{"finetune"},
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errorx.ErrBadRequest))
+}
+
+// TestSpaceResourceComponent_Create_ScenarioExcludeHardware verifies that a
+// scenario whose exclude_hardware is hit by the resource hardware is rejected.
+// A CPU+GPU resource selecting sandbox (excludes graphic accelerators) fails.
+func TestSpaceResourceComponent_Create_ScenarioExcludeHardware(t *testing.T) {
+	ctx := context.TODO()
+	sc := initializeTestSpaceResourceComponent(ctx, t)
+
+	sc.mocks.stores.ScenarioConstraintMock().EXPECT().FindAllOrdered(ctx).Return(
+		[]database.ScenarioConstraint{{Scenario: "sandbox", Code: types.SandboxType, ExcludeHardware: int64(types.HardwareMaskGraphic)}}, nil)
+
+	// CPU+GPU resource — sandbox excludes accelerators.
+	_, err := sc.Create(ctx, &types.CreateSpaceResourceReq{
+		Name:      "n",
+		Resources: `{"cpu":{"num":"2","type":"intel"},"memory":"8G","gpu":{"num":"1","type":"nvidia"}}`,
+		ClusterID: "c",
+		Scenarios: []string{"sandbox"},
 	})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errorx.ErrBadRequest))


### PR DESCRIPTION
Summary:
- Added `required_hardware`, `exclude_hardware`, and `max_replica` fields to the `ScenarioInfo` struct and the `/space_resources/scenarios` response to support frontend hardware constraint validation.
- Enables the space creation form to pre-validate and disable scenarios that do not meet specific hardware requirements.