### PR TITLE
Update LLM log dataflow payload and resource scenario

### DIFF
--- a/builder/store/database/migrations/20260722052324_add_llmlog_dataflow_scenario.down.sql
+++ b/builder/store/database/migrations/20260722052324_add_llmlog_dataflow_scenario.down.sql
@@ -1,0 +1,6 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+DELETE FROM space_resource_scenario_constraints
+WHERE scenario = 'wf_dataflow_llmlog';

--- a/builder/store/database/migrations/20260722052324_add_llmlog_dataflow_scenario.up.sql
+++ b/builder/store/database/migrations/20260722052324_add_llmlog_dataflow_scenario.up.sql
@@ -1,0 +1,30 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+INSERT INTO space_resource_scenario_constraints (
+    scenario,
+    code,
+    category,
+    i18n_key,
+    required_hardware,
+    exclude_hardware,
+    max_replica
+)
+VALUES (
+    'wf_dataflow_llmlog',
+    39,
+    'workflow',
+    'scenario.wf_dataflow_llmlog',
+    0,
+    0,
+    1
+)
+ON CONFLICT (scenario) DO UPDATE SET
+    code = EXCLUDED.code,
+    category = EXCLUDED.category,
+    i18n_key = EXCLUDED.i18n_key,
+    required_hardware = EXCLUDED.required_hardware,
+    exclude_hardware = EXCLUDED.exclude_hardware,
+    max_replica = EXCLUDED.max_replica,
+    updated_at = CURRENT_TIMESTAMP;

--- a/builder/store/database/scenario_constraint.go
+++ b/builder/store/database/scenario_constraint.go
@@ -49,7 +49,7 @@ func NewScenarioConstraintStoreWithDB(db *DB) ScenarioConstraintStore {
 //   - Scenario: scenario name (e.g. "finetune", "sandbox", "wf_evaluation").
 //   - Code: bit position. Deploy scenarios use the DeployType int values 0-7 so
 //     the deploy_type passed to Index doubles as a scenario code; workflow
-//     scenarios use 32-38. The bitmask is `1 << Code`. Unique.
+//     scenarios use 32-39. The bitmask is `1 << Code`. Unique.
 //   - Category: "deploy" or "workflow".
 //   - DisplayName: i18n key (e.g. "scenario.finetune") resolved by the frontend
 //   - I18nKey: i18n key (e.g. "scenario.finetune") resolved by the frontend

--- a/builder/store/database/scenario_constraint_test.go
+++ b/builder/store/database/scenario_constraint_test.go
@@ -39,6 +39,12 @@ func TestScenarioConstraintStore_CRUD(t *testing.T) {
 	require.Equal(t, "scenario.finetune", gotByCode.I18nKey)
 	require.Equal(t, string(types.ScenarioCategoryDeploy), gotByCode.Category)
 
+	llmLogDataflow, err := store.FindByScenario(ctx, types.ScenarioNameWfDataflowLLMLog)
+	require.Nil(t, err)
+	require.Equal(t, 39, llmLogDataflow.Code)
+	require.Equal(t, "scenario.wf_dataflow_llmlog", llmLogDataflow.I18nKey)
+	require.Equal(t, string(types.ScenarioCategoryWorkflow), llmLogDataflow.Category)
+
 	// FindByCode on an unknown code returns (nil, nil) — no row, not an error.
 	unknown, err := store.FindByCode(ctx, 999)
 	require.Nil(t, err)
@@ -77,11 +83,11 @@ func TestScenarioConstraintStore_CRUD(t *testing.T) {
 	require.Equal(t, "custom_scenario", got3.Scenario)
 	require.Equal(t, 10, got3.Code)
 
-	// FindAllOrdered returns every row ordered by code; the 10 seeded rows
-	// (6 deploy + 4 workflow, finetune updated in place) plus the 1 inserted = 11.
+	// FindAllOrdered returns every row ordered by code; the 11 seeded rows
+	// (6 deploy + 5 workflow, finetune updated in place) plus the 1 inserted = 12.
 	all, err := store.FindAllOrdered(ctx)
 	require.Nil(t, err)
-	require.Equal(t, 11, len(all))
+	require.Equal(t, 12, len(all))
 	// ordered by code ascending: space(0), inference(1), finetune(2), ...
 	require.Equal(t, 0, all[0].Code)
 	require.Equal(t, 1, all[1].Code)

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -539,7 +539,7 @@ type Config struct {
 			MaxShardSizeBytes int64  `env:"STARHUB_SERVER_LLMLOG_SYNC_MAX_SHARD_SIZE_BYTES" default:"67108864"` // 64 MiB
 			Dataflow          struct {
 				Enable           bool   `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_ENABLE" default:"false"`
-				ResourceScenario string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_RESOURCE_SCENARIO" default:"wf_dataflow"`
+				ResourceScenario string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_RESOURCE_SCENARIO" default:"wf_dataflow_llmlog"`
 				DatasetNamespace string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_DATASET_NAMESPACE" default:""`
 				DatasetName      string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_DATASET_NAME" default:"Runtime_data_curated"`
 				StorageSize      string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_STORAGE_SIZE" default:"1Gi"`

--- a/common/types/space_resource.go
+++ b/common/types/space_resource.go
@@ -135,16 +135,17 @@ const ScenarioAll ScenarioType = -1
 // Defining them as constants (instead of string literals) keeps the seed, the
 // scenarioBit table, and any caller that needs a name in sync.
 const (
-	ScenarioNameSpace      = "space"
-	ScenarioNameInference  = "inference"
-	ScenarioNameFinetune   = "finetune"
-	ScenarioNameServerless = "serverless"
-	ScenarioNameNotebook   = "notebook"
-	ScenarioNameSandbox    = "sandbox"
-	ScenarioNameWfEvaluation = "wf_evaluation"
-	ScenarioNameWfClawEval  = "wf_claw_eval"
-	ScenarioNameWfFinetune  = "wf_finetune"
-	ScenarioNameWfDataflow = "wf_dataflow"
+	ScenarioNameSpace            = "space"
+	ScenarioNameInference        = "inference"
+	ScenarioNameFinetune         = "finetune"
+	ScenarioNameServerless       = "serverless"
+	ScenarioNameNotebook         = "notebook"
+	ScenarioNameSandbox          = "sandbox"
+	ScenarioNameWfEvaluation     = "wf_evaluation"
+	ScenarioNameWfClawEval       = "wf_claw_eval"
+	ScenarioNameWfFinetune       = "wf_finetune"
+	ScenarioNameWfDataflow       = "wf_dataflow"
+	ScenarioNameWfDataflowLLMLog = "wf_dataflow_llmlog"
 )
 
 // scenarioBit maps each scenario bit constant to its name. These bit numbers
@@ -173,16 +174,17 @@ var scenarioBit = []struct {
 	name string
 	bit  ScenarioType
 }{
-	{ScenarioNameSpace, 1 << 0},      // bit0  deploy Space
-	{ScenarioNameInference, 1 << 1},  // bit1  deploy Inference
-	{ScenarioNameFinetune, 1 << 2},   // bit2  deploy Finetune
-	{ScenarioNameServerless, 1 << 3}, // bit3  deploy Serverless
-	{ScenarioNameNotebook, 1 << 5},   // bit5  deploy Notebook
-	{ScenarioNameSandbox, 1 << 7},    // bit7  deploy Sandbox
-	{ScenarioNameWfEvaluation, 1 << 32}, // bit32 workflow Evaluation
-	{ScenarioNameWfClawEval, 1 << 33},    // bit33 workflow ClawEval
-	{ScenarioNameWfFinetune, 1 << 37},    // bit37 workflow Finetune
-	{ScenarioNameWfDataflow, 1 << 38},    // bit38 workflow Dataflow
+	{ScenarioNameSpace, 1 << 0},             // bit0  deploy Space
+	{ScenarioNameInference, 1 << 1},         // bit1  deploy Inference
+	{ScenarioNameFinetune, 1 << 2},          // bit2  deploy Finetune
+	{ScenarioNameServerless, 1 << 3},        // bit3  deploy Serverless
+	{ScenarioNameNotebook, 1 << 5},          // bit5  deploy Notebook
+	{ScenarioNameSandbox, 1 << 7},           // bit7  deploy Sandbox
+	{ScenarioNameWfEvaluation, 1 << 32},     // bit32 workflow Evaluation
+	{ScenarioNameWfClawEval, 1 << 33},       // bit33 workflow ClawEval
+	{ScenarioNameWfFinetune, 1 << 37},       // bit37 workflow Finetune
+	{ScenarioNameWfDataflow, 1 << 38},       // bit38 workflow Dataflow
+	{ScenarioNameWfDataflowLLMLog, 1 << 39}, // bit39 workflow LLM Log Dataflow
 }
 
 const (
@@ -194,10 +196,11 @@ const (
 	ScenarioNotebook   ScenarioType = 1 << 5
 	ScenarioSandbox    ScenarioType = 1 << 7
 	// workflow scenarios (bits 32-63)
-	ScenarioWfEvaluation ScenarioType = 1 << 32
-	ScenarioWfClawEval   ScenarioType = 1 << 33
-	ScenarioWfFinetune   ScenarioType = 1 << 37
-	ScenarioWfDataflow   ScenarioType = 1 << 38
+	ScenarioWfEvaluation     ScenarioType = 1 << 32
+	ScenarioWfClawEval       ScenarioType = 1 << 33
+	ScenarioWfFinetune       ScenarioType = 1 << 37
+	ScenarioWfDataflow       ScenarioType = 1 << 38
+	ScenarioWfDataflowLLMLog ScenarioType = 1 << 39
 )
 
 // ScenarioName returns the name of the scenario identified by the given single-bit
@@ -226,7 +229,7 @@ const (
 // (GET /space_resources/scenarios). The data is read from the
 // space_resource_scenario_constraints table at runtime.
 //
-//   - Code: bit position (0-7 for deploy, 32-38 for workflow); it doubles as the
+//   - Code: bit position (0-7 for deploy, 32-39 for workflow); it doubles as the
 //     value callers pass to the space resource Index API as deploy_type. The
 //     bitmask is `1 << Code`. Deploy codes equal the DeployType int values.
 //   - Name: scenario name (machine name, e.g. "finetune").

--- a/common/types/space_resource_test.go
+++ b/common/types/space_resource_test.go
@@ -18,6 +18,7 @@ func TestScenarioName(t *testing.T) {
 		{"deploy sandbox", ScenarioSandbox, "sandbox"},
 		{"workflow evaluation", ScenarioWfEvaluation, "wf_evaluation"},
 		{"workflow dataflow", ScenarioWfDataflow, "wf_dataflow"},
+		{"workflow llm log dataflow", ScenarioWfDataflowLLMLog, "wf_dataflow_llmlog"},
 		{"zero value", 0, ""},
 		{"all scenarios", ScenarioAll, ""},
 		{"multi-bit mask", ScenarioSpace | ScenarioInference, ""},

--- a/component/space_resource.go
+++ b/component/space_resource.go
@@ -77,7 +77,7 @@ func (c *spaceResourceComponentImpl) Index(ctx context.Context, req *types.Space
 	var result []types.SpaceResource
 	var total int
 	// req.DeployType is a scenario code (bit position): 0-7 deploy scenarios,
-	// 32-38 workflow scenarios (see space_resource_scenario_constraints table).
+	// 32-39 workflow scenarios (see space_resource_scenario_constraints table).
 	// scenarioMask is used to filter resources by their scenarios bitmask (a
 	// resource is included only if it supports the requested scenario). A zero
 	// scenarioMask means the caller did not pass a known scenario code, so no


### PR DESCRIPTION
Summary:
- Updated the LLM log sync Dataflow job payload to remove `repo_ids` and introduce `CSGHUB_ENDPOINT`, `SOURCE_DATASET`, and `TARGET_DATASET` via environment variables for runtime data cleaning.
- Introduced a dedicated `wf_dataflow_llmlog` Space resource scenario to isolate LLM log sync resources from the generic `wf_dataflow` scenario, including necessary database migrations and i18n support.