### PR TITLE
fix: Add pagination support to tags endpoint

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_TagStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_TagStore.go
@@ -780,6 +780,74 @@ func (_c *MockTagStore_AllTags_Call) RunAndReturn(run func(context.Context, *typ
 	return _c
 }
 
+// AllTagsWithPagination provides a mock function with given fields: ctx, filter, per, page
+func (_m *MockTagStore) AllTagsWithPagination(ctx context.Context, filter *types.TagFilter, per int, page int) ([]*database.Tag, int, error) {
+	ret := _m.Called(ctx, filter, per, page)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AllTagsWithPagination")
+	}
+
+	var r0 []*database.Tag
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, *types.TagFilter, int, int) ([]*database.Tag, int, error)); ok {
+		return rf(ctx, filter, per, page)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *types.TagFilter, int, int) []*database.Tag); ok {
+		r0 = rf(ctx, filter, per, page)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*database.Tag)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *types.TagFilter, int, int) int); ok {
+		r1 = rf(ctx, filter, per, page)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, *types.TagFilter, int, int) error); ok {
+		r2 = rf(ctx, filter, per, page)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// MockTagStore_AllTagsWithPagination_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllTagsWithPagination'
+type MockTagStore_AllTagsWithPagination_Call struct {
+	*mock.Call
+}
+
+// AllTagsWithPagination is a helper method to define mock.On call
+//   - ctx context.Context
+//   - filter *types.TagFilter
+//   - per int
+//   - page int
+func (_e *MockTagStore_Expecter) AllTagsWithPagination(ctx interface{}, filter interface{}, per interface{}, page interface{}) *MockTagStore_AllTagsWithPagination_Call {
+	return &MockTagStore_AllTagsWithPagination_Call{Call: _e.mock.On("AllTagsWithPagination", ctx, filter, per, page)}
+}
+
+func (_c *MockTagStore_AllTagsWithPagination_Call) Run(run func(ctx context.Context, filter *types.TagFilter, per int, page int)) *MockTagStore_AllTagsWithPagination_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*types.TagFilter), args[2].(int), args[3].(int))
+	})
+	return _c
+}
+
+func (_c *MockTagStore_AllTagsWithPagination_Call) Return(_a0 []*database.Tag, _a1 int, _a2 error) *MockTagStore_AllTagsWithPagination_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *MockTagStore_AllTagsWithPagination_Call) RunAndReturn(run func(context.Context, *types.TagFilter, int, int) ([]*database.Tag, int, error)) *MockTagStore_AllTagsWithPagination_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CheckTagIDsExist provides a mock function with given fields: ctx, ids
 func (_m *MockTagStore) CheckTagIDsExist(ctx context.Context, ids []int64) error {
 	ret := _m.Called(ctx, ids)

--- a/_mocks/opencsg.com/csghub-server/component/mock_TagComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_TagComponent.go
@@ -141,6 +141,74 @@ func (_c *MockTagComponent_AllTags_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+// AllTagsWithPagination provides a mock function with given fields: ctx, filter, per, page
+func (_m *MockTagComponent) AllTagsWithPagination(ctx context.Context, filter *types.TagFilter, per int, page int) ([]*types.RepoTag, int, error) {
+	ret := _m.Called(ctx, filter, per, page)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AllTagsWithPagination")
+	}
+
+	var r0 []*types.RepoTag
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, *types.TagFilter, int, int) ([]*types.RepoTag, int, error)); ok {
+		return rf(ctx, filter, per, page)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *types.TagFilter, int, int) []*types.RepoTag); ok {
+		r0 = rf(ctx, filter, per, page)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*types.RepoTag)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *types.TagFilter, int, int) int); ok {
+		r1 = rf(ctx, filter, per, page)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, *types.TagFilter, int, int) error); ok {
+		r2 = rf(ctx, filter, per, page)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// MockTagComponent_AllTagsWithPagination_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllTagsWithPagination'
+type MockTagComponent_AllTagsWithPagination_Call struct {
+	*mock.Call
+}
+
+// AllTagsWithPagination is a helper method to define mock.On call
+//   - ctx context.Context
+//   - filter *types.TagFilter
+//   - per int
+//   - page int
+func (_e *MockTagComponent_Expecter) AllTagsWithPagination(ctx interface{}, filter interface{}, per interface{}, page interface{}) *MockTagComponent_AllTagsWithPagination_Call {
+	return &MockTagComponent_AllTagsWithPagination_Call{Call: _e.mock.On("AllTagsWithPagination", ctx, filter, per, page)}
+}
+
+func (_c *MockTagComponent_AllTagsWithPagination_Call) Run(run func(ctx context.Context, filter *types.TagFilter, per int, page int)) *MockTagComponent_AllTagsWithPagination_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*types.TagFilter), args[2].(int), args[3].(int))
+	})
+	return _c
+}
+
+func (_c *MockTagComponent_AllTagsWithPagination_Call) Return(_a0 []*types.RepoTag, _a1 int, _a2 error) *MockTagComponent_AllTagsWithPagination_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *MockTagComponent_AllTagsWithPagination_Call) RunAndReturn(run func(context.Context, *types.TagFilter, int, int) ([]*types.RepoTag, int, error)) *MockTagComponent_AllTagsWithPagination_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ClearMetaTags provides a mock function with given fields: ctx, repoType, namespace, name
 func (_m *MockTagComponent) ClearMetaTags(ctx context.Context, repoType types.RepositoryType, namespace string, name string) error {
 	ret := _m.Called(ctx, repoType, namespace, name)

--- a/api/handler/tag.go
+++ b/api/handler/tag.go
@@ -40,6 +40,8 @@ type TagsHandler struct {
 // @Param		 scope query string false "scope name" Enums(model, dataset, code, space, prompt, skill)
 // @Param		 built_in query bool false "built_in"
 // @Param		 search query string false "search on name and show_name fields"
+// @Param		 per query int false "Page size, default 50, max 100" default(50)
+// @Param		 page query int false "Page number, default 1" default(1)
 // @Success      200  {object}  types.Response{data=[]types.RepoTag} "tags"
 // @Failure      400  {object}  types.APIBadRequest "Bad request"
 // @Failure      500  {object}  types.APIInternalServerError "Internal server error"
@@ -51,13 +53,19 @@ func (t *TagsHandler) AllTags(ctx *gin.Context) {
 		httpbase.BadRequest(ctx, err.Error())
 		return
 	}
-	tags, err := t.tag.AllTags(ctx.Request.Context(), filter)
+	per, page, err := common.GetPerAndPageFromContext(ctx)
+	if err != nil {
+		httpbase.BadRequest(ctx, err.Error())
+		return
+	}
+
+	tags, total, err := t.tag.AllTagsWithPagination(ctx.Request.Context(), filter, per, page)
 	if err != nil {
 		slog.ErrorContext(ctx.Request.Context(), "Failed to load tags", slog.Any("filter", filter), slog.Any("error", err))
 		httpbase.ServerError(ctx, err)
 		return
 	}
-	httpbase.OK(ctx, tags)
+	httpbase.OKWithTotal(ctx, tags, total)
 }
 
 // CreateTag     godoc

--- a/api/handler/tag_test.go
+++ b/api/handler/tag_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -41,11 +42,11 @@ func TestTagHandler_AllTags(t *testing.T) {
 		ginContext.Request = req
 
 		tagComp := mockcom.NewMockTagComponent(t)
-		tagComp.EXPECT().AllTags(ginContext.Request.Context(), &types.TagFilter{
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), &types.TagFilter{
 			Scopes:     []types.TagScope{types.TagScope("model")},
 			Categories: []string{"task"},
 			BuiltIn:    nil,
-		}).Return(tags, nil)
+		}, 50, 1).Return(tags, 1, nil)
 
 		tagHandler, err := NewTestTagHandler(tagComp)
 		require.Nil(t, err)
@@ -62,6 +63,7 @@ func TestTagHandler_AllTags(t *testing.T) {
 		require.Equal(t, "", resp.Code)
 		require.Equal(t, "OK", resp.Msg)
 		require.NotNil(t, resp.Data)
+		require.Equal(t, 1, resp.Total)
 	})
 
 	t.Run("with builtin", func(t *testing.T) {
@@ -72,6 +74,8 @@ func TestTagHandler_AllTags(t *testing.T) {
 		values.Add("category", "task")
 		values.Add("scope", "model")
 		values.Add("built_in", "true")
+		values.Add("per", "10")
+		values.Add("page", "2")
 		req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
 
 		hr := httptest.NewRecorder()
@@ -80,11 +84,11 @@ func TestTagHandler_AllTags(t *testing.T) {
 
 		tagComp := mockcom.NewMockTagComponent(t)
 		builtin := true
-		tagComp.EXPECT().AllTags(ginContext.Request.Context(), &types.TagFilter{
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), &types.TagFilter{
 			Scopes:     []types.TagScope{types.TagScope("model")},
 			Categories: []string{"task"},
 			BuiltIn:    &builtin,
-		}).Return(tags, nil)
+		}, 10, 2).Return(tags, 15, nil)
 
 		tagHandler, err := NewTestTagHandler(tagComp)
 		require.Nil(t, err)
@@ -101,6 +105,91 @@ func TestTagHandler_AllTags(t *testing.T) {
 		require.Equal(t, "", resp.Code)
 		require.Equal(t, "OK", resp.Msg)
 		require.NotNil(t, resp.Data)
+		require.Equal(t, 15, resp.Total)
+	})
+
+	t.Run("invalid per", func(t *testing.T) {
+		req := httptest.NewRequest("get", "/api/v1/tags?per=101", nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+		require.Equal(t, http.StatusBadRequest, hr.Code)
+	})
+
+	t.Run("invalid page", func(t *testing.T) {
+		req := httptest.NewRequest("get", "/api/v1/tags?page=0", nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+		require.Equal(t, http.StatusBadRequest, hr.Code)
+	})
+
+	t.Run("non-numeric per", func(t *testing.T) {
+		req := httptest.NewRequest("get", "/api/v1/tags?per=abc", nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+		require.Equal(t, http.StatusBadRequest, hr.Code)
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		req := httptest.NewRequest("get", "/api/v1/tags?per=10&page=1", nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), mock.Anything, 10, 1).Return(nil, 0, fmt.Errorf("db error"))
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+		require.Equal(t, http.StatusInternalServerError, hr.Code)
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		req := httptest.NewRequest("get", "/api/v1/tags?search=none", nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), mock.Anything, 50, 1).Return(nil, 0, nil)
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+		require.Equal(t, http.StatusOK, hr.Code)
+
+		var resp httpbase.R
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
+		require.Equal(t, 0, resp.Total)
 	})
 }
 

--- a/builder/store/database/tag.go
+++ b/builder/store/database/tag.go
@@ -18,6 +18,11 @@ type tagStoreImpl struct {
 type TagStore interface {
 	// Alltags returns all tags in the database
 	AllTags(ctx context.Context, filter *types.TagFilter) ([]*Tag, error)
+	// AllTagsWithPagination returns tags matching the filter with pagination.
+	// When per > 0 and page > 0, results are paginated by limit=per and
+	// offset=(page-1)*per. total always reflects the count of all matching
+	// rows (via SELECT count(*)), regardless of whether pagination is applied.
+	AllTagsWithPagination(ctx context.Context, filter *types.TagFilter, per, page int) ([]*Tag, int, error)
 	AllModelTags(ctx context.Context) ([]*Tag, error)
 	AllPromptTags(ctx context.Context) ([]*Tag, error)
 	AllMCPTags(ctx context.Context) ([]*Tag, error)
@@ -86,9 +91,8 @@ type TagCategory struct {
 	AutoDetected bool           `bun:"default:false" json:"auto_detected" yaml:"auto_detected"`
 }
 
-// Alltags returns all tags in the database
-func (ts *tagStoreImpl) AllTags(ctx context.Context, filter *types.TagFilter) ([]*Tag, error) {
-	var tags []*Tag
+// buildTagQuery builds the base select query for tag filtering
+func (ts *tagStoreImpl) buildTagQuery(filter *types.TagFilter) *bun.SelectQuery {
 	q := ts.db.Operator.Core.NewSelect().Model(&Tag{})
 
 	if filter != nil {
@@ -107,11 +111,42 @@ func (ts *tagStoreImpl) AllTags(ctx context.Context, filter *types.TagFilter) ([
 		}
 	}
 
-	err := q.Scan(ctx, &tags)
+	return q
+}
+
+// AllTags returns all tags in the database
+func (ts *tagStoreImpl) AllTags(ctx context.Context, filter *types.TagFilter) ([]*Tag, error) {
+	var tags []*Tag
+	q := ts.buildTagQuery(filter)
+
+	err := q.Order("id DESC").Scan(ctx, &tags)
 	if err != nil {
 		return nil, fmt.Errorf("failed to select tags,cause: %w", err)
 	}
 	return tags, nil
+}
+
+// AllTagsWithPagination returns tags matching the filter with optional pagination
+func (ts *tagStoreImpl) AllTagsWithPagination(ctx context.Context, filter *types.TagFilter, per, page int) ([]*Tag, int, error) {
+	var tags []*Tag
+	q := ts.buildTagQuery(filter)
+
+	// First query: get total count
+	total, err := q.Count(ctx)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count tags,cause: %w", err)
+	}
+
+	// Second query: get paginated tags
+	if per > 0 && page > 0 {
+		q = q.Limit(per).Offset((page - 1) * per)
+	}
+
+	err = q.Order("id DESC").Scan(ctx, &tags)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to select tags,cause: %w", err)
+	}
+	return tags, total, nil
 }
 
 func (ts *tagStoreImpl) AllTagsByScope(ctx context.Context, scope types.TagScope) ([]*Tag, error) {

--- a/builder/store/database/tag_test.go
+++ b/builder/store/database/tag_test.go
@@ -179,6 +179,80 @@ func TestTagStore_AllTags(t *testing.T) {
 	require.Equal(t, mcpTag.Name, mcpTags[0].Name)
 }
 
+func TestTagStore_AllTagsWithPagination(t *testing.T) {
+	db := tests.InitTestDB()
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var err error
+	// clear all existing data
+	_, err = db.Core.NewDelete().Model(&database.Tag{}).Where("1=1").Exec(ctx)
+	require.Empty(t, err)
+
+	ts := database.NewTagStoreWithDB(db)
+
+	// insert 5 tags
+	for i := 0; i < 5; i++ {
+		_, err = ts.CreateTag(ctx, database.Tag{
+			Category: "task",
+			Name:     fmt.Sprintf("tag_%s_%d", uuid.NewString(), i),
+			Group:    "Group One",
+			Scope:    types.ModelTagScope,
+		})
+		require.Empty(t, err)
+	}
+
+	// no pagination (per=0, page=0) returns all
+	tags, total, err := ts.AllTagsWithPagination(ctx, nil, 0, 0)
+	require.Empty(t, err)
+	require.Equal(t, 5, total)
+	require.Equal(t, 5, len(tags))
+
+	// page 1 with per=2
+	tags, total, err = ts.AllTagsWithPagination(ctx, nil, 2, 1)
+	require.Empty(t, err)
+	require.Equal(t, 5, total)
+	require.Equal(t, 2, len(tags))
+
+	// page 2 with per=2
+	tags, total, err = ts.AllTagsWithPagination(ctx, nil, 2, 2)
+	require.Empty(t, err)
+	require.Equal(t, 5, total)
+	require.Equal(t, 2, len(tags))
+
+	// page 3 with per=2 (last page, only 1 tag)
+	tags, total, err = ts.AllTagsWithPagination(ctx, nil, 2, 3)
+	require.Empty(t, err)
+	require.Equal(t, 5, total)
+	require.Equal(t, 1, len(tags))
+
+	// with filter
+	builtIn := false
+	filter := &types.TagFilter{
+		Scopes:     []types.TagScope{types.ModelTagScope},
+		Categories: []string{"task"},
+		BuiltIn:    &builtIn,
+	}
+	tags, total, err = ts.AllTagsWithPagination(ctx, filter, 3, 1)
+	require.Empty(t, err)
+	require.Equal(t, 5, total)
+	require.Equal(t, 3, len(tags))
+
+	// filter with no results
+	filterSearchNoResult := &types.TagFilter{
+		Scopes:     []types.TagScope{types.ModelTagScope},
+		Categories: []string{"task"},
+		BuiltIn:    &builtIn,
+		Search:     "noResult",
+	}
+	tags, total, err = ts.AllTagsWithPagination(ctx, filterSearchNoResult, 10, 1)
+	require.Empty(t, err)
+	require.Equal(t, 0, total)
+	require.Equal(t, 0, len(tags))
+}
+
 // TestAllModelCategories tests the AllModelCategories method
 func TestTagStore_AllModelCategories(t *testing.T) {
 	db := tests.InitTestDB()

--- a/common/utils/common/params.go
+++ b/common/utils/common/params.go
@@ -70,6 +70,8 @@ func GetPerAndPageFromContext(ctx *gin.Context) (perInt int, pageInt int, err er
 	}
 	pageInt, err = strconv.Atoi(page)
 	if err != nil {
+		ext := errorx.Ctx().Set("query", "page")
+		err = errorx.ReqParamInvalid(err, ext)
 		return
 	}
 	if pageInt <= 0 {

--- a/component/tag.go
+++ b/component/tag.go
@@ -15,6 +15,7 @@ import (
 
 type TagComponent interface {
 	AllTags(ctx context.Context, filter *types.TagFilter) ([]*types.RepoTag, error)
+	AllTagsWithPagination(ctx context.Context, filter *types.TagFilter, per, page int) ([]*types.RepoTag, int, error)
 	ClearMetaTags(ctx context.Context, repoType types.RepositoryType, namespace, name string) error
 	UpdateMetaTags(ctx context.Context, tagScope types.TagScope, namespace, name, content string) ([]*database.RepositoryTag, error)
 	UpdateLibraryTags(ctx context.Context, tagScope types.TagScope, namespace, name, oldFilePath, newFilePath string) error
@@ -70,6 +71,29 @@ func (tc *tagComponentImpl) AllTags(ctx context.Context, filter *types.TagFilter
 		}
 	}
 	return resTags, nil
+}
+
+func (tc *tagComponentImpl) AllTagsWithPagination(ctx context.Context, filter *types.TagFilter, per, page int) ([]*types.RepoTag, int, error) {
+	tags, total, err := tc.tagStore.AllTagsWithPagination(ctx, filter, per, page)
+	if err != nil {
+		return nil, 0, err
+	}
+	resTags := make([]*types.RepoTag, len(tags))
+	for i, tag := range tags {
+		resTags[i] = &types.RepoTag{
+			ID:        tag.ID,
+			Name:      tag.Name,
+			Category:  tag.Category,
+			Group:     tag.Group,
+			Scope:     tag.Scope,
+			BuiltIn:   tag.BuiltIn,
+			ShowName:  tag.I18nKey,
+			I18nKey:   tag.I18nKey,
+			CreatedAt: tag.CreatedAt,
+			UpdatedAt: tag.UpdatedAt,
+		}
+	}
+	return resTags, total, nil
 }
 
 func (c *tagComponentImpl) ClearMetaTags(ctx context.Context, repoType types.RepositoryType, namespace, name string) error {

--- a/component/tag_test.go
+++ b/component/tag_test.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -261,6 +262,57 @@ func TestTagComponent_UpdateCategory(t *testing.T) {
 		}, int64(1))
 		require.Nil(t, err)
 		require.NotNil(t, category)
+	})
+}
+
+func TestTagComponent_AllTagsWithPagination(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("success with tags", func(t *testing.T) {
+		tc := initializeTestTagComponent(ctx, t)
+		filter := &types.TagFilter{
+			Scopes:     []types.TagScope{types.ModelTagScope},
+			Categories: []string{"task"},
+		}
+		dbTags := []*database.Tag{
+			{ID: 1, Name: "tag1", Category: "task", Scope: types.ModelTagScope, BuiltIn: true, I18nKey: "tag1_key"},
+			{ID: 2, Name: "tag2", Category: "task", Scope: types.ModelTagScope, BuiltIn: false, I18nKey: "tag2_key"},
+		}
+		tc.mocks.stores.TagMock().EXPECT().AllTagsWithPagination(ctx, filter, 10, 2).Return(dbTags, 15, nil)
+
+		tags, total, err := tc.AllTagsWithPagination(ctx, filter, 10, 2)
+		require.Nil(t, err)
+		require.Equal(t, 15, total)
+		require.Len(t, tags, 2)
+		require.Equal(t, int64(1), tags[0].ID)
+		require.Equal(t, "tag1", tags[0].Name)
+		require.Equal(t, "task", tags[0].Category)
+		require.Equal(t, types.ModelTagScope, tags[0].Scope)
+		require.Equal(t, true, tags[0].BuiltIn)
+		require.Equal(t, "tag1_key", tags[0].ShowName)
+		require.Equal(t, "tag1_key", tags[0].I18nKey)
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		tc := initializeTestTagComponent(ctx, t)
+		filter := &types.TagFilter{Search: "nonexistent"}
+		tc.mocks.stores.TagMock().EXPECT().AllTagsWithPagination(ctx, filter, 50, 1).Return([]*database.Tag{}, 0, nil)
+
+		tags, total, err := tc.AllTagsWithPagination(ctx, filter, 50, 1)
+		require.Nil(t, err)
+		require.Equal(t, 0, total)
+		require.Len(t, tags, 0)
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		tc := initializeTestTagComponent(ctx, t)
+		filter := &types.TagFilter{}
+		tc.mocks.stores.TagMock().EXPECT().AllTagsWithPagination(ctx, filter, 10, 1).Return(nil, 0, fmt.Errorf("db error"))
+
+		tags, total, err := tc.AllTagsWithPagination(ctx, filter, 10, 1)
+		require.NotNil(t, err)
+		require.Equal(t, 0, total)
+		require.Nil(t, tags)
 	})
 }
 


### PR DESCRIPTION
Summary:
- Added pagination support to the `GET /api/v1/tags` endpoint by introducing `AllTagsWithPagination` and returning a standard `{data, total}` response to enable frontend pagination.
- Implemented validation for `per` and `page` parameters with sensible defaults (per=50, page=1) to ensure backward compatibility while rejecting invalid inputs.
- Updated unit tests and mocks to cover the new pagination logic and error handling scenarios.