### PR TITLE
stabilize llm log ingestion and dataset sync workflow

### DIFF
--- a/builder/mq/nasts.go
+++ b/builder/mq/nasts.go
@@ -60,6 +60,7 @@ func (n *Nats) Subscribe(params SubscribeParams) error {
 			msg.Data(),
 			MessageMeta{
 				Topic: msg.Subject(),
+				Acker: msg,
 			},
 		)
 
@@ -70,7 +71,7 @@ func (n *Nats) Subscribe(params SubscribeParams) error {
 		if params.AutoACK {
 			action := ""
 			if err != nil && params.IsRedeliverForCBFailed {
-				err = msg.Ack()
+				err = msg.Nak()
 				action = "nak"
 			} else {
 				err = msg.Ack()
@@ -122,6 +123,8 @@ func (n *Nats) getOrCreateStreamConsumer(params SubscribeParams) (jetstream.Cons
 			FilterSubjects: params.Topics,
 			AckPolicy:      jetstream.AckExplicitPolicy,
 			DeliverPolicy:  jetstream.DeliverAllPolicy,
+			AckWait:        ackWaitOrDefault(params.AckWait),
+			MaxDeliver:     maxDeliverOrDefault(params.MaxDeliver),
 		})
 	if err != nil {
 		return nil, fmt.Errorf("[nats] failed to create or update consumer %s error: %w", params.Group.ConsumerName, err)
@@ -219,6 +222,20 @@ func (n *Nats) DeleteMessagesByFilter(streamName string, filter func(data []byte
 }
 
 func maxBytesOrDefault(v int64) int64 {
+	if v <= 0 {
+		return -1
+	}
+	return v
+}
+
+func ackWaitOrDefault(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 30 * time.Second
+	}
+	return d
+}
+
+func maxDeliverOrDefault(v int) int {
 	if v <= 0 {
 		return -1
 	}

--- a/builder/mq/types.go
+++ b/builder/mq/types.go
@@ -121,6 +121,13 @@ var (
 
 type MessageMeta struct {
 	Topic string
+	Acker MessageAcker
+}
+
+type MessageAcker interface {
+	Ack() error
+	Nak() error
+	InProgress() error
 }
 
 type MessageCallback func(raw []byte, meta MessageMeta) error
@@ -137,4 +144,8 @@ type SubscribeParams struct {
 	// MaxAge sets the stream's maximum message age.
 	// Zero value is handled by the message queue implementation.
 	MaxAge time.Duration
+	// AckWait configures how long JetStream waits for an explicit ACK.
+	AckWait time.Duration
+	// MaxDeliver configures how many times JetStream redelivers a message before stopping.
+	MaxDeliver int
 }

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -527,17 +527,24 @@ type Config struct {
 		Bucket               string `env:"OPENCSG_LLMLOG_BUCKET" default:"opencsg-inference-logs"`
 		Prefix               string `env:"OPENCSG_LLMLOG_PREFIX" default:"llmlog"`
 		WorkerNum            int    `env:"OPENCSG_LLMLOG_WORKER_NUM" default:"10"`
-		BatchSize            int    `env:"OPENCSG_LLMLOG_BATCH_SIZE" default:"1000"`
-		FlushIntervalSeconds int    `env:"OPENCSG_LLMLOG_FLUSH_INTERVAL_SECONDS" default:"300"`
+		TaskQueueSize        int    `env:"OPENCSG_LLMLOG_TASK_QUEUE_SIZE" default:"1000"`
+		UploadQueueSize      int    `env:"OPENCSG_LLMLOG_UPLOAD_QUEUE_SIZE" default:"20"`
+		BatchSize            int    `env:"OPENCSG_LLMLOG_BATCH_SIZE" default:"50"`
+		FlushIntervalSeconds int    `env:"OPENCSG_LLMLOG_FLUSH_INTERVAL_SECONDS" default:"60"`
+		UploadTimeoutSeconds int    `env:"OPENCSG_LLMLOG_UPLOAD_TIMEOUT_SECONDS" default:"30"`
+		AckWaitSeconds       int    `env:"OPENCSG_LLMLOG_ACK_WAIT_SECONDS" default:"180"`
+		MaxDeliver           int    `env:"OPENCSG_LLMLOG_MAX_DELIVER" default:"6"`
 		StreamMaxBytes       int64  `env:"OPENCSG_LLMLOG_STREAM_MAX_BYTES" default:"8589934592"`    // 8 GiB
 		StreamMaxAgeSeconds  int    `env:"OPENCSG_LLMLOG_STREAM_MAX_AGE_SECONDS" default:"1209600"` // 14 days
 		Sync                 struct {
-			Enable            bool   `env:"STARHUB_SERVER_LLMLOG_SYNC_ENABLE" default:"false"`
-			Username          string `env:"STARHUB_SERVER_LLMLOG_SYNC_USERNAME" default:""`
-			DatasetNamespace  string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATASET_NAMESPACE" default:""`
-			DatasetName       string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATASET_NAME" default:""`
-			MaxShardSizeBytes int64  `env:"STARHUB_SERVER_LLMLOG_SYNC_MAX_SHARD_SIZE_BYTES" default:"67108864"` // 64 MiB
-			Dataflow          struct {
+			Enable             bool     `env:"STARHUB_SERVER_LLMLOG_SYNC_ENABLE" default:"false"`
+			Username           string   `env:"STARHUB_SERVER_LLMLOG_SYNC_USERNAME" default:""`
+			DatasetNamespace   string   `env:"STARHUB_SERVER_LLMLOG_SYNC_DATASET_NAMESPACE" default:""`
+			DatasetName        string   `env:"STARHUB_SERVER_LLMLOG_SYNC_DATASET_NAME" default:""`
+			MaxShardSizeBytes  int64    `env:"STARHUB_SERVER_LLMLOG_SYNC_MAX_SHARD_SIZE_BYTES" default:"67108864"` // 64 MiB
+			PreuploadBatchSize int      `env:"STARHUB_SERVER_LLMLOG_SYNC_PREUPLOAD_BATCH_SIZE" default:"10"`
+			NotifyEmails       []string `env:"OPENCSG_LLMLOG_SYNC_NOTIFY_EMAILS" default:""`
+			Dataflow           struct {
 				Enable           bool   `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_ENABLE" default:"false"`
 				ResourceScenario string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_RESOURCE_SCENARIO" default:"wf_dataflow"`
 				DatasetNamespace string `env:"STARHUB_SERVER_LLMLOG_SYNC_DATAFLOW_DATASET_NAMESPACE" default:""`

--- a/common/types/notification.go
+++ b/common/types/notification.go
@@ -345,6 +345,37 @@ type EmailWeeklyRechargesNotification struct {
 	EndDate   string   `json:"end_date"`
 }
 
+type EmailLLMLogSyncNotification struct {
+	Emails          []string `json:"emails"`
+	Date            string   `json:"date"`
+	Status          string   `json:"status"`
+	FileCount       int      `json:"file_count"`
+	DataflowStarted bool     `json:"dataflow_started"`
+	DataflowJobID   string   `json:"dataflow_job_id"`
+	ArgoTaskID      string   `json:"argo_task_id"`
+	JobName         string   `json:"job_name"`
+	DataflowStatus  string   `json:"dataflow_status"`
+	Message         string   `json:"message"`
+	ErrorMessage    string   `json:"error_message"`
+	StartedAt       string   `json:"started_at"`
+	FinishedAt      string   `json:"finished_at"`
+}
+
+type SendLLMLogSyncMailInput struct {
+	Date            string
+	Status          string
+	FileCount       int
+	DataflowStarted bool
+	DataflowJobID   string
+	ArgoTaskID      string
+	JobName         string
+	DataflowStatus  string
+	Message         string
+	ErrorMessage    string
+	StartedAt       string
+	FinishedAt      string
+}
+
 type SMSReq struct {
 	PhoneNumbers []string `json:"phone_numbers"`
 	SignName     string   `json:"sign_name"`

--- a/common/types/notification_scenario.go
+++ b/common/types/notification_scenario.go
@@ -16,6 +16,7 @@ const (
 	MessageScenarioLowBalance           MessageScenario = "low-balance"
 	MessageScenarioRechargeSuccess      MessageScenario = "recharge-success"
 	MessageScenarioWeeklyRecharges      MessageScenario = "weekly-recharges"
+	MessageScenarioLLMLogSync           MessageScenario = "llmlog-sync"
 	MessageScenarioDeployment           MessageScenario = "deployment"
 	MessageScenarioNegativeBalance      MessageScenario = "negative-balance"
 	MessageScenarioResourceApplication  MessageScenario = "resource-application"

--- a/notification/tmplmgr/templates/llmlog-sync/email.en-US.tpl
+++ b/notification/tmplmgr/templates/llmlog-sync/email.en-US.tpl
@@ -1,0 +1,73 @@
+{{/* title section */}}
+LLM log sync {{.status}} for {{.date}}
+---
+{{/* content section */}}
+<html>
+    <body style="margin:0;padding:24px;background:#f6f8fa;color:#24292f;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif;font-size:14px;line-height:1.5;">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:880px;margin:0 auto;background:#ffffff;border:1px solid #d0d7de;border-radius:8px;border-collapse:separate;">
+            <tr>
+                <td style="padding:20px 24px;border-bottom:1px solid #d0d7de;">
+                    <h2 style="margin:0 0 8px;font-size:20px;line-height:1.3;color:#24292f;">LLM log sync {{.status}}</h2>
+                    <div style="font-size:13px;color:#57606a;">Date: {{.date}}</div>
+                </td>
+            </tr>
+            <tr>
+                <td style="padding:20px 24px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="border-collapse:collapse;">
+                        <tr>
+                            <td style="width:220px;padding:8px 12px;border-bottom:1px solid #d8dee4;color:#57606a;">Status</td>
+                            <td style="padding:8px 12px;border-bottom:1px solid #d8dee4;font-weight:600;">{{.status}}</td>
+                        </tr>
+                        <tr>
+                            <td style="width:220px;padding:8px 12px;border-bottom:1px solid #d8dee4;color:#57606a;">Discovered source objects</td>
+                            <td style="padding:8px 12px;border-bottom:1px solid #d8dee4;">{{.file_count}}</td>
+                        </tr>
+                        <tr>
+                            <td style="width:220px;padding:8px 12px;border-bottom:1px solid #d8dee4;color:#57606a;">Started at</td>
+                            <td style="padding:8px 12px;border-bottom:1px solid #d8dee4;">{{.started_at}}</td>
+                        </tr>
+                        <tr>
+                            <td style="width:220px;padding:8px 12px;border-bottom:1px solid #d8dee4;color:#57606a;">Finished at</td>
+                            <td style="padding:8px 12px;border-bottom:1px solid #d8dee4;">{{.finished_at}}</td>
+                        </tr>
+        {{if .dataflow_started}}
+                        <tr>
+                            <td style="width:220px;padding:8px 12px;border-bottom:1px solid #d8dee4;color:#57606a;">Dataflow job ID</td>
+                            <td style="padding:8px 12px;border-bottom:1px solid #d8dee4;">{{.dataflow_job_id}}</td>
+                        </tr>
+        {{if .argo_task_id}}
+                        <tr>
+                            <td style="width:220px;padding:8px 12px;border-bottom:1px solid #d8dee4;color:#57606a;">Argo task ID</td>
+                            <td style="padding:8px 12px;border-bottom:1px solid #d8dee4;">{{.argo_task_id}}</td>
+                        </tr>
+        {{end}}
+        {{if .job_name}}
+                        <tr>
+                            <td style="width:220px;padding:8px 12px;border-bottom:1px solid #d8dee4;color:#57606a;">Job name</td>
+                            <td style="padding:8px 12px;border-bottom:1px solid #d8dee4;">{{.job_name}}</td>
+                        </tr>
+        {{end}}
+                        <tr>
+                            <td style="width:220px;padding:8px 12px;border-bottom:1px solid #d8dee4;color:#57606a;">Dataflow status</td>
+                            <td style="padding:8px 12px;border-bottom:1px solid #d8dee4;">{{.dataflow_status}}</td>
+                        </tr>
+                    </table>
+        {{if .message}}
+                    <h3 style="margin:20px 0 8px;font-size:15px;color:#24292f;">Message</h3>
+                    <div style="padding:12px;background:#f6f8fa;border:1px solid #d0d7de;border-radius:6px;white-space:pre-wrap;word-break:break-word;font-family:ui-monospace,SFMono-Regular,Consolas,'Liberation Mono',Menlo,monospace;font-size:13px;color:#24292f;">{{.message}}</div>
+        {{end}}
+        {{else}}
+                    </table>
+        {{end}}
+        {{if .error_message}}
+                    <h3 style="margin:20px 0 8px;font-size:15px;color:#cf222e;">Error</h3>
+                    <div style="padding:12px;background:#fff8f8;border:1px solid #ffb3b8;border-radius:6px;white-space:pre-wrap;word-break:break-word;font-family:ui-monospace,SFMono-Regular,Consolas,'Liberation Mono',Menlo,monospace;font-size:13px;color:#24292f;">{{.error_message}}</div>
+        {{end}}
+        {{if .frontend_url}}
+                    <p style="margin:20px 0 0;color:#57606a;">Portal: <a href="{{.frontend_url}}" style="color:#0969da;">{{.frontend_url}}</a></p>
+        {{end}}
+                </td>
+            </tr>
+        </table>
+    </body>
+</html>


### PR DESCRIPTION
Summary:
- Decoupled LLM log ingestion by switching to manual ACKs and separating active file writing from S3 uploads to prevent JetStream message backlogs during storage delays.
- Optimized dataset sync workflow to immediately close, upload, and delete local shard files upon reaching size thresholds, eliminating local storage growth risks for large datasets.
- Extended sync activity timeouts to 2 hours and introduced new configuration options for upload and acknowledgment waits to support robust handling of large log transfers.