### PR TITLE
feat(moderation): add pagination to admin/wordsets list endpoint

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_SensitiveWordSetStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_SensitiveWordSetStore.go
@@ -175,34 +175,100 @@ func (_c *MockSensitiveWordSetStore_Get_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
-// List provides a mock function with given fields: ctx, filter
-func (_m *MockSensitiveWordSetStore) List(ctx context.Context, filter *database.SensitiveWordSetFilter) ([]database.SensitiveWordSet, error) {
-	ret := _m.Called(ctx, filter)
+// GetByName provides a mock function with given fields: ctx, name
+func (_m *MockSensitiveWordSetStore) GetByName(ctx context.Context, name string) (*database.SensitiveWordSet, error) {
+	ret := _m.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetByName")
+	}
+
+	var r0 *database.SensitiveWordSet
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*database.SensitiveWordSet, error)); ok {
+		return rf(ctx, name)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *database.SensitiveWordSet); ok {
+		r0 = rf(ctx, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.SensitiveWordSet)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockSensitiveWordSetStore_GetByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetByName'
+type MockSensitiveWordSetStore_GetByName_Call struct {
+	*mock.Call
+}
+
+// GetByName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+func (_e *MockSensitiveWordSetStore_Expecter) GetByName(ctx interface{}, name interface{}) *MockSensitiveWordSetStore_GetByName_Call {
+	return &MockSensitiveWordSetStore_GetByName_Call{Call: _e.mock.On("GetByName", ctx, name)}
+}
+
+func (_c *MockSensitiveWordSetStore_GetByName_Call) Run(run func(ctx context.Context, name string)) *MockSensitiveWordSetStore_GetByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockSensitiveWordSetStore_GetByName_Call) Return(_a0 *database.SensitiveWordSet, _a1 error) *MockSensitiveWordSetStore_GetByName_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockSensitiveWordSetStore_GetByName_Call) RunAndReturn(run func(context.Context, string) (*database.SensitiveWordSet, error)) *MockSensitiveWordSetStore_GetByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// List provides a mock function with given fields: ctx, filter, per, page
+func (_m *MockSensitiveWordSetStore) List(ctx context.Context, filter *database.SensitiveWordSetFilter, per int, page int) ([]database.SensitiveWordSet, int, error) {
+	ret := _m.Called(ctx, filter, per, page)
 
 	if len(ret) == 0 {
 		panic("no return value specified for List")
 	}
 
 	var r0 []database.SensitiveWordSet
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *database.SensitiveWordSetFilter) ([]database.SensitiveWordSet, error)); ok {
-		return rf(ctx, filter)
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, *database.SensitiveWordSetFilter, int, int) ([]database.SensitiveWordSet, int, error)); ok {
+		return rf(ctx, filter, per, page)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *database.SensitiveWordSetFilter) []database.SensitiveWordSet); ok {
-		r0 = rf(ctx, filter)
+	if rf, ok := ret.Get(0).(func(context.Context, *database.SensitiveWordSetFilter, int, int) []database.SensitiveWordSet); ok {
+		r0 = rf(ctx, filter, per, page)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]database.SensitiveWordSet)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *database.SensitiveWordSetFilter) error); ok {
-		r1 = rf(ctx, filter)
+	if rf, ok := ret.Get(1).(func(context.Context, *database.SensitiveWordSetFilter, int, int) int); ok {
+		r1 = rf(ctx, filter, per, page)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(int)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context, *database.SensitiveWordSetFilter, int, int) error); ok {
+		r2 = rf(ctx, filter, per, page)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // MockSensitiveWordSetStore_List_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'List'
@@ -213,23 +279,25 @@ type MockSensitiveWordSetStore_List_Call struct {
 // List is a helper method to define mock.On call
 //   - ctx context.Context
 //   - filter *database.SensitiveWordSetFilter
-func (_e *MockSensitiveWordSetStore_Expecter) List(ctx interface{}, filter interface{}) *MockSensitiveWordSetStore_List_Call {
-	return &MockSensitiveWordSetStore_List_Call{Call: _e.mock.On("List", ctx, filter)}
+//   - per int
+//   - page int
+func (_e *MockSensitiveWordSetStore_Expecter) List(ctx interface{}, filter interface{}, per interface{}, page interface{}) *MockSensitiveWordSetStore_List_Call {
+	return &MockSensitiveWordSetStore_List_Call{Call: _e.mock.On("List", ctx, filter, per, page)}
 }
 
-func (_c *MockSensitiveWordSetStore_List_Call) Run(run func(ctx context.Context, filter *database.SensitiveWordSetFilter)) *MockSensitiveWordSetStore_List_Call {
+func (_c *MockSensitiveWordSetStore_List_Call) Run(run func(ctx context.Context, filter *database.SensitiveWordSetFilter, per int, page int)) *MockSensitiveWordSetStore_List_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*database.SensitiveWordSetFilter))
+		run(args[0].(context.Context), args[1].(*database.SensitiveWordSetFilter), args[2].(int), args[3].(int))
 	})
 	return _c
 }
 
-func (_c *MockSensitiveWordSetStore_List_Call) Return(_a0 []database.SensitiveWordSet, _a1 error) *MockSensitiveWordSetStore_List_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *MockSensitiveWordSetStore_List_Call) Return(_a0 []database.SensitiveWordSet, _a1 int, _a2 error) *MockSensitiveWordSetStore_List_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *MockSensitiveWordSetStore_List_Call) RunAndReturn(run func(context.Context, *database.SensitiveWordSetFilter) ([]database.SensitiveWordSet, error)) *MockSensitiveWordSetStore_List_Call {
+func (_c *MockSensitiveWordSetStore_List_Call) RunAndReturn(run func(context.Context, *database.SensitiveWordSetFilter, int, int) ([]database.SensitiveWordSet, int, error)) *MockSensitiveWordSetStore_List_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/_mocks/opencsg.com/csghub-server/moderation/component/mock_SensitiveWordSetComponent.go
+++ b/_mocks/opencsg.com/csghub-server/moderation/component/mock_SensitiveWordSetComponent.go
@@ -128,34 +128,41 @@ func (_c *MockSensitiveWordSetComponent_Get_Call) RunAndReturn(run func(context.
 	return _c
 }
 
-// Index provides a mock function with given fields: ctx, search
-func (_m *MockSensitiveWordSetComponent) Index(ctx context.Context, search string) ([]types.SensitiveWordSet, error) {
-	ret := _m.Called(ctx, search)
+// Index provides a mock function with given fields: ctx, req
+func (_m *MockSensitiveWordSetComponent) Index(ctx context.Context, req types.SensitiveWordSetListReq) ([]types.SensitiveWordSet, int, error) {
+	ret := _m.Called(ctx, req)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Index")
 	}
 
 	var r0 []types.SensitiveWordSet
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]types.SensitiveWordSet, error)); ok {
-		return rf(ctx, search)
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.SensitiveWordSetListReq) ([]types.SensitiveWordSet, int, error)); ok {
+		return rf(ctx, req)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []types.SensitiveWordSet); ok {
-		r0 = rf(ctx, search)
+	if rf, ok := ret.Get(0).(func(context.Context, types.SensitiveWordSetListReq) []types.SensitiveWordSet); ok {
+		r0 = rf(ctx, req)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]types.SensitiveWordSet)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, search)
+	if rf, ok := ret.Get(1).(func(context.Context, types.SensitiveWordSetListReq) int); ok {
+		r1 = rf(ctx, req)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(int)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context, types.SensitiveWordSetListReq) error); ok {
+		r2 = rf(ctx, req)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // MockSensitiveWordSetComponent_Index_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Index'
@@ -165,24 +172,24 @@ type MockSensitiveWordSetComponent_Index_Call struct {
 
 // Index is a helper method to define mock.On call
 //   - ctx context.Context
-//   - search string
-func (_e *MockSensitiveWordSetComponent_Expecter) Index(ctx interface{}, search interface{}) *MockSensitiveWordSetComponent_Index_Call {
-	return &MockSensitiveWordSetComponent_Index_Call{Call: _e.mock.On("Index", ctx, search)}
+//   - req types.SensitiveWordSetListReq
+func (_e *MockSensitiveWordSetComponent_Expecter) Index(ctx interface{}, req interface{}) *MockSensitiveWordSetComponent_Index_Call {
+	return &MockSensitiveWordSetComponent_Index_Call{Call: _e.mock.On("Index", ctx, req)}
 }
 
-func (_c *MockSensitiveWordSetComponent_Index_Call) Run(run func(ctx context.Context, search string)) *MockSensitiveWordSetComponent_Index_Call {
+func (_c *MockSensitiveWordSetComponent_Index_Call) Run(run func(ctx context.Context, req types.SensitiveWordSetListReq)) *MockSensitiveWordSetComponent_Index_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(context.Context), args[1].(types.SensitiveWordSetListReq))
 	})
 	return _c
 }
 
-func (_c *MockSensitiveWordSetComponent_Index_Call) Return(_a0 []types.SensitiveWordSet, _a1 error) *MockSensitiveWordSetComponent_Index_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *MockSensitiveWordSetComponent_Index_Call) Return(_a0 []types.SensitiveWordSet, _a1 int, _a2 error) *MockSensitiveWordSetComponent_Index_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *MockSensitiveWordSetComponent_Index_Call) RunAndReturn(run func(context.Context, string) ([]types.SensitiveWordSet, error)) *MockSensitiveWordSetComponent_Index_Call {
+func (_c *MockSensitiveWordSetComponent_Index_Call) RunAndReturn(run func(context.Context, types.SensitiveWordSetListReq) ([]types.SensitiveWordSet, int, error)) *MockSensitiveWordSetComponent_Index_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/builder/store/database/sensitive_word_set.go
+++ b/builder/store/database/sensitive_word_set.go
@@ -28,7 +28,14 @@ type SensitiveWordSetStore interface {
 	Get(ctx context.Context, id int64) (*SensitiveWordSet, error)
 	Update(ctx context.Context, input SensitiveWordSet) error
 	Delete(ctx context.Context, id int64) error
-	List(ctx context.Context, filter *SensitiveWordSetFilter) ([]SensitiveWordSet, error)
+	// List returns sensitive word sets matching the filter.
+	// When per > 0 and page > 0, results are paginated by limit=per and
+	// offset=(page-1)*per. total always reflects the count of all matching
+	// rows (via SELECT count(*)), regardless of whether pagination is applied.
+	// When per <= 0 or page <= 0, all matching rows are returned without
+	// pagination.
+	List(ctx context.Context, filter *SensitiveWordSetFilter, per, page int) ([]SensitiveWordSet, int, error)
+	GetByName(ctx context.Context, name string) (*SensitiveWordSet, error)
 }
 
 type SensitiveWordSetFilter struct {

--- a/builder/store/database/sensitive_word_set_impl.go
+++ b/builder/store/database/sensitive_word_set_impl.go
@@ -2,7 +2,12 @@ package database
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
 	"time"
+
+	"opencsg.com/csghub-server/common/errorx"
 )
 
 // implement SensitiveWordSetStore
@@ -28,7 +33,23 @@ func (s *sensitiveWordSetStoreImpl) Get(ctx context.Context, id int64) (*Sensiti
 	return ws, err
 }
 
-func (s *sensitiveWordSetStoreImpl) List(ctx context.Context, filter *SensitiveWordSetFilter) ([]SensitiveWordSet, error) {
+func (s *sensitiveWordSetStoreImpl) GetByName(ctx context.Context, name string) (*SensitiveWordSet, error) {
+	ws := &SensitiveWordSet{}
+	err := s.db.Core.NewSelect().Model(ws).
+		Relation("Category").
+		Where("sensitive_word_set.name = ?", name).Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+
+		slog.ErrorContext(ctx, "get sensitive word set by name failed", "error", err)
+		return nil, errorx.HandleDBError(err, nil)
+	}
+	return ws, nil
+}
+
+func (s *sensitiveWordSetStoreImpl) List(ctx context.Context, filter *SensitiveWordSetFilter, per, page int) ([]SensitiveWordSet, int, error) {
 	var res []SensitiveWordSet
 	q := s.db.Core.NewSelect().Model(&res).
 		Relation("Category")
@@ -40,8 +61,21 @@ func (s *sensitiveWordSetStoreImpl) List(ctx context.Context, filter *SensitiveW
 			q.Where("enabled = ?", enabled)
 		}
 	}
-	err := q.Scan(ctx)
-	return res, err
+
+	total, err := q.Count(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if per > 0 && page > 0 {
+		q = q.Limit(per).Offset((page - 1) * per)
+	}
+
+	err = q.Order("id DESC").Scan(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	return res, total, nil
 }
 
 func (s *sensitiveWordSetStoreImpl) Update(ctx context.Context, input SensitiveWordSet) error {

--- a/common/types/sensitive_word_set.go
+++ b/common/types/sensitive_word_set.go
@@ -35,3 +35,11 @@ type UpdateSensitiveWordSetReq struct {
 	Enabled    *bool    `json:"enabled"`
 	CategoryID *int64   `json:"category_id"`
 }
+
+// SensitiveWordSetListReq is the request payload for listing sensitive word
+// sets with pagination and an optional search keyword.
+type SensitiveWordSetListReq struct {
+	Search string `json:"search" form:"search"`
+	Per    int    `json:"per" form:"per"`
+	Page   int    `json:"page" form:"page"`
+}

--- a/moderation/component/interfaces.go
+++ b/moderation/component/interfaces.go
@@ -23,7 +23,7 @@ type RepoFileComponent interface {
 }
 
 type SensitiveWordSetComponent interface {
-	Index(ctx context.Context, search string) ([]types.SensitiveWordSet, error)
+	Index(ctx context.Context, req types.SensitiveWordSetListReq) ([]types.SensitiveWordSet, int, error)
 	Get(ctx context.Context, id int64) (*types.SensitiveWordSet, error)
 	Create(ctx context.Context, input types.CreateSensitiveWordSetReq) error
 	Update(ctx context.Context, input types.UpdateSensitiveWordSetReq) error


### PR DESCRIPTION
Summary:
- Adds standard pagination to the `GET /api/v1/admin/wordsets` endpoint to prevent high memory usage and latency when handling large datasets, aligning it with existing admin list interfaces.
- Refactors the handler, component, and store layers to support `per`/`page` parameters and returns a standard `{data, total}` response, while ensuring the runtime sensitive word loader bypasses pagination to maintain backward compatibility.