### PR TITLE
feat: Add PaddleOCR support with /v1/ocr endpoint and PaddleX serving runtime

### DIFF
--- a/.specs/paddle-ocr/paddle_ocr.md
+++ b/.specs/paddle-ocr/paddle_ocr.md
@@ -1,0 +1,602 @@
+# PaddleOCR Integration
+
+## Goal
+
+Integrate PaddleOCR into CSGHub as a deployable inference runtime and expose it through AIGateway with a stable OCR API.
+
+The target v1 design should support self-hosted PaddleOCR/PaddleX serving for model inference deployments. It should not depend on PaddleOCR's hosted official API as the primary path, because hosted API usage does not run local inference inside our runtime framework.
+
+## Sources
+
+- PaddleOCR general OCR pipeline usage: https://www.paddleocr.ai/main/en/version3.x/pipeline_usage/OCR.html
+- PaddleOCR self-hosted serving: https://www.paddleocr.ai/main/en/version3.x/inference_deployment/serving/serving.html
+- PaddleOCR official API Go SDK: https://www.paddleocr.ai/latest/en/version3.x/inference_deployment/serving/paddleocr_official_api/go.html
+- PaddleOCR official API CLI: https://www.paddleocr.ai/latest/en/version3.x/inference_deployment/serving/paddleocr_official_api/cli.html
+- Legacy PaddleOCR HubServing docs: https://github.com/PaddlePaddle/PaddleOCR/blob/main/deploy/hubserving/readme_en.md
+- LiteLLM OCR endpoint: https://docs.litellm.ai/docs/ocr
+- Mistral OCR API: https://docs.mistral.ai (endpoint shape mirrored at https://docs.aimlapi.com/api-references/vision-models/ocr-optical-character-recognition/mistral-ai/mistral-ocr)
+- OpenRouter PDF inputs: https://openrouter.ai/docs/guides/overview/multimodal/pdfs
+- vLLM PaddleOCR-VL recipe: https://docs.vllm.ai/projects/recipes/en/stable/PaddlePaddle/PaddleOCR-VL.html
+- new-api relay modes (no OCR): https://github.com/Calcium-Ion/new-api/blob/main/relay/constant/relay_mode.go
+
+## Source Findings
+
+PaddleOCR 3.x provides a general OCR pipeline for extracting editable text from images. Current documentation lists PP-OCRv3, PP-OCRv4, PP-OCRv5, and PP-OCRv6 support, with PP-OCRv6 as the newer default general OCR pipeline in recent docs.
+
+The general OCR pipeline is composed of these modules:
+
+- document image orientation classification, optional
+- document image unwarping, optional
+- text line orientation classification, optional
+- text detection
+- text recognition
+
+PaddleOCR recommends PaddleX for self-hosted serving. The basic serving command is:
+
+```bash
+paddlex --serve --pipeline OCR
+```
+
+The service exposes an OCR endpoint, commonly shown as `/ocr`, and accepts a base64-encoded file payload. The basic serving mode is recommended for quick validation before evaluating high-stability serving based on Triton.
+
+The PaddleOCR official API SDKs and CLI submit OCR or document parsing jobs to hosted PaddleOCR services. Those clients are useful as an external provider integration, but they do not run local models or load local inference artifacts inside CSGHub deployments.
+
+Legacy PaddleOCR HubServing and PaddleServing docs exist, but for a new integration the PaddleX 3.x serving path is the better baseline because it aligns with current PaddleOCR documentation and PaddlePaddle 3.x support.
+
+PaddleOCR also ships PaddleOCR-VL, a 0.9B vision-language document parsing model. vLLM supports it natively, so a standard vLLM deployment exposes it through the OpenAI chat completions API with an `image_url` content part and a task prompt such as `OCR:`, `Table Recognition:`, `Formula Recognition:`, or `Chart Recognition:`. This means PaddleOCR-VL can be served through CSGHub's existing vLLM runtime and AIGateway chat completions route without any new gateway code. The classic PP-OCR pipeline (PaddleX serving) remains the path that needs the new `/v1/ocr` route, and it is the only path that returns per-line bounding boxes.
+
+## AI Gateway Prior Art
+
+A July 2026 survey of how other AI gateways expose OCR:
+
+- **LiteLLM**: the only major gateway with a first-class OCR route. `POST /v1/ocr`, Mistral API-compatible. Providers are registered with `mode: ocr` in the model list. Supports Mistral OCR, Azure Document Intelligence, Azure AI Mistral, and Vertex AI OCR. Accepts JSON document references and multipart uploads.
+- **Mistral OCR API**: the de-facto OCR API shape that LiteLLM adopted. JSON body with `document: {type: document_url|image_url, document_url: <url or base64 data URI>}`. Response is `pages[]` with per-page `markdown`, extracted `images` with bounding boxes, page `dimensions`, and `usage_info.pages_processed`. Billed per page.
+- **OpenRouter**: no OCR route. PDF parsing is a `file-parser` plugin on chat completions with selectable engines (`mistral-ocr` at roughly $2 per 1,000 pages, `cloudflare-ai` free, or the model's native file support billed as input tokens).
+- **new-api / one-api**: no OCR relay mode. The relay layer covers chat, completions, embeddings, moderations, images, Midjourney, audio speech/transcription/translation, Suno, video, rerank, responses, realtime, and Gemini passthrough. OCR workloads run as vision-model chat completions.
+- **Portkey**: no OCR or document parsing support.
+
+Two conclusions for CSGHub:
+
+- A first-class `/v1/ocr` route is validated by LiteLLM and Mistral rather than being an outlier, and per-page billing matches industry practice.
+- Gateways that skip a dedicated route still serve OCR through chat completions with vision models. CSGHub gets that path for free once PaddleOCR-VL is deployable through vLLM, so both paths should be supported.
+
+## Current CSGHub Findings
+
+AIGateway currently exposes OpenAI-style API families:
+
+- `GET /v1/models`
+- `POST /v1/responses`
+- `POST /v1/chat/completions`
+- `POST /v1/embeddings`
+- `POST /v1/rerank`
+- `POST /v1/images/generations`
+- `POST /v1/images/edits`
+- `POST /v1/audio/transcriptions`
+- `POST /v1/audio/speech`
+- `POST /v1/videos`
+
+There is no existing OCR route.
+
+Runtime frameworks are loaded from `configs/inference/*.json`. `component/runtime_architecture.go` reads each JSON file, unmarshals it into `types.EngineConfig`, stores a `runtime_framework`, and stores supported architectures and supported model names. A PaddleOCR runtime can therefore be added by creating a normal inference framework config.
+
+AIGateway model listing already includes running deploy metadata from deploy records:
+
+- public model ID
+- `task`
+- `metadata.llm_type`
+- `metadata.repo_path`
+- `runtime_framework`
+- `endpoint`
+
+This means OCR deployments can appear in `/v1/models` with the same model discovery path as existing inference models if the deploy task has an OCR task value and the runtime framework is seeded.
+
+The closest existing AIGateway handler pattern is audio transcription:
+
+- parse multipart form
+- require `model` and `file`
+- resolve model target
+- start modal trace
+- check balance
+- rewrite the model field to the upstream model name
+- proxy to the runtime endpoint
+- wrap response
+- record usage asynchronously
+
+OCR should follow this shape rather than introducing handler-local special cases outside the normal AIGateway flow.
+
+## Design Decisions
+
+- Add PaddleOCR as a self-hosted inference runtime framework.
+- Add a first-class AIGateway OCR route instead of overloading chat, responses, image generation, or audio transcription.
+- Use PaddleX basic serving as the v1 runtime baseline.
+- Normalize PaddleX OCR responses into an AIGateway-owned OCR response shape.
+- Keep the raw upstream OCR result available in the response for compatibility and debugging.
+- Add a dedicated OCR pipeline task value so `/v1/models?task=...` can filter OCR-capable deployments.
+- Meter OCR by request/page/image count in v1. Do not reuse text-token or audio-duration accounting.
+- Treat PaddleOCR official hosted API as a possible future external provider path, not the default CSGHub inference integration.
+- Support two PaddleOCR deployment modes: the classic PP-OCR pipeline through PaddleX serving behind the new `/v1/ocr` route, and PaddleOCR-VL through the existing vLLM runtime and chat completions route (no new gateway code).
+- Keep multipart as the v1 request format (parity with audio transcription), and plan a Mistral-compatible JSON body (`document` with URL or base64 data URI) as a fast-follow so clients using the Mistral OCR SDK shape work against AIGateway.
+- Reserve an optional per-page `markdown` field in the OCR response for VL-backed or layout-parsing upstreams; the classic pipeline leaves it empty.
+- Do not update GitLab issues or MRs as part of this spec.
+
+## Public API
+
+### Route
+
+```text
+POST /v1/ocr
+```
+
+The route should require the same API-key authentication as other AIGateway inference routes.
+
+### Multipart Request
+
+`multipart/form-data` is the v1 request format.
+
+A Mistral-compatible JSON variant is planned as a fast-follow (not v1): `application/json` with `model` and `document: {type: "document_url"|"image_url", document_url: "<url or base64 data URI>"}`. It maps onto the same upstream transform, since PaddleX serving consumes base64 file bytes either way.
+
+Required fields:
+
+- `model`: public AIGateway model ID
+- `file`: image or PDF file
+
+Optional fields:
+
+- `page_ranges`: page range for PDF or multi-page input, for example `1,3-5`
+- `use_doc_orientation_classify`: boolean
+- `use_doc_unwarping`: boolean
+- `use_textline_orientation`: boolean
+- `return_image`: boolean, defaults to false
+- `raw_response`: boolean, defaults to false
+
+Allowed file content should include common OCR inputs:
+
+- `image/png`
+- `image/jpeg`
+- `image/webp`
+- `image/bmp`
+- `image/tiff`
+- `application/pdf`
+
+### Example Request
+
+```bash
+curl https://hub.example.com/v1/ocr \
+  -H "Authorization: Bearer $CSGHUB_API_KEY" \
+  -F "model=owner/paddleocr-demo:abc123" \
+  -F "file=@invoice.png" \
+  -F "use_doc_orientation_classify=true" \
+  -F "use_doc_unwarping=false" \
+  -F "use_textline_orientation=true"
+```
+
+### Response
+
+```json
+{
+  "id": "ocr_abc123",
+  "object": "ocr.result",
+  "created": 1760000000,
+  "model": "owner/paddleocr-demo:abc123",
+  "text": "recognized full text",
+  "pages": [
+    {
+      "index": 0,
+      "text": "recognized page text",
+      "markdown": "",
+      "lines": [
+        {
+          "text": "line text",
+          "score": 0.98,
+          "bbox": [[10, 20], [200, 20], [200, 40], [10, 40]]
+        }
+      ],
+      "image_url": ""
+    }
+  ],
+  "usage": {
+    "pages": 1,
+    "images": 1
+  },
+  "raw_result": {}
+}
+```
+
+`raw_result` should be omitted unless `raw_response=true` or an internal/debug option enables it.
+
+`markdown` is reserved for VL-backed or layout-parsing upstreams (for example PaddleOCR-VL or PP-StructureV3 output) and is omitted or empty for the classic PP-OCR pipeline.
+
+## Runtime Framework
+
+Add `configs/inference/paddleocr.json`.
+
+Initial shape:
+
+```json
+{
+  "engine_name": "paddleocr",
+  "enabled": 1,
+  "container_port": 8000,
+  "model_format": "paddle_static",
+  "description": "PaddleOCR/PaddleX self-hosted OCR serving runtime",
+  "engine_images": [
+    {
+      "compute_type": "gpu",
+      "image": "opencsghq/paddleocr:3.7.0",
+      "driver_version": "12.8",
+      "engine_version": "3.7.0"
+    },
+    {
+      "compute_type": "cpu",
+      "image": "opencsghq/paddleocr-cpu:3.7.0",
+      "engine_version": "3.7.0"
+    }
+  ],
+  "supported_archs": [
+    "PaddleOCRPipeline",
+    "OCR"
+  ],
+  "supported_models": [
+    "PP-OCRv6",
+    "PP-OCRv5",
+    "PP-OCRv5-latin"
+  ]
+}
+```
+
+Image tags are pinned to PaddleOCR `3.7.0` (with PaddleX `3.7.x` and PaddlePaddle `3.3.x` underneath). Revalidate against the latest PaddleOCR release before publishing new image tags.
+
+### Runtime Image
+
+The runtime image downloads the CSGHub model repo via `entry.py`, then starts a PaddleX serving process:
+
+```bash
+paddlex --serve --pipeline "${MODEL_DIR}/pipeline.yaml" \
+  --host 0.0.0.0 \
+  --port "${PORT:-8000}" \
+  --device "${PADDLEOCR_DEVICE:-gpu:0}"
+```
+
+**Model source strategy (default: `HF_ENDPOINT` first, official-hoster fallback).** Official model repos on HF/ModelScope/OpenCSG (e.g. `PP-OCRv6_medium_rec`) ship only weights for a single sub-model — an OCR pipeline needs det + rec + optional classifiers, which PaddleX resolves by `model_name` at runtime. `serve.sh` points PaddleX's HuggingFace hoster at the deployment-provided `HF_ENDPOINT` (`PADDLE_PDX_HUGGING_FACE_ENDPOINT=${HF_ENDPOINT}/hf` — CSGHub serves its HF-compatible API under the `/hf` subpath — and `HF_TOKEN=$ACCESS_TOKEN`), so sub-models are pulled from that hub first; missing ones fall through PaddleX's built-in hoster chain (AIStudio → ModelScope → BOS). When the downloaded repo contains `pipeline.yaml`/`OCR.yaml`, that config is used as-is. When it is a single recognition model (has `inference.pdiparams`, repo basename ends `_rec`), `serve.sh` runs `paddlex --get_pipeline_config OCR` and patches it via `gen_pipeline.py`: `TextRecognition` is pointed at the local weights (`model_dir` = the downloaded repo), and `TextDetection` is switched to the matching-tier det model name (language prefixes `latin_`/`korean_`/`eslav_` are stripped for the det name) which is still resolved from the model sources — so deploying `PP-OCRv6_tiny_rec` actually serves the tiny tier instead of the medium default. Otherwise the built-in `OCR` pipeline is served and every sub-model is resolved from the configured sources. The runtime images pin `huggingface-hub==0.36.2` because hf_hub 1.x lists repo files via the `/tree` API, which CSGHub's `/hf` endpoint does not implement — 0.x uses `model_info` + `siblings`, which works.
+
+For air-gapped deployments, `PADDLEOCR_MODEL_SOURCE=local-only` restores the strict offline mode: `PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK=True`, no external sources, and the repo **must** be a self-contained bundle (`pipeline.yaml` whose `model_dir` entries point at local subdirs) — startup fails fast otherwise. Bundle layout:
+
+```
+<repo>/
+├── pipeline.yaml                 # every model_dir points at a local subdir
+├── PP-OCRv6_medium_det/          # inference.pdiparams, inference.yml, ...
+├── PP-OCRv6_medium_rec/
+├── PP-LCNet_x1_0_doc_ori/        # optional: doc orientation classify
+├── PP-LCNet_x1_0_textline_ori/   # optional: textline orientation
+└── UVDoc/                        # optional: doc unwarping
+```
+
+A minimal bundle with only det + rec is valid if `use_doc_preprocessor`/`use_textline_orientation` are `False` in the pipeline config. The template comes from `paddlex --get_pipeline_config OCR --save_path pipeline.yaml` with each `model_dir: null` rewritten to the local subdir.
+
+Environment variables:
+
+- `PADDLEOCR_MODEL_SOURCE`: `hub` (default, pull from `HF_ENDPOINT` first with official-hoster fallback) or `local-only` (strict offline, requires pipeline bundle)
+- `PADDLEX_PIPELINE`: explicit pipeline config path override
+- `PADDLEOCR_DEVICE`: `gpu`, `cpu`, or another PaddleX-supported device (set per image)
+- `PORT`: serving port, defaults to `8000`
+- `ENGINE_ARGS`: extra args appended to `paddlex --serve` (e.g. `--use_hpip`)
+- `PADDLEOCR_RETURN_URLS`: future option for binary result URLs
+
+ROCm/AMD note: no `paddleocr-rocm` image is planned for now. The repo's ROCm images standardize on ROCm 7.2.2 (`rocm/pytorch:rocm7.2.2_ubuntu22.04_py3.10_pytorch_release_2.10.0`), but PaddlePaddle does not publish official ROCm pip wheels — its AMD support ships mainly through Baidu's DCU (Hygon) custom builds, so a ROCm variant would need a different base image and separate validation.
+
+### Runtime Endpoint
+
+The PaddleX service endpoint should be treated as the upstream runtime API. For v1, AIGateway can transform its multipart request into the PaddleX expected JSON body:
+
+```json
+{
+  "file": "<base64 file bytes>",
+  "fileType": 1
+}
+```
+
+The handler or adapter should derive `fileType` from the uploaded input:
+
+- image: `1`
+- PDF: value to be confirmed against the exact PaddleX serving contract during runtime validation
+
+If the PaddleX endpoint path differs from `/ocr` in the selected image version, the runtime image should normalize it or the AIGateway adapter should make the endpoint path configurable.
+
+## AIGateway Design
+
+### Route
+
+Add the route in `aigateway/router/aigateway.go`:
+
+```go
+v1Group.POST("/ocr", middlewareCollection.Auth.MustUserOrgApiKey, modalAPIRateLimiter, openAIhandler.OCR)
+```
+
+Use the modal API rate limiter because OCR is image/document inference and can be resource intensive.
+
+### Types
+
+Add `aigateway/types/ocr.go`.
+
+Recommended DTOs:
+
+```go
+type OCRRequest struct {
+    Model                       string
+    PageRanges                  string
+    UseDocOrientationClassify   *bool
+    UseDocUnwarping             *bool
+    UseTextlineOrientation      *bool
+    ReturnImage                 bool
+    RawResponse                 bool
+}
+
+type OCRResponse struct {
+    ID        string       `json:"id"`
+    Object    string       `json:"object"`
+    Created   int64        `json:"created"`
+    Model     string       `json:"model"`
+    Text      string       `json:"text"`
+    Pages     []OCRPage    `json:"pages"`
+    Usage     OCRUsage     `json:"usage"`
+    RawResult any          `json:"raw_result,omitempty"`
+}
+
+type OCRPage struct {
+    Index    int       `json:"index"`
+    Text     string    `json:"text"`
+    Markdown string    `json:"markdown,omitempty"`
+    Lines    []OCRLine `json:"lines"`
+    ImageURL string    `json:"image_url,omitempty"`
+}
+
+type OCRLine struct {
+    Text  string      `json:"text"`
+    Score *float64    `json:"score,omitempty"`
+    BBox  interface{} `json:"bbox,omitempty"`
+}
+
+type OCRUsage struct {
+    Pages  int `json:"pages"`
+    Images int `json:"images"`
+}
+```
+
+The handler package can own multipart parsing, but the response and normalized request data should live in `aigateway/types`.
+
+### Handler Flow
+
+Add `aigateway/handler/openai_ocr.go`.
+
+Flow:
+
+1. Parse `multipart/form-data`.
+2. Require `model`.
+3. Require exactly one `file`.
+4. Validate uploaded content type and size.
+5. Resolve the target model through `resolveModelTarget`.
+6. Ensure the resolved model is OCR-capable:
+   - `model.Task == "optical-character-recognition"`, or
+   - `model.RuntimeFramework == "paddleocr"`
+7. Start modal trace with output type `text`.
+8. Run balance check.
+9. Transform multipart upload into the PaddleX OCR serving payload.
+10. Apply model auth headers.
+11. Proxy to the PaddleOCR runtime endpoint.
+12. Parse PaddleX response.
+13. Normalize to `types.OCRResponse`.
+14. Record OCR usage asynchronously.
+
+The handler should follow the existing transcription handler pattern for target resolution, trace lifecycle, balance handling, auth header application, reverse proxy creation, and async usage recording.
+
+### Adapter
+
+Add an OCR adapter package only if more than one upstream protocol is expected:
+
+```text
+aigateway/component/adapter/ocr
+  adapter.go
+  paddlex.go
+```
+
+For v1, a PaddleX adapter is enough:
+
+- build upstream request from multipart input
+- select endpoint path, default `/ocr`
+- parse PaddleX response
+- normalize pages, lines, text, image output, and raw result
+
+If the runtime image can expose an AIGateway-native `/v1/ocr` contract directly, the adapter can be simpler and only preserve the existing proxy/rewrite pattern.
+
+### Task Type
+
+Add a new common pipeline task:
+
+```go
+OpticalCharacterRecognition PipelineTask = "optical-character-recognition"
+```
+
+This lets deployed PaddleOCR models appear with:
+
+```json
+{
+  "task": "optical-character-recognition"
+}
+```
+
+Then clients can discover OCR models with:
+
+```text
+GET /v1/models?task=optical-character-recognition
+```
+
+### Model Listing
+
+No separate AIGateway model-list path is needed. Existing CSGHub deploys already populate model fields from running deploy records.
+
+The important requirement is that OCR deploy records carry:
+
+- `Task = optical-character-recognition`
+- `RuntimeFramework = paddleocr`
+- `Endpoint` pointing to the PaddleOCR serving endpoint
+
+### Usage and Billing
+
+Add OCR usage semantics instead of pretending OCR uses text tokens or audio duration.
+
+This matches industry practice: Mistral OCR bills per processed page (`usage_info.pages_processed`), and OpenRouter's Mistral OCR engine is priced per 1,000 pages.
+
+Initial v1 usage dimensions:
+
+- request count
+- page count
+- image count
+
+If the accounting SKU system needs a single unit, use page count for PDFs and image count for image files. For single-image requests, both may be `1`.
+
+If the runtime cannot reliably report pages, derive:
+
+- image upload: `pages = 1`, `images = 1`
+- PDF upload: page count from runtime response, if present; otherwise `pages = 1` as a conservative fallback with a warning log
+
+### Trace and Logs
+
+Trace metadata should include:
+
+- `aigateway.api = /v1/ocr`
+- `aigateway.model.id`
+- `aigateway.ocr.page_ranges`
+- `aigateway.ocr.return_image`
+- `aigateway.ocr.pages`
+- `aigateway.ocr.images`
+
+Do not store raw OCR text in span attributes by default.
+
+## Error Handling
+
+Return OpenAI-style AIGateway errors consistent with existing handlers.
+
+Recommended errors:
+
+- missing `model`: `invalid_request_error`
+- missing `file`: `invalid_request_error`
+- multiple files: `invalid_request_error`
+- unsupported content type: `invalid_request_error`
+- model not found: existing model target error handling
+- model is not OCR-capable: `unsupported_model`
+- upstream unavailable: existing upstream unavailable error handling
+- malformed PaddleX response: `upstream_response_error`
+
+## Security
+
+- Require API-key auth.
+- Apply existing model target authorization and visibility rules.
+- Do not log file content or recognized OCR text by default.
+- Enforce upload size limits before reading the full file into memory.
+- Avoid returning raw upstream payloads unless explicitly requested.
+- If `return_image` produces binary output, prefer storing generated artifacts in object storage and returning URLs instead of inline base64 for large results.
+
+## Rollout Plan
+
+### Phase 1: Runtime Validation
+
+- Build CPU and GPU PaddleOCR runtime images.
+- Run `paddlex --serve --pipeline OCR` in the image.
+- Confirm exact request and response contract for image input and PDF input.
+- Confirm endpoint path and `fileType` values.
+- Pin image tags.
+- Optionally validate PaddleOCR-VL serving through vLLM (`vllm serve PaddlePaddle/PaddleOCR-VL`) as the zero-gateway-code companion path.
+
+### Phase 2: Runtime Framework Registration
+
+- Add `configs/inference/paddleocr.json`.
+- Run runtime framework scan or startup initialization.
+- Confirm `runtime_framework` and `runtime_architectures` rows are created.
+- Confirm OCR model repositories can select PaddleOCR as an inference runtime.
+
+### Phase 3: AIGateway API
+
+- Add `POST /v1/ocr`.
+- Add OCR request/response types.
+- Add PaddleX request transform and response normalization.
+- Add OCR-specific usage counter.
+- Add trace metadata.
+
+### Phase 4: Tests and Docs
+
+- Add handler tests for multipart validation, model resolution, request transform, and response normalization.
+- Add adapter tests for PaddleX response parsing.
+- Add model-list test coverage for `optical-character-recognition`.
+- Add a user-facing usage guide if portal or docs need API examples.
+
+## Test Plan
+
+Unit tests:
+
+- `aigateway/types` OCR response JSON shape
+- OCR multipart parser rejects missing model, missing file, multiple files, unsupported content type
+- OCR handler rewrites public model ID to runtime model name
+- PaddleX adapter builds expected upstream JSON
+- PaddleX adapter normalizes page and line results
+- OCR usage is derived from normalized response
+
+Focused package tests:
+
+```bash
+go test ./aigateway/types ./aigateway/handler ./aigateway/component/adapter/ocr
+```
+
+Runtime validation:
+
+```bash
+curl http://localhost:8000/ocr \
+  -H "Content-Type: application/json" \
+  -d '{"file":"<base64>","fileType":1}'
+```
+
+AIGateway validation:
+
+```bash
+curl http://localhost:8080/v1/ocr \
+  -H "Authorization: Bearer $CSGHUB_API_KEY" \
+  -F "model=<paddleocr-model-id>" \
+  -F "file=@demo.png"
+```
+
+## Open Questions
+
+- Exact PaddleX `fileType` values for PDF and multi-page inputs need runtime validation.
+- Should v1 support PDF uploads, or should it ship image-only first and add PDF after page-count billing is verified?
+- Should the runtime image normalize PaddleX output into AIGateway's OCR response shape directly, or should AIGateway own all normalization?
+- What is the final SKU unit for OCR: request, page, image, or weighted page by file type? Industry precedent (Mistral per-page, OpenRouter per-1,000-pages) favors page count.
+- Does portal need a dedicated OCR playground, or is API-only enough for the first milestone?
+- Mistral-compatible JSON request body: v1 or fast-follow? Current recommendation is fast-follow, confirmed before implementation starts.
+
+Resolved during gateway prior-art research:
+
+- First-class `/v1/ocr` route vs chat-completions-only: keep the first-class route for the PaddleX pipeline (validated by LiteLLM/Mistral), and additionally serve PaddleOCR-VL through the existing vLLM chat completions path.
+
+## Recommended V1 Scope
+
+Ship the smallest complete integration:
+
+- PaddleOCR runtime image using PaddleX basic serving
+- `configs/inference/paddleocr.json`
+- `optical-character-recognition` task value
+- `POST /v1/ocr` multipart image upload
+- normalized text/pages/lines response
+- request/image-count usage
+- tests for handler validation and adapter normalization
+
+Companion path that ships independently with no new gateway code:
+
+- PaddleOCR-VL deployed through the existing vLLM runtime framework, callable through `POST /v1/chat/completions` with `image_url` input and an `OCR:` task prompt
+
+Defer:
+
+- Mistral-compatible JSON request body (fast-follow)
+- official hosted PaddleOCR API provider
+- Triton/high-stability serving
+- PDF-specific billing if page count is not reliable
+- object-storage URLs for result images
+- portal playground

--- a/aigateway/component/adapter/ocr/adapter.go
+++ b/aigateway/component/adapter/ocr/adapter.go
@@ -1,0 +1,64 @@
+package ocr
+
+import (
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+// PaddleX fileType values for the upstream serving contract.
+const (
+	FileTypePDF   = 0
+	FileTypeImage = 1
+)
+
+// UpstreamInput carries everything an adapter needs to build the upstream
+// OCR runtime request body.
+type UpstreamInput struct {
+	FileBytes                 []byte
+	FileType                  int
+	UseDocOrientationClassify *bool
+	UseDocUnwarping           *bool
+	UseTextlineOrientation    *bool
+	Visualize                 bool
+}
+
+// ResponseOptions controls how the upstream response is normalized.
+type ResponseOptions struct {
+	ModelID     string
+	RawResponse bool
+	ReturnImage bool
+}
+
+// Adapter transforms AIGateway OCR requests to an upstream OCR runtime
+// protocol and normalizes its responses.
+type Adapter interface {
+	Name() string
+	CanHandle(model *types.Model) bool
+	// EndpointPath is the upstream OCR route path, default "/ocr".
+	EndpointPath(model *types.Model) string
+	BuildUpstreamRequest(in *UpstreamInput) ([]byte, error)
+	TransformResponse(respBody []byte, opts *ResponseOptions) (*types.OCRResponse, error)
+}
+
+type Registry struct {
+	adapters []Adapter
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		adapters: []Adapter{
+			NewPaddleXAdapter(),
+		},
+	}
+}
+
+func (r *Registry) GetAdapter(model *types.Model) Adapter {
+	if model == nil {
+		return nil
+	}
+	for _, adapter := range r.adapters {
+		if adapter.CanHandle(model) {
+			return adapter
+		}
+	}
+	return nil
+}

--- a/aigateway/component/adapter/ocr/paddlex.go
+++ b/aigateway/component/adapter/ocr/paddlex.go
@@ -1,0 +1,178 @@
+package ocr
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"opencsg.com/csghub-server/aigateway/types"
+	commontypes "opencsg.com/csghub-server/common/types"
+)
+
+const (
+	paddleXAdapterName  = "paddlex"
+	paddleXEndpointPath = "/ocr"
+	// RuntimeFrameworkPaddleOCR is the engine_name of the PaddleOCR runtime
+	// framework registered from configs/inference/paddleocr.json.
+	RuntimeFrameworkPaddleOCR = "paddleocr"
+)
+
+// PaddleXAdapter implements the PaddleX serving (`paddlex --serve --pipeline OCR`)
+// protocol: JSON body with a base64 file, camelCase option flags, and an
+// ocrResults response envelope.
+type PaddleXAdapter struct{}
+
+func NewPaddleXAdapter() *PaddleXAdapter {
+	return &PaddleXAdapter{}
+}
+
+func (a *PaddleXAdapter) Name() string {
+	return paddleXAdapterName
+}
+
+func (a *PaddleXAdapter) CanHandle(model *types.Model) bool {
+	if model == nil {
+		return false
+	}
+	if isValue(model.RuntimeFramework, RuntimeFrameworkPaddleOCR) {
+		return true
+	}
+	if isValue(model.Provider, "opencsg") {
+		return true
+	}
+	for _, task := range strings.Split(model.Task, ",") {
+		if strings.TrimSpace(task) == string(commontypes.OpticalCharacterRecognition) {
+			return true
+		}
+	}
+	return false
+}
+
+func isValue(value, expected string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), expected)
+}
+
+func (a *PaddleXAdapter) EndpointPath(_ *types.Model) string {
+	return paddleXEndpointPath
+}
+
+// paddleXRequest is the upstream request contract. Optional booleans use
+// pointers so they are only sent when the client explicitly set them.
+type paddleXRequest struct {
+	File                      string `json:"file"`
+	FileType                  int    `json:"fileType"`
+	UseDocOrientationClassify *bool  `json:"useDocOrientationClassify,omitempty"`
+	UseDocUnwarping           *bool  `json:"useDocUnwarping,omitempty"`
+	UseTextlineOrientation    *bool  `json:"useTextlineOrientation,omitempty"`
+	Visualize                 bool   `json:"visualize"`
+}
+
+func (a *PaddleXAdapter) BuildUpstreamRequest(in *UpstreamInput) ([]byte, error) {
+	if in == nil || len(in.FileBytes) == 0 {
+		return nil, fmt.Errorf("ocr upstream input file is empty")
+	}
+	body := paddleXRequest{
+		File:                      base64.StdEncoding.EncodeToString(in.FileBytes),
+		FileType:                  in.FileType,
+		UseDocOrientationClassify: in.UseDocOrientationClassify,
+		UseDocUnwarping:           in.UseDocUnwarping,
+		UseTextlineOrientation:    in.UseTextlineOrientation,
+		Visualize:                 in.Visualize,
+	}
+	return json.Marshal(body)
+}
+
+// paddleXResponse mirrors the PaddleX serving response envelope. Unknown
+// fields are ignored on purpose so newer PaddleX versions keep parsing.
+type paddleXResponse struct {
+	LogID     string        `json:"logId"`
+	ErrorCode int           `json:"errorCode"`
+	ErrorMsg  string        `json:"errorMsg"`
+	Result    paddleXResult `json:"result"`
+}
+
+type paddleXResult struct {
+	OCRResults []paddleXOCRResult `json:"ocrResults"`
+}
+
+type paddleXOCRResult struct {
+	PrunedResult paddleXPrunedResult `json:"prunedResult"`
+	OCRImage     string              `json:"ocrImage"`
+	InputImage   string              `json:"inputImage"`
+}
+
+type paddleXPrunedResult struct {
+	RecTexts  []string  `json:"rec_texts"`
+	RecScores []float64 `json:"rec_scores"`
+	RecPolys  []any     `json:"rec_polys"`
+}
+
+func (a *PaddleXAdapter) TransformResponse(respBody []byte, opts *ResponseOptions) (*types.OCRResponse, error) {
+	var upstream paddleXResponse
+	if err := json.Unmarshal(respBody, &upstream); err != nil {
+		return nil, fmt.Errorf("decode paddlex ocr response: %w", err)
+	}
+	if upstream.ErrorCode != 0 {
+		return nil, fmt.Errorf("paddlex ocr error %d: %s", upstream.ErrorCode, upstream.ErrorMsg)
+	}
+
+	resp := &types.OCRResponse{
+		ID:      types.NewOCRResponseID(),
+		Object:  types.OCRResponseObject,
+		Created: time.Now().Unix(),
+	}
+	if opts != nil {
+		resp.Model = opts.ModelID
+	}
+
+	var pageTexts []string
+	for i, result := range upstream.Result.OCRResults {
+		page := types.OCRPage{Index: i}
+		pruned := result.PrunedResult
+		for j, text := range pruned.RecTexts {
+			line := types.OCRLine{Text: text}
+			if j < len(pruned.RecScores) {
+				score := pruned.RecScores[j]
+				line.Score = &score
+			}
+			if j < len(pruned.RecPolys) {
+				line.BBox = pruned.RecPolys[j]
+			}
+			page.Lines = append(page.Lines, line)
+		}
+		page.Text = joinOCRLineTexts(pruned.RecTexts)
+		pageTexts = append(pageTexts, page.Text)
+		resp.Pages = append(resp.Pages, page)
+	}
+	if len(resp.Pages) == 0 {
+		// Upstream succeeded but returned no ocrResults: keep one empty page so
+		// the response shape stays stable for image inputs.
+		resp.Pages = []types.OCRPage{{Index: 0}}
+		pageTexts = []string{""}
+	}
+	resp.Text = strings.Join(pageTexts, "\n")
+	resp.Usage = types.OCRUsage{
+		Pages:  len(resp.Pages),
+		Images: 1,
+	}
+
+	if opts != nil && opts.RawResponse {
+		var raw any
+		if err := json.Unmarshal(respBody, &raw); err == nil {
+			resp.RawResult = raw
+		}
+	}
+	return resp, nil
+}
+
+func joinOCRLineTexts(texts []string) string {
+	filtered := make([]string, 0, len(texts))
+	for _, t := range texts {
+		if t != "" {
+			filtered = append(filtered, t)
+		}
+	}
+	return strings.Join(filtered, "\n")
+}

--- a/aigateway/component/adapter/ocr/paddlex_test.go
+++ b/aigateway/component/adapter/ocr/paddlex_test.go
@@ -1,0 +1,226 @@
+package ocr
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/types"
+	commontypes "opencsg.com/csghub-server/common/types"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestPaddleXAdapter_CanHandle(t *testing.T) {
+	a := NewPaddleXAdapter()
+
+	tests := []struct {
+		name  string
+		model *types.Model
+		want  bool
+	}{
+		{
+			name: "by runtime framework",
+			model: &types.Model{
+				InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "paddleocr"},
+			},
+			want: true,
+		},
+		{
+			name: "by task",
+			model: &types.Model{
+				BaseModel: types.BaseModel{Task: string(commontypes.OpticalCharacterRecognition)},
+			},
+			want: true,
+		},
+		{
+			name: "by comma separated task",
+			model: &types.Model{
+				BaseModel: types.BaseModel{Task: "text-generation, optical-character-recognition"},
+			},
+			want: true,
+		},
+		{
+			name: "by opencsg provider",
+			model: &types.Model{
+				ExternalModelInfo: types.ExternalModelInfo{Provider: " OpenCSG "},
+			},
+			want: true,
+		},
+		{
+			name: "other framework and task",
+			model: &types.Model{
+				BaseModel:         types.BaseModel{Task: "text-generation"},
+				InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "vllm"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, a.CanHandle(tt.model))
+		})
+	}
+}
+
+func TestPaddleXAdapter_BuildUpstreamRequest(t *testing.T) {
+	a := NewPaddleXAdapter()
+
+	body, err := a.BuildUpstreamRequest(&UpstreamInput{
+		FileBytes:                 []byte("fake-image-bytes"),
+		FileType:                  FileTypeImage,
+		UseDocOrientationClassify: boolPtr(true),
+		UseTextlineOrientation:    boolPtr(false),
+		Visualize:                 true,
+	})
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(body, &got))
+
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("fake-image-bytes")), got["file"])
+	assert.EqualValues(t, FileTypeImage, got["fileType"])
+	assert.Equal(t, true, got["useDocOrientationClassify"])
+	assert.Equal(t, false, got["useTextlineOrientation"])
+	assert.Equal(t, true, got["visualize"])
+	// unset optional flags must be omitted
+	assert.NotContains(t, got, "useDocUnwarping")
+}
+
+func TestPaddleXAdapter_BuildUpstreamRequest_EmptyFile(t *testing.T) {
+	a := NewPaddleXAdapter()
+	_, err := a.BuildUpstreamRequest(&UpstreamInput{FileType: FileTypeImage})
+	require.Error(t, err)
+}
+
+const paddleXSuccessBody = `{
+  "logId": "log-1",
+  "errorCode": 0,
+  "errorMsg": "Success",
+  "result": {
+    "ocrResults": [
+      {
+        "prunedResult": {
+          "rec_texts": ["hello", "world"],
+          "rec_scores": [0.99, 0.87],
+          "rec_polys": [
+            [[1, 2], [50, 2], [50, 20], [1, 20]],
+            [[1, 30], [60, 30], [60, 48], [1, 48]]
+          ],
+          "rec_boxes": [[1, 2, 50, 20], [1, 30, 60, 48]]
+        },
+        "inputImage": "aW1hZ2U="
+      }
+    ],
+    "dataInfo": {"width": 100, "height": 50}
+  }
+}`
+
+func TestPaddleXAdapter_TransformResponse_Success(t *testing.T) {
+	a := NewPaddleXAdapter()
+
+	resp, err := a.TransformResponse([]byte(paddleXSuccessBody), &ResponseOptions{
+		ModelID: "owner/paddleocr-demo:abc123",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, types.OCRResponseObject, resp.Object)
+	assert.Equal(t, "owner/paddleocr-demo:abc123", resp.Model)
+	assert.NotEmpty(t, resp.ID)
+	assert.NotZero(t, resp.Created)
+	assert.Equal(t, "hello\nworld", resp.Text)
+
+	require.Len(t, resp.Pages, 1)
+	page := resp.Pages[0]
+	assert.Equal(t, 0, page.Index)
+	assert.Equal(t, "hello\nworld", page.Text)
+	require.Len(t, page.Lines, 2)
+	assert.Equal(t, "hello", page.Lines[0].Text)
+	require.NotNil(t, page.Lines[0].Score)
+	assert.InDelta(t, 0.99, *page.Lines[0].Score, 1e-9)
+	assert.NotNil(t, page.Lines[1].BBox)
+
+	assert.Equal(t, 1, resp.Usage.Pages)
+	assert.Equal(t, 1, resp.Usage.Images)
+	assert.Nil(t, resp.RawResult)
+}
+
+func TestPaddleXAdapter_TransformResponse_RawResultGating(t *testing.T) {
+	a := NewPaddleXAdapter()
+
+	resp, err := a.TransformResponse([]byte(paddleXSuccessBody), &ResponseOptions{RawResponse: true})
+	require.NoError(t, err)
+
+	raw, ok := resp.RawResult.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "log-1", raw["logId"])
+}
+
+func TestPaddleXAdapter_TransformResponse_UpstreamError(t *testing.T) {
+	a := NewPaddleXAdapter()
+
+	body := `{"logId": "log-2", "errorCode": 101, "errorMsg": "invalid image"}`
+	_, err := a.TransformResponse([]byte(body), &ResponseOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid image")
+}
+
+func TestPaddleXAdapter_TransformResponse_Malformed(t *testing.T) {
+	a := NewPaddleXAdapter()
+	_, err := a.TransformResponse([]byte(`not-json`), &ResponseOptions{})
+	require.Error(t, err)
+}
+
+func TestPaddleXAdapter_TransformResponse_MissingScoresAndPolys(t *testing.T) {
+	a := NewPaddleXAdapter()
+
+	body := `{
+      "errorCode": 0,
+      "result": {"ocrResults": [{"prunedResult": {"rec_texts": ["only text"]}}]}
+    }`
+	resp, err := a.TransformResponse([]byte(body), &ResponseOptions{})
+	require.NoError(t, err)
+
+	require.Len(t, resp.Pages, 1)
+	require.Len(t, resp.Pages[0].Lines, 1)
+	assert.Equal(t, "only text", resp.Pages[0].Lines[0].Text)
+	assert.Nil(t, resp.Pages[0].Lines[0].Score)
+	assert.Nil(t, resp.Pages[0].Lines[0].BBox)
+}
+
+func TestPaddleXAdapter_TransformResponse_MultiPage(t *testing.T) {
+	a := NewPaddleXAdapter()
+
+	body := `{
+      "errorCode": 0,
+      "result": {"ocrResults": [
+        {"prunedResult": {"rec_texts": ["page one"]}},
+        {"prunedResult": {"rec_texts": ["page two"]}}
+      ]}
+    }`
+	resp, err := a.TransformResponse([]byte(body), &ResponseOptions{})
+	require.NoError(t, err)
+
+	require.Len(t, resp.Pages, 2)
+	assert.Equal(t, 1, resp.Pages[1].Index)
+	assert.Equal(t, "page one\npage two", resp.Text)
+	assert.Equal(t, 2, resp.Usage.Pages)
+}
+
+func TestRegistry_GetAdapter(t *testing.T) {
+	r := NewRegistry()
+
+	model := &types.Model{
+		InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "paddleocr"},
+	}
+	assert.Equal(t, paddleXAdapterName, r.GetAdapter(model).Name())
+
+	other := &types.Model{
+		BaseModel:         types.BaseModel{Task: "text-generation"},
+		InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "vllm"},
+	}
+	assert.Nil(t, r.GetAdapter(other))
+	assert.Nil(t, r.GetAdapter(nil))
+}

--- a/aigateway/handler/openai.go
+++ b/aigateway/handler/openai.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openai/openai-go/v3"
 	"opencsg.com/csghub-server/aigateway/component"
 	audioadapter "opencsg.com/csghub-server/aigateway/component/adapter/audio"
+	ocradapter "opencsg.com/csghub-server/aigateway/component/adapter/ocr"
 	"opencsg.com/csghub-server/aigateway/component/adapter/text2image"
 	"opencsg.com/csghub-server/aigateway/component/adapter/text2video"
 	"opencsg.com/csghub-server/aigateway/component/availability"
@@ -65,6 +66,8 @@ type OpenAIHandler interface {
 	GetVideoContent(c *gin.Context)
 	// Transcribe audio to text
 	Transcription(c *gin.Context)
+	// Extract text from an image with OCR
+	OCR(c *gin.Context)
 	// Generate speech audio from text
 	Speech(c *gin.Context)
 	// Generate speech audio for multiple texts in a single request
@@ -170,6 +173,7 @@ func newOpenAIHandler(
 		whitelistRule:              whitelistRule,
 		aiGenerationStore:          aiGenerationStore,
 		sensitivePolicy:            component.NewSensitivePolicy(modComponent, whitelistRule),
+		ocrRegistry:                ocradapter.NewRegistry(),
 		llmLogPublisher:            component.NewLLMLogPublisher(),
 		sessionRouter:              router.NewSessionRouter(),
 		chatAttemptFailureReporter: noopChatAttemptFailureReporter{},
@@ -262,6 +266,7 @@ type OpenAIHandlerImpl struct {
 	t2iRegistry                *text2image.Registry
 	t2vRegistry                *text2video.Registry
 	audioRegistry              *audioadapter.Registry
+	ocrRegistry                *ocradapter.Registry
 	config                     *config.Config
 	storage                    types.Storage
 	whitelistRule              database.RepositoryFileCheckRuleStore

--- a/aigateway/handler/openai_ocr.go
+++ b/aigateway/handler/openai_ocr.go
@@ -1,0 +1,332 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"opencsg.com/csghub-server/aigateway/component/adapter/ocr"
+	"opencsg.com/csghub-server/aigateway/http/response/wrapper"
+	"opencsg.com/csghub-server/aigateway/token"
+	"opencsg.com/csghub-server/aigateway/types"
+	"opencsg.com/csghub-server/api/httpbase"
+	"opencsg.com/csghub-server/builder/proxy"
+	"opencsg.com/csghub-server/common/utils/trace"
+)
+
+const (
+	maxOCRMultipartMemory = 32 << 20 // 32MB, matches EditImage
+	maxOCRFileSize        = 20 << 20 // 20MB uploaded file limit
+	// Bounds the whole request body (file + multipart overhead + other fields)
+	// so oversized uploads are rejected before being read to disk.
+	maxOCRRequestSize = maxOCRFileSize + 1<<20
+)
+
+var ocrAllowedContentTypes = map[string]struct{}{
+	"image/png":  {},
+	"image/jpeg": {},
+	"image/webp": {},
+	"image/bmp":  {},
+	"image/tiff": {},
+}
+
+// OCR godoc
+// @Security     ApiKey
+// @Summary      Extract text from an image with OCR
+// @Description  Sends a multipart OCR request to a PaddleOCR-capable backend model and returns normalized text, pages and lines. PDF input is not supported yet; page_ranges is accepted for API stability but not forwarded upstream.
+// @Tags         AIGateway
+// @Accept       multipart/form-data
+// @Produce      json
+// @Param        model formData string true "Model ID"
+// @Param        file formData file true "Image file (png, jpeg, webp, bmp, tiff)"
+// @Param        page_ranges formData string false "Page range for multi-page input, e.g. 1,3-5 (reserved)"
+// @Param        use_doc_orientation_classify formData bool false "Enable document orientation classification"
+// @Param        use_doc_unwarping formData bool false "Enable document unwarping"
+// @Param        use_textline_orientation formData bool false "Enable text line orientation classification"
+// @Param        return_image formData bool false "Ask upstream to visualize results (images surface only in raw_result)"
+// @Param        raw_response formData bool false "Include the raw upstream OCR result in the response"
+// @Success      200  {object}  types.OCRResponse "OK"
+// @Failure      400  {object}  error "Bad request"
+// @Failure      404  {object}  error "Model not found"
+// @Failure      500  {object}  error "Internal server error"
+// @Router       /v1/ocr [post]
+func (h *OpenAIHandlerImpl) OCR(c *gin.Context) {
+	username := httpbase.GetCurrentUser(c)
+	nsUUID := httpbase.GetCurrentNamespaceUUID(c)
+	apikey := httpbase.GetAccessToken(c)
+	ctx := c.Request.Context()
+	requestID := trace.GetTraceIDInGinContext(c)
+	ctx, preflight := startPreflightTrace(ctx, preflightTraceStart{
+		API:       c.FullPath(),
+		RequestID: requestID,
+		UserID:    nsUUID,
+	})
+	c.Request = c.Request.WithContext(ctx)
+
+	ocrReq, fileHeader, ok := h.parseOCRMultipartForm(c, preflight)
+	if !ok {
+		return
+	}
+	modelID := ocrReq.Model
+
+	modelTarget, err := h.resolveModelTarget(ctx, username, modelID, c.Request.Header)
+	if err != nil {
+		preflight.RecordError(err, "model_resolve")
+		handleModelTargetError(c, ctx, modelID, "failed to get ocr target address", err)
+		return
+	}
+	if !supportsOCRTask(modelTarget.Model) {
+		err := fmt.Errorf("model '%s' does not support OCR", modelID)
+		preflight.RecordError(err, "unsupported_model")
+		preflight.End()
+		c.JSON(http.StatusBadRequest, gin.H{"error": types.Error{
+			Code:    "unsupported_model",
+			Message: err.Error(),
+			Type:    "invalid_request_error",
+		}})
+		return
+	}
+	preflight.SetTargetModel(modelID, modelTarget)
+	preflight.End()
+
+	traceCtx, generationRecorder := h.startModalGenerationTrace(ctx, modalTraceStartInput{
+		API:           c.FullPath(),
+		OperationName: modalTraceOperationGenerateContent,
+		OutputType:    modalTraceOutputText,
+		RequestID:     requestID,
+		NSUUID:        nsUUID,
+		ModelID:       modelID,
+		ModelTarget:   modelTarget,
+		Metadata: map[string]any{
+			"aigateway.ocr.page_ranges":  ocrReq.PageRanges,
+			"aigateway.ocr.return_image": ocrReq.ReturnImage,
+		},
+	})
+	ctx = traceCtx
+	c.Request = c.Request.WithContext(traceCtx)
+
+	if !modelTarget.Model.SkipBalance() {
+		if err := h.openaiComponent.CheckBalance(ctx, nsUUID); err != nil {
+			finishModalGenerationTraceWithError(generationRecorder, err, types.TraceErrInsufficientBalance)
+			h.handleInsufficientBalance(c, false, nsUUID, modelID, err)
+			return
+		}
+	}
+
+	adapter := h.ocrRegistry.GetAdapter(modelTarget.Model)
+	if adapter == nil {
+		finishModalGenerationTraceWithError(generationRecorder, fmt.Errorf("no ocr adapter for model '%s'", modelID), types.TraceErrUpstreamUnavailable)
+		c.JSON(http.StatusBadRequest, gin.H{"error": types.Error{
+			Code:    "unsupported_model",
+			Message: fmt.Sprintf("no ocr adapter for model '%s'", modelID),
+			Type:    "invalid_request_error",
+		}})
+		return
+	}
+
+	fileBytes, err := readOCRUpload(fileHeader)
+	if err != nil {
+		finishModalGenerationTraceWithError(generationRecorder, err, types.TraceErrUpstreamUnavailable)
+		slog.ErrorContext(ctx, "failed to read ocr upload", slog.Any("error", err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": types.Error{
+			Code: "internal_error", Message: "failed to read uploaded file", Type: "internal_error",
+		}})
+		return
+	}
+
+	bodyBytes, err := adapter.BuildUpstreamRequest(&ocr.UpstreamInput{
+		FileBytes:                 fileBytes,
+		FileType:                  ocr.FileTypeImage,
+		UseDocOrientationClassify: ocrReq.UseDocOrientationClassify,
+		UseDocUnwarping:           ocrReq.UseDocUnwarping,
+		UseTextlineOrientation:    ocrReq.UseTextlineOrientation,
+		Visualize:                 ocrReq.ReturnImage,
+	})
+	if err != nil {
+		finishModalGenerationTraceWithError(generationRecorder, err, types.TraceErrUpstreamUnavailable)
+		slog.ErrorContext(ctx, "failed to build ocr upstream request", slog.Any("error", err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": types.Error{
+			Code: "internal_error", Message: err.Error(), Type: "internal_error",
+		}})
+		return
+	}
+
+	c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	c.Request.ContentLength = int64(len(bodyBytes))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Del("Content-Length")
+
+	if err := applyModelAuthHeaders(c.Request.Header, modelTarget.Model); err != nil {
+		slog.WarnContext(ctx, "invalid auth head", slog.String("model", modelTarget.ModelName), slog.Any("error", err))
+	}
+
+	rp, err := proxy.NewReverseProxy(modelTarget.Target, proxy.WithoutAcceptEncoding())
+	if err != nil {
+		finishModalGenerationTraceWithError(generationRecorder, err, types.TraceErrUpstreamUnavailable)
+		slog.ErrorContext(ctx, "failed to create reverse proxy", slog.Any("error", err))
+		c.String(http.StatusInternalServerError, fmt.Errorf("failed to create reverse proxy:%w", err).Error())
+		return
+	}
+
+	proxyToApi := adapter.EndpointPath(modelTarget.Model)
+	if modelTarget.Model.Endpoint != "" {
+		uri, err := url.ParseRequestURI(modelTarget.Model.Endpoint)
+		if err != nil {
+			slog.WarnContext(ctx, "endpoint has wrong struct", slog.String("model", modelTarget.ModelName))
+		} else if uri.Path != "" && uri.Path != "/" {
+			proxyToApi = uri.Path
+		}
+	}
+
+	slog.InfoContext(ctx, "proxy ocr request to model endpoint", slog.Any("target", modelTarget.Target), slog.Any("host", modelTarget.Host), slog.Any("user", username), slog.Any("model_id", modelID), slog.Any("model_name", modelTarget.ModelName))
+
+	ocrCounter := token.NewOCRUsageCounter()
+	w := wrapper.NewOCR(c.Writer, adapter, ocrCounter, &ocr.ResponseOptions{
+		ModelID:     modelID,
+		RawResponse: ocrReq.RawResponse,
+		ReturnImage: ocrReq.ReturnImage,
+	})
+	rp.ServeHTTP(w, c.Request, proxyToApi, modelTarget.Host)
+
+	if err := w.Finalize(); err != nil {
+		finishModalGenerationTraceWithError(generationRecorder, err, types.TraceErrUpstreamError)
+		slog.ErrorContext(ctx, "failed to finalize ocr response", slog.Any("error", err))
+		return
+	}
+
+	go func() {
+		usageCtx, cancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 3*time.Second)
+		defer cancel()
+
+		var usage *token.Usage
+		if w.StatusCode() < http.StatusBadRequest {
+			var usageErr error
+			usage, usageErr = ocrCounter.Usage(usageCtx)
+			if usageErr != nil {
+				slog.ErrorContext(usageCtx, "failed to get ocr usage", slog.Any("error", usageErr))
+			}
+		}
+		if generationRecorder != nil {
+			metadata := map[string]any{}
+			if resp := w.Response(); resp != nil {
+				metadata["aigateway.ocr.pages"] = resp.Usage.Pages
+				metadata["aigateway.ocr.images"] = resp.Usage.Images
+			}
+			recordModalGenerationTraceCompletion(modalTraceCompletionInput{
+				Recorder:   generationRecorder,
+				Provider:   modelTarget.Model.Provider,
+				Model:      modelTarget.ModelName,
+				Usage:      usage,
+				StatusCode: w.StatusCode(),
+				Metadata:   metadata,
+			})
+			generationRecorder.End()
+		}
+
+		if w.StatusCode() < http.StatusBadRequest && usage != nil {
+			if err := h.openaiComponent.RecordUsageFromTokenUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, usage, apikey); err != nil {
+				slog.ErrorContext(usageCtx, "failed to record ocr usage", slog.Any("error", err))
+			}
+		}
+	}()
+}
+
+// parseOCRMultipartForm validates the multipart request and returns the
+// normalized request values and the uploaded file header. It writes the error
+// response and returns ok=false on any validation failure.
+func (h *OpenAIHandlerImpl) parseOCRMultipartForm(c *gin.Context, preflight *preflightTrace) (*types.OCRRequest, *multipart.FileHeader, bool) {
+	fail := func(err error, message string) (*types.OCRRequest, *multipart.FileHeader, bool) {
+		preflight.RecordError(err, "bad_request")
+		c.JSON(http.StatusBadRequest, gin.H{"error": types.Error{
+			Code:    "invalid_request_error",
+			Message: message,
+			Type:    "invalid_request_error",
+		}})
+		return nil, nil, false
+	}
+
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxOCRRequestSize)
+	if err := c.Request.ParseMultipartForm(maxOCRMultipartMemory); err != nil {
+		return fail(fmt.Errorf("invalid multipart form: %w", err), "invalid multipart form: "+err.Error())
+	}
+	form := c.Request.MultipartForm
+	if form == nil {
+		return fail(fmt.Errorf("request must be multipart/form-data"), "request must be multipart/form-data")
+	}
+
+	modelID := strings.TrimSpace(firstMultipartValue(form, "model"))
+	if modelID == "" {
+		return fail(fmt.Errorf("model cannot be empty"), "Model cannot be empty")
+	}
+
+	files := form.File["file"]
+	if len(files) == 0 {
+		return fail(fmt.Errorf("file cannot be empty"), "File cannot be empty")
+	}
+	if len(files) > 1 {
+		return fail(fmt.Errorf("only one file is allowed"), "Only one file is allowed")
+	}
+	fileHeader := files[0]
+
+	contentType := strings.ToLower(strings.TrimSpace(fileHeader.Header.Get("Content-Type")))
+	if contentType == "application/pdf" {
+		return fail(fmt.Errorf("pdf input is not supported yet"), "PDF input is not supported yet")
+	}
+	if _, allowed := ocrAllowedContentTypes[contentType]; !allowed {
+		return fail(fmt.Errorf("unsupported content type %q", contentType), fmt.Sprintf("Unsupported file content type: %s", contentType))
+	}
+	if fileHeader.Size > maxOCRFileSize {
+		return fail(fmt.Errorf("file size %d exceeds limit %d", fileHeader.Size, maxOCRFileSize), "File size exceeds the 20MB limit")
+	}
+
+	return &types.OCRRequest{
+		Model:                     modelID,
+		PageRanges:                strings.TrimSpace(firstMultipartValue(form, "page_ranges")),
+		UseDocOrientationClassify: optionalMultipartBool(form, "use_doc_orientation_classify"),
+		UseDocUnwarping:           optionalMultipartBool(form, "use_doc_unwarping"),
+		UseTextlineOrientation:    optionalMultipartBool(form, "use_textline_orientation"),
+		ReturnImage:               strings.EqualFold(firstMultipartValue(form, "return_image"), "true"),
+		RawResponse:               strings.EqualFold(firstMultipartValue(form, "raw_response"), "true"),
+	}, fileHeader, true
+}
+
+func optionalMultipartBool(form *multipart.Form, key string) *bool {
+	raw := strings.TrimSpace(firstMultipartValue(form, key))
+	if raw == "" {
+		return nil
+	}
+	parsed, err := strconv.ParseBool(raw)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func readOCRUpload(fileHeader *multipart.FileHeader) ([]byte, error) {
+	f, err := fileHeader.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	return io.ReadAll(f)
+}
+
+// supportsOCRTask reports whether the model can serve OCR requests. Logic is
+// delegated to the OCR adapter registry so handler and adapter stay aligned.
+func supportsOCRTask(model *types.Model) bool {
+	if model == nil {
+		return false
+	}
+	return ocr.NewPaddleXAdapter().CanHandle(model)
+}

--- a/aigateway/handler/openai_ocr_test.go
+++ b/aigateway/handler/openai_ocr_test.go
@@ -1,0 +1,374 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/token"
+	"opencsg.com/csghub-server/aigateway/types"
+	"opencsg.com/csghub-server/common/errorx"
+	commontypes "opencsg.com/csghub-server/common/types"
+)
+
+const ocrTestUpstreamBody = `{
+  "logId": "log-1",
+  "errorCode": 0,
+  "errorMsg": "Success",
+  "result": {
+    "ocrResults": [
+      {
+        "prunedResult": {
+          "rec_texts": ["hello", "world"],
+          "rec_scores": [0.99, 0.87],
+          "rec_polys": [
+            [[1, 2], [50, 2], [50, 20], [1, 20]],
+            [[1, 30], [60, 30], [60, 48], [1, 48]]
+          ]
+        }
+      }
+    ]
+  }
+}`
+
+func newMultipartOCRRequest(t *testing.T, model, fileContent, fileContentType string, fields map[string]string, fileCount int) *http.Request {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if model != "" {
+		require.NoError(t, writer.WriteField("model", model))
+	}
+	for key, value := range fields {
+		require.NoError(t, writer.WriteField(key, value))
+	}
+	for i := 0; i < fileCount; i++ {
+		header := make(textproto.MIMEHeader)
+		header.Set("Content-Disposition", `form-data; name="file"; filename="input.png"`)
+		if fileContentType != "" {
+			header.Set("Content-Type", fileContentType)
+		}
+		part, err := writer.CreatePart(header)
+		require.NoError(t, err)
+		_, err = part.Write([]byte(fileContent))
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/ocr", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+// withCancelableContext mimics a real server request: production requests
+// carry a cancelable context, which makes the reverse proxy skip its
+// CloseNotifier path (that path panics on httptest.ResponseRecorder).
+func withCancelableContext(t *testing.T, req *http.Request) *http.Request {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return req.WithContext(ctx)
+}
+
+func ocrTestModelWithEndpoint(id, upstreamModelName, endpoint string) *types.Model {
+	return &types.Model{
+		BaseModel: types.BaseModel{
+			ID:      id,
+			Object:  "model",
+			OwnedBy: "testuser",
+			Task:    string(commontypes.OpticalCharacterRecognition),
+		},
+		InternalModelInfo: types.InternalModelInfo{
+			RuntimeFramework: "paddleocr",
+		},
+		Endpoint: endpoint,
+		Upstreams: []commontypes.UpstreamConfig{
+			{URL: endpoint, Enabled: true, ModelName: upstreamModelName},
+		},
+	}
+}
+
+func TestSupportsOCRTask(t *testing.T) {
+	assert.False(t, supportsOCRTask(nil))
+	assert.True(t, supportsOCRTask(&types.Model{
+		BaseModel: types.BaseModel{Task: "optical-character-recognition"},
+	}))
+	assert.True(t, supportsOCRTask(&types.Model{
+		BaseModel: types.BaseModel{Task: "text-generation, optical-character-recognition"},
+	}))
+	assert.True(t, supportsOCRTask(&types.Model{
+		InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "paddleocr"},
+	}))
+	assert.True(t, supportsOCRTask(&types.Model{
+		ExternalModelInfo: types.ExternalModelInfo{Provider: "opencsg"},
+	}))
+	assert.False(t, supportsOCRTask(&types.Model{
+		BaseModel:         types.BaseModel{Task: "text-generation"},
+		InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "vllm"},
+	}))
+}
+
+func TestOpenAIHandler_OCRValidation(t *testing.T) {
+	t.Run("invalid multipart body", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/ocr", strings.NewReader("not multipart"))
+		c.Request.Header.Set("Content-Type", "multipart/form-data; boundary=missing")
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "invalid_request_error")
+	})
+
+	t.Run("missing model", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = newMultipartOCRRequest(t, "", "image-bytes", "image/png", nil, 1)
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "Model cannot be empty")
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = newMultipartOCRRequest(t, "model1", "", "", nil, 0)
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "File cannot be empty")
+	})
+
+	t.Run("multiple files", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = newMultipartOCRRequest(t, "model1", "image-bytes", "image/png", nil, 2)
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "Only one file is allowed")
+	})
+
+	t.Run("pdf rejected", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = newMultipartOCRRequest(t, "model1", "pdf-bytes", "application/pdf", nil, 1)
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "PDF input is not supported yet")
+	})
+
+	t.Run("unsupported content type", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = newMultipartOCRRequest(t, "model1", "gif-bytes", "image/gif", nil, 1)
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "Unsupported file content type")
+	})
+
+	t.Run("oversized file rejected by request body limit", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = newMultipartOCRRequest(t, "model1", strings.Repeat("a", int(maxOCRRequestSize)+1), "image/png", nil, 1)
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "invalid multipart form")
+	})
+
+	t.Run("oversized unrelated field rejected by request body limit", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		fields := map[string]string{"junk": strings.Repeat("a", int(maxOCRRequestSize))}
+		c.Request = newMultipartOCRRequest(t, "model1", "image-bytes", "image/png", fields, 1)
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "invalid multipart form")
+	})
+}
+
+func TestOpenAIHandler_OCRPreProxyErrors(t *testing.T) {
+	t.Run("model not found", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = newMultipartOCRRequest(t, "missing-model", "image-bytes", "image/png", nil, 1)
+		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "missing-model").Return(nil, nil).Once()
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "model_not_found")
+	})
+
+	t.Run("model is not OCR-capable", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = newMultipartOCRRequest(t, "model1", "image-bytes", "image/png", nil, 1)
+		chatModel := &types.Model{
+			BaseModel:         types.BaseModel{ID: "model1", Object: "model", Task: "text-generation"},
+			InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "vllm"},
+			Endpoint:          "https://api.example.com",
+			Upstreams: []commontypes.UpstreamConfig{
+				{URL: "https://api.example.com", Enabled: true, ModelName: "backend-model"},
+			},
+		}
+		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").Return(chatModel, nil).Once()
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "unsupported_model")
+	})
+
+	t.Run("insufficient balance", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = newMultipartOCRRequest(t, "model1", "image-bytes", "image/png", nil, 1)
+		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").
+			Return(ocrTestModelWithEndpoint("model1", "paddleocr-model", "https://api.example.com"), nil).Once()
+		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(errorx.ErrInsufficientBalance).Once()
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusForbidden, w.Code)
+	})
+}
+
+func TestOpenAIHandler_OCRUpstreamErrorPassthrough(t *testing.T) {
+	tester, c, w := setupTest(t)
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "runtime exploded"}`))
+	}))
+	defer upstream.Close()
+
+	c.Request = withCancelableContext(t, newMultipartOCRRequest(t, "model1", "image-bytes", "image/png", nil, 1))
+	tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").
+		Return(ocrTestModelWithEndpoint("model1", "paddleocr-model", upstream.URL), nil).Once()
+	tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+
+	tester.handler.OCR(c)
+
+	require.Equal(t, "/ocr", gotPath)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Contains(t, w.Body.String(), "runtime exploded")
+}
+
+func TestOpenAIHandler_OCRHappyPath(t *testing.T) {
+	tester, c, w := setupTest(t)
+
+	var (
+		gotPath        string
+		gotMethod      string
+		gotContentType string
+		gotBody        []byte
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ocrTestUpstreamBody))
+	}))
+	defer upstream.Close()
+
+	c.Request = withCancelableContext(t, newMultipartOCRRequest(t, "model1", "image-bytes", "image/png", map[string]string{
+		"use_doc_orientation_classify": "true",
+	}, 1))
+	model := ocrTestModelWithEndpoint("model1", "paddleocr-model", upstream.URL)
+	tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").Return(model, nil).Once()
+	tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	tester.mocks.openAIComp.EXPECT().
+		RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, "paddleocr-model", mock.MatchedBy(func(usage *token.Usage) bool {
+			return usage != nil &&
+				usage.DataType == string(commontypes.DataTypeOCR) &&
+				usage.CompletionRC == 1
+		}), mock.Anything).
+		RunAndReturn(func(context.Context, string, *types.Model, string, *token.Usage, string) error {
+			wg.Done()
+			return nil
+		}).Once()
+
+	tester.handler.OCR(c)
+
+	// upstream received a valid PaddleX request
+	require.Equal(t, "/ocr", gotPath)
+	require.Equal(t, http.MethodPost, gotMethod)
+	require.Equal(t, "application/json", gotContentType)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &payload))
+	decoded, err := base64.StdEncoding.DecodeString(payload["file"].(string))
+	require.NoError(t, err)
+	require.Equal(t, "image-bytes", string(decoded))
+	require.EqualValues(t, 1, payload["fileType"])
+	require.Equal(t, true, payload["useDocOrientationClassify"])
+	require.Equal(t, false, payload["visualize"])
+	require.NotContains(t, payload, "useDocUnwarping")
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp types.OCRResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, types.OCRResponseObject, resp.Object)
+	assert.Equal(t, "model1", resp.Model)
+	assert.Equal(t, "hello\nworld", resp.Text)
+	require.Len(t, resp.Pages, 1)
+	require.Len(t, resp.Pages[0].Lines, 2)
+	assert.Equal(t, "hello", resp.Pages[0].Lines[0].Text)
+	require.NotNil(t, resp.Pages[0].Lines[0].Score)
+	assert.Equal(t, 1, resp.Usage.Pages)
+	assert.Equal(t, 1, resp.Usage.Images)
+	assert.Nil(t, resp.RawResult)
+
+	wg.Wait()
+}
+
+func TestOpenAIHandler_OCRRawResponse(t *testing.T) {
+	tester, c, w := setupTest(t)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ocrTestUpstreamBody))
+	}))
+	defer upstream.Close()
+
+	c.Request = withCancelableContext(t, newMultipartOCRRequest(t, "model1", "image-bytes", "image/png", map[string]string{
+		"raw_response": "true",
+	}, 1))
+	model := ocrTestModelWithEndpoint("model1", "paddleocr-model", upstream.URL)
+	tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").Return(model, nil).Once()
+	tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+	tester.mocks.openAIComp.EXPECT().
+		RecordUsageFromTokenUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Maybe()
+
+	tester.handler.OCR(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"raw_result"`)
+	assert.Contains(t, w.Body.String(), `"logId"`)
+}

--- a/aigateway/http/response/wrapper/ocr.go
+++ b/aigateway/http/response/wrapper/ocr.go
@@ -1,0 +1,137 @@
+package wrapper
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"opencsg.com/csghub-server/aigateway/component/adapter/ocr"
+	"opencsg.com/csghub-server/aigateway/token"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+// OCR buffers the upstream OCR runtime response, then normalizes it into the
+// AIGateway OCR response shape in Finalize. Upstream error responses (status
+// >= 400) are passed through unchanged.
+type OCR struct {
+	internalWritter gin.ResponseWriter
+	adapter         ocr.Adapter
+	counter         *token.OCRUsageCounter
+	opts            *ocr.ResponseOptions
+	buffer          bytes.Buffer
+	statusCode      int
+	contentType     string
+	headerWritten   bool
+	response        *types.OCRResponse
+}
+
+func NewOCR(
+	w gin.ResponseWriter,
+	adapter ocr.Adapter,
+	counter *token.OCRUsageCounter,
+	opts *ocr.ResponseOptions,
+) *OCR {
+	return &OCR{
+		internalWritter: w,
+		adapter:         adapter,
+		counter:         counter,
+		opts:            opts,
+		statusCode:      http.StatusOK,
+	}
+}
+
+func (w *OCR) Header() http.Header {
+	return w.internalWritter.Header()
+}
+
+func (w *OCR) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+	w.contentType = w.internalWritter.Header().Get("Content-Type")
+}
+
+func (w *OCR) Write(data []byte) (int, error) {
+	return w.buffer.Write(data)
+}
+
+func (w *OCR) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.internalWritter.Hijack()
+}
+
+func (w *OCR) CloseNotify() <-chan bool {
+	return w.internalWritter.CloseNotify()
+}
+
+func (w *OCR) Flush() {
+	w.internalWritter.Flush()
+}
+
+func (w *OCR) Finalize() error {
+	if w.headerWritten {
+		return nil
+	}
+	w.headerWritten = true
+
+	body := w.buffer.Bytes()
+	if w.statusCode >= http.StatusBadRequest {
+		// Pass upstream errors through unchanged.
+		h := w.internalWritter.Header()
+		if w.contentType != "" {
+			h.Set("Content-Type", w.contentType)
+		}
+		h.Set("Content-Length", strconv.Itoa(len(body)))
+		w.internalWritter.WriteHeader(w.statusCode)
+		_, err := w.internalWritter.Write(body)
+		return err
+	}
+
+	ocrResp, err := w.adapter.TransformResponse(body, w.opts)
+	if err != nil {
+		w.statusCode = http.StatusInternalServerError
+		w.internalWritter.Header().Set("Content-Type", "application/json")
+		w.internalWritter.WriteHeader(http.StatusInternalServerError)
+		return json.NewEncoder(w.internalWritter).Encode(gin.H{"error": types.Error{
+			Code:    "upstream_response_error",
+			Message: err.Error(),
+			Type:    "internal_error",
+		}})
+	}
+
+	if w.counter != nil {
+		w.counter.OCRResponse(ocrResp)
+	}
+	w.response = ocrResp
+
+	out, err := json.Marshal(ocrResp)
+	if err != nil {
+		w.statusCode = http.StatusInternalServerError
+		w.internalWritter.Header().Set("Content-Type", "application/json")
+		w.internalWritter.WriteHeader(http.StatusInternalServerError)
+		return err
+	}
+
+	h := w.internalWritter.Header()
+	h.Set("Content-Type", "application/json")
+	h.Del("Content-Encoding")
+	h.Set("Content-Length", strconv.Itoa(len(out)))
+	w.internalWritter.WriteHeader(w.statusCode)
+	_, err = w.internalWritter.Write(out)
+	return err
+}
+
+func (w *OCR) StatusCode() int {
+	if w == nil || w.statusCode == 0 {
+		return http.StatusOK
+	}
+	return w.statusCode
+}
+
+func (w *OCR) Response() *types.OCRResponse {
+	if w == nil {
+		return nil
+	}
+	return w.response
+}

--- a/aigateway/http/response/wrapper/ocr_test.go
+++ b/aigateway/http/response/wrapper/ocr_test.go
@@ -1,0 +1,137 @@
+package wrapper
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/component/adapter/ocr"
+	"opencsg.com/csghub-server/aigateway/token"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+const ocrUpstreamOKBody = `{
+  "logId": "log-1",
+  "errorCode": 0,
+  "errorMsg": "Success",
+  "result": {
+    "ocrResults": [
+      {"prunedResult": {"rec_texts": ["hello"], "rec_scores": [0.99], "rec_polys": [[[1,2],[50,2],[50,20],[1,20]]]}}
+    ]
+  }
+}`
+
+func newOCRTestGinWriter(recorder *httptest.ResponseRecorder) gin.ResponseWriter {
+	w, _ := gin.CreateTestContext(recorder)
+	return w.Writer
+}
+
+func TestOCRWrapper_TransformOnSuccess(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	ginWriter := newOCRTestGinWriter(recorder)
+	counter := token.NewOCRUsageCounter()
+
+	w := NewOCR(ginWriter, ocr.NewPaddleXAdapter(), counter, &ocr.ResponseOptions{ModelID: "owner/m:1"})
+
+	ginWriter.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write([]byte(ocrUpstreamOKBody))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var resp types.OCRResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+	assert.Equal(t, types.OCRResponseObject, resp.Object)
+	assert.Equal(t, "owner/m:1", resp.Model)
+	assert.Equal(t, "hello", resp.Text)
+	require.Len(t, resp.Pages, 1)
+	assert.Nil(t, resp.RawResult)
+
+	usage, err := counter.Usage(t.Context())
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, usage.CompletionRC)
+	assert.Equal(t, "ocr", usage.DataType)
+
+	assert.Equal(t, http.StatusOK, w.StatusCode())
+	assert.NotNil(t, w.Response())
+}
+
+func TestOCRWrapper_PassthroughOnUpstreamError(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	ginWriter := newOCRTestGinWriter(recorder)
+	counter := token.NewOCRUsageCounter()
+
+	w := NewOCR(ginWriter, ocr.NewPaddleXAdapter(), counter, &ocr.ResponseOptions{})
+
+	errBody := `{"error": "upstream exploded"}`
+	ginWriter.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	_, err := w.Write([]byte(errBody))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.Equal(t, errBody, recorder.Body.String())
+
+	// no usage recorded on failure
+	_, err = counter.Usage(t.Context())
+	require.Error(t, err)
+}
+
+func TestOCRWrapper_TransformFailure(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	ginWriter := newOCRTestGinWriter(recorder)
+
+	w := NewOCR(ginWriter, ocr.NewPaddleXAdapter(), token.NewOCRUsageCounter(), &ocr.ResponseOptions{})
+
+	ginWriter.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write([]byte(`not-json`))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+
+	var errResp map[string]types.Error
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &errResp))
+	assert.Equal(t, "upstream_response_error", errResp["error"].Code)
+}
+
+func TestOCRWrapper_UpstreamErrorCodeInBody(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	ginWriter := newOCRTestGinWriter(recorder)
+
+	w := NewOCR(ginWriter, ocr.NewPaddleXAdapter(), token.NewOCRUsageCounter(), &ocr.ResponseOptions{})
+
+	ginWriter.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write([]byte(`{"errorCode": 101, "errorMsg": "bad image"}`))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+
+	// upstream returned 200 but an OCR error envelope -> treated as transform failure
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "upstream_response_error")
+}
+
+func TestOCRWrapper_FinalizeIdempotent(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	ginWriter := newOCRTestGinWriter(recorder)
+
+	w := NewOCR(ginWriter, ocr.NewPaddleXAdapter(), token.NewOCRUsageCounter(), &ocr.ResponseOptions{})
+
+	ginWriter.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write([]byte(ocrUpstreamOKBody))
+	require.NoError(t, err)
+	require.NoError(t, w.Finalize())
+	firstLen := recorder.Body.Len()
+	require.NoError(t, w.Finalize())
+	assert.Equal(t, firstLen, recorder.Body.Len())
+}

--- a/aigateway/router/aigateway.go
+++ b/aigateway/router/aigateway.go
@@ -86,6 +86,7 @@ func NewRouter(config *config.Config) (*gin.Engine, func(), error) {
 	v1Group.PUT("/audio/voices", middlewareCollection.Auth.MustUserOrgApiKey, modalAPIRateLimiter, openAIhandler.UpdateVoice)
 	v1Group.DELETE("/audio/voices/:name", middlewareCollection.Auth.MustUserOrgApiKey, modalAPIRateLimiter, openAIhandler.DeleteVoice)
 	v1Group.POST("/videos", middlewareCollection.Auth.MustUserOrgApiKey, modalAPIRateLimiter, openAIhandler.CreateVideo)
+	v1Group.POST("/ocr", middlewareCollection.Auth.MustUserOrgApiKey, modalAPIRateLimiter, openAIhandler.OCR)
 	v1Group.GET("/videos/:video_id", middlewareCollection.Auth.MustUserOrgApiKey, openAIhandler.GetVideo)
 	v1Group.GET("/videos/:video_id/content", middlewareCollection.Auth.MustUserOrgApiKey, modalAPIRateLimiter, openAIhandler.GetVideoContent)
 

--- a/aigateway/token/ocr_usage_counter.go
+++ b/aigateway/token/ocr_usage_counter.go
@@ -1,0 +1,58 @@
+package token
+
+import (
+	"context"
+	"fmt"
+
+	"opencsg.com/csghub-server/aigateway/types"
+	commontypes "opencsg.com/csghub-server/common/types"
+)
+
+var _ Counter = (*OCRUsageCounter)(nil)
+
+// OCRUsageCounter derives OCR usage from the normalized OCR response.
+// Pages are the billing unit; recognized text must never be recorded here.
+type OCRUsageCounter struct {
+	usage  *Usage
+	images int64
+	pages  int64
+}
+
+func NewOCRUsageCounter() *OCRUsageCounter {
+	return &OCRUsageCounter{images: 1, pages: 1}
+}
+
+func (c *OCRUsageCounter) SetRequestDetails(images, pages int64) {
+	if images > 0 {
+		c.images = images
+	}
+	if pages > 0 {
+		c.pages = pages
+	}
+}
+
+func (c *OCRUsageCounter) OCRResponse(resp *types.OCRResponse) {
+	if resp == nil {
+		return
+	}
+	pages := int64(resp.Usage.Pages)
+	if pages <= 0 {
+		pages = c.pages
+	}
+	images := int64(resp.Usage.Images)
+	if images <= 0 {
+		images = c.images
+	}
+	c.usage = &Usage{
+		DataType:       string(commontypes.DataTypeOCR),
+		CompletionRC:   pages,
+		CompletionDesc: fmt.Sprintf("pages=%d,images=%d", pages, images),
+	}
+}
+
+func (c *OCRUsageCounter) Usage(_ context.Context) (*Usage, error) {
+	if c.usage == nil {
+		return nil, fmt.Errorf("no usage data available")
+	}
+	return c.usage, nil
+}

--- a/aigateway/token/ocr_usage_counter_test.go
+++ b/aigateway/token/ocr_usage_counter_test.go
@@ -1,0 +1,49 @@
+package token
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/types"
+	commontypes "opencsg.com/csghub-server/common/types"
+)
+
+func TestOCRUsageCounter_UsageFromResponse(t *testing.T) {
+	c := NewOCRUsageCounter()
+	c.OCRResponse(&types.OCRResponse{
+		Usage: types.OCRUsage{Pages: 3, Images: 1},
+	})
+
+	usage, err := c.Usage(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, string(commontypes.DataTypeOCR), usage.DataType)
+	assert.EqualValues(t, 3, usage.CompletionRC)
+	assert.Equal(t, "pages=3,images=1", usage.CompletionDesc)
+	assert.Zero(t, usage.TotalTokens)
+}
+
+func TestOCRUsageCounter_FallbackToRequestDetails(t *testing.T) {
+	c := NewOCRUsageCounter()
+	c.SetRequestDetails(2, 5)
+	c.OCRResponse(&types.OCRResponse{})
+
+	usage, err := c.Usage(context.Background())
+	require.NoError(t, err)
+	assert.EqualValues(t, 5, usage.CompletionRC)
+	assert.Equal(t, "pages=5,images=2", usage.CompletionDesc)
+}
+
+func TestOCRUsageCounter_ErrorBeforeResponse(t *testing.T) {
+	c := NewOCRUsageCounter()
+	_, err := c.Usage(context.Background())
+	require.Error(t, err)
+}
+
+func TestOCRUsageCounter_NilResponse(t *testing.T) {
+	c := NewOCRUsageCounter()
+	c.OCRResponse(nil)
+	_, err := c.Usage(context.Background())
+	require.Error(t, err)
+}

--- a/aigateway/types/ocr.go
+++ b/aigateway/types/ocr.go
@@ -1,0 +1,62 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// OCR object type returned in OCRResponse.Object.
+const OCRResponseObject = "ocr.result"
+
+// NewOCRResponseID generates the public id for an OCR result, mirroring the
+// id style used by other AIGateway response objects.
+func NewOCRResponseID() string {
+	return fmt.Sprintf("ocr_%s", strings.ReplaceAll(uuid.NewString(), "-", ""))
+}
+
+// OCRRequest carries the normalized multipart form values of a /v1/ocr call.
+type OCRRequest struct {
+	Model                     string
+	PageRanges                string
+	UseDocOrientationClassify *bool
+	UseDocUnwarping           *bool
+	UseTextlineOrientation    *bool
+	ReturnImage               bool
+	RawResponse               bool
+}
+
+// OCRResponse is the AIGateway-owned normalized OCR result.
+type OCRResponse struct {
+	ID        string    `json:"id"`
+	Object    string    `json:"object"`
+	Created   int64     `json:"created"`
+	Model     string    `json:"model"`
+	Text      string    `json:"text"`
+	Pages     []OCRPage `json:"pages"`
+	Usage     OCRUsage  `json:"usage"`
+	RawResult any       `json:"raw_result,omitempty"`
+}
+
+// OCRPage is the recognized content of a single page or image.
+type OCRPage struct {
+	Index    int       `json:"index"`
+	Text     string    `json:"text"`
+	Markdown string    `json:"markdown,omitempty"`
+	Lines    []OCRLine `json:"lines"`
+	ImageURL string    `json:"image_url,omitempty"`
+}
+
+// OCRLine is one recognized text line with its confidence and bounding box.
+type OCRLine struct {
+	Text  string   `json:"text"`
+	Score *float64 `json:"score,omitempty"`
+	BBox  any      `json:"bbox,omitempty"`
+}
+
+// OCRUsage reports the billable dimensions of an OCR request.
+type OCRUsage struct {
+	Pages  int `json:"pages"`
+	Images int `json:"images"`
+}

--- a/aigateway/types/ocr_test.go
+++ b/aigateway/types/ocr_test.go
@@ -1,0 +1,104 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOCRResponse_JSONShape(t *testing.T) {
+	score := 0.98
+	resp := OCRResponse{
+		ID:      "ocr_abc123",
+		Object:  OCRResponseObject,
+		Created: 1760000000,
+		Model:   "owner/paddleocr-demo:abc123",
+		Text:    "recognized full text",
+		Pages: []OCRPage{
+			{
+				Index: 0,
+				Text:  "recognized page text",
+				Lines: []OCRLine{
+					{
+						Text:  "line text",
+						Score: &score,
+						BBox:  [][]int{{10, 20}, {200, 20}, {200, 40}, {10, 40}},
+					},
+				},
+			},
+		},
+		Usage: OCRUsage{Pages: 1, Images: 1},
+	}
+
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, "ocr_abc123", got["id"])
+	assert.Equal(t, "ocr.result", got["object"])
+	assert.Equal(t, "owner/paddleocr-demo:abc123", got["model"])
+	assert.Equal(t, "recognized full text", got["text"])
+
+	pages, ok := got["pages"].([]any)
+	require.True(t, ok)
+	require.Len(t, pages, 1)
+	page := pages[0].(map[string]any)
+	assert.Equal(t, "recognized page text", page["text"])
+
+	lines, ok := page["lines"].([]any)
+	require.True(t, ok)
+	require.Len(t, lines, 1)
+	line := lines[0].(map[string]any)
+	assert.Equal(t, "line text", line["text"])
+	assert.InDelta(t, 0.98, line["score"], 1e-9)
+
+	usage := got["usage"].(map[string]any)
+	assert.EqualValues(t, 1, usage["pages"])
+	assert.EqualValues(t, 1, usage["images"])
+}
+
+func TestOCRResponse_OmitsOptionalFields(t *testing.T) {
+	resp := OCRResponse{
+		ID:     "ocr_x",
+		Object: OCRResponseObject,
+		Pages: []OCRPage{
+			{Index: 0, Text: "t", Lines: []OCRLine{{Text: "l"}}},
+		},
+		Usage: OCRUsage{Pages: 1, Images: 1},
+	}
+
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+	s := string(data)
+
+	assert.NotContains(t, s, "raw_result")
+	assert.NotContains(t, s, "markdown")
+	assert.NotContains(t, s, "image_url")
+	assert.NotContains(t, s, "score")
+	assert.NotContains(t, s, "bbox")
+}
+
+func TestOCRResponse_RawResultIncludedWhenSet(t *testing.T) {
+	resp := OCRResponse{
+		ID:        "ocr_x",
+		Object:    OCRResponseObject,
+		RawResult: map[string]any{"logId": "123"},
+	}
+
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"raw_result"`)
+	assert.Contains(t, string(data), `"logId"`)
+}
+
+func TestNewOCRResponseID(t *testing.T) {
+	id := NewOCRResponseID()
+	assert.True(t, strings.HasPrefix(id, "ocr_"))
+	assert.NotContains(t, id, "-")
+	assert.Len(t, id, len("ocr_")+32)
+}

--- a/builder/store/database/migrations/20260720132047_add_optical_character_recognition_tag.down.sql
+++ b/builder/store/database/migrations/20260720132047_add_optical_character_recognition_tag.down.sql
@@ -1,0 +1,8 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+DELETE FROM tags
+WHERE name = 'optical-character-recognition'
+  AND scope = 'model'
+  AND built_in = TRUE;

--- a/builder/store/database/migrations/20260720132047_add_optical_character_recognition_tag.up.sql
+++ b/builder/store/database/migrations/20260720132047_add_optical_character_recognition_tag.up.sql
@@ -1,0 +1,27 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+INSERT INTO tags (
+    name,
+    category,
+    "group",
+    scope,
+    show_name,
+    i18n_key,
+    built_in
+)
+SELECT
+    'optical-character-recognition',
+    'task',
+    'computer_vision',
+    'model',
+    '光学字符识别',
+    'optical-character-recognition',
+    TRUE
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM tags
+    WHERE name = 'optical-character-recognition'
+      AND scope = 'model'
+);

--- a/builder/store/database/migrations/seeds/tags.yml
+++ b/builder/store/database/migrations/seeds/tags.yml
@@ -19,6 +19,12 @@ tags:
   built_in: true
 - category: task
   group: computer_vision
+  name: optical-character-recognition
+  scope: model
+  show_name: 光学字符识别
+  built_in: true
+- category: task
+  group: computer_vision
   name: skin-retouching
   scope: model
   show_name: 人像美肤

--- a/common/i18n/en-US/tags.json
+++ b/common/i18n/en-US/tags.json
@@ -95,6 +95,9 @@
   "Tag.I18nKey.automatic-speech-recognition": {
     "other": "automatic speech recognition"
   },
+  "Tag.I18nKey.optical-character-recognition": {
+    "other": "optical character recognition"
+  },
   "Tag.I18nKey.text-to-speech": {
     "other": "text to speech"
   },

--- a/common/i18n/zh-CN/tags.json
+++ b/common/i18n/zh-CN/tags.json
@@ -95,6 +95,9 @@
   "Tag.I18nKey.automatic-speech-recognition": {
     "other": "自动语音识别"
   },
+  "Tag.I18nKey.optical-character-recognition": {
+    "other": "光学字符识别"
+  },
   "Tag.I18nKey.text-to-speech": {
     "other": "文本转语音"
   },

--- a/common/i18n/zh-HK/tags.json
+++ b/common/i18n/zh-HK/tags.json
@@ -95,6 +95,9 @@
     "Tag.I18nKey.automatic-speech-recognition": {
         "other": "自動語音辨識"
     },
+    "Tag.I18nKey.optical-character-recognition": {
+        "other": "光學字符識別"
+    },
     "Tag.I18nKey.text-to-speech": {
         "other": "文本轉語音"
     },

--- a/common/types/accounting.go
+++ b/common/types/accounting.go
@@ -34,11 +34,12 @@ const (
 	DataTypeImage DataType = "image"
 	DataTypeAudio DataType = "audio"
 	DataTypeVideo DataType = "video"
+	DataTypeOCR   DataType = "ocr"
 )
 
 func (d DataType) IsMultiModal() bool {
 	switch d {
-	case DataTypeImage, DataTypeAudio, DataTypeVideo:
+	case DataTypeImage, DataTypeAudio, DataTypeVideo, DataTypeOCR:
 		return true
 	default:
 		return false
@@ -131,7 +132,7 @@ var (
 	SceneMultiSync            SceneType = 13 // multi source sync
 	SceneEvaluation           SceneType = 14 // model evaluation
 	SceneModelServerless      SceneType = 15 // serverless and external model from aigateway
-	SceneMultiModalServerless SceneType = 16 // Multi modal model from aigateway for image/audio/video
+	SceneMultiModalServerless SceneType = 16 // Multi modal model from aigateway for image/audio/video/ocr
 	// starship
 	SceneStarship SceneType = 20 // starship is deprecated
 	SceneGuiAgent SceneType = 22 // gui agent is deprecated

--- a/common/types/repo.go
+++ b/common/types/repo.go
@@ -122,11 +122,12 @@ const (
 	TextToAudio        PipelineTask = "text-to-audio"
 	// AutomaticSpeechRecognition is the Hugging Face pipeline task name. Keep
 	// AutoSpeechRecognition as a legacy tag alias for existing seeded data.
-	AutomaticSpeechRecognition PipelineTask    = "automatic-speech-recognition"
-	AutoSpeechRecognition      PipelineTask    = "auto-speech-recognition"
-	LlamaCpp                   InferenceEngine = "llama.cpp"
-	TEI                        InferenceEngine = "tei"
-	Ktransformers              InferenceEngine = "ktransformers"
+	AutomaticSpeechRecognition  PipelineTask    = "automatic-speech-recognition"
+	AutoSpeechRecognition       PipelineTask    = "auto-speech-recognition"
+	OpticalCharacterRecognition PipelineTask    = "optical-character-recognition"
+	LlamaCpp                    InferenceEngine = "llama.cpp"
+	TEI                         InferenceEngine = "tei"
+	Ktransformers               InferenceEngine = "ktransformers"
 
 	MaxFileTreeSize int = 500
 )

--- a/component/callback/git_callback.go
+++ b/component/callback/git_callback.go
@@ -617,6 +617,9 @@ func GetPipelineTaskFromTags(tags []database.Tag) types.PipelineTask {
 		if tag.Name == string(types.AutomaticSpeechRecognition) || tag.Name == string(types.AutoSpeechRecognition) {
 			return types.AutomaticSpeechRecognition
 		}
+		if tag.Name == string(types.OpticalCharacterRecognition) {
+			return types.OpticalCharacterRecognition
+		}
 	}
 	return ""
 }

--- a/component/callback/git_callback_test.go
+++ b/component/callback/git_callback_test.go
@@ -58,6 +58,12 @@ func TestGetPipelineTaskFromTags_TextToAudio(t *testing.T) {
 	require.Equal(t, types.TextToAudio, task)
 }
 
+func TestGetPipelineTaskFromTags_OCR(t *testing.T) {
+	task := GetPipelineTaskFromTags([]database.Tag{{Name: string(types.OpticalCharacterRecognition)}})
+
+	require.Equal(t, types.OpticalCharacterRecognition, task)
+}
+
 func TestGitCallbackComponent_WatchSpaceChange(t *testing.T) {
 	ctx := mock.Anything
 	gc := initializeTestGitCallbackComponent(context.TODO(), t)

--- a/configs/inference/paddleocr.json
+++ b/configs/inference/paddleocr.json
@@ -1,0 +1,34 @@
+{
+  "engine_name": "paddleocr",
+  "enabled": 1,
+  "container_port": 8000,
+  "model_format": "paddle_static",
+  "description": "PaddleOCR/PaddleX self-hosted OCR serving runtime",
+  "engine_images": [
+    {
+      "compute_type": "gpu",
+      "image": "opencsghq/paddleocr:3.7.0",
+      "driver_version": "12.8",
+      "engine_version": "3.7.0"
+    },
+    {
+      "compute_type": "cpu",
+      "image": "opencsghq/paddleocr-cpu:3.7.0",
+      "engine_version": "3.7.0"
+    }
+  ],
+  "supported_archs": [
+    "PaddleOCRPipeline",
+    "OCR"
+  ],
+  "supported_models": [
+    "PP-OCRv6_tiny_rec",
+    "PP-OCRv6_small_rec",
+    "PP-OCRv6_medium_rec",
+    "PP-OCRv5_server_rec",
+    "PP-OCRv5_mobile_rec",
+    "latin_PP-OCRv5_mobile_rec",
+    "korean_PP-OCRv5_mobile_rec",
+    "eslav_PP-OCRv5_mobile_rec"
+  ]
+}

--- a/docker/inference/Dockerfile.paddleocr
+++ b/docker/inference/Dockerfile.paddleocr
@@ -1,0 +1,39 @@
+FROM docker.m.daocloud.io/pytorch/pytorch:2.9.1-cuda12.8-cudnn9-devel
+SHELL ["/bin/bash", "-c"]
+
+LABEL maintainer="opencsg"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    git \
+    git-lfs \
+    libgl1 \
+    libglib2.0-0 \
+    dumb-init && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /etc/csghub
+# huggingface-hub pinned <1.0: hf_hub 1.x snapshot_download lists files via the
+# /tree API, which CSGHub's /hf endpoint does not implement (0.x uses
+# model_info + siblings, which works).
+RUN pip config set global.index-url https://mirrors.aliyun.com/pypi/simple && \
+    pip install --no-cache-dir paddlepaddle-gpu==3.3.1 \
+        -i https://www.paddlepaddle.org.cn/packages/stable/cu126/ \
+        --extra-index-url https://mirrors.aliyun.com/pypi/simple && \
+    pip install --no-cache-dir paddleocr==3.7.0 "paddlex[serving]==3.7.2" csghub-sdk==0.7.10 \
+        huggingface-hub==0.36.2
+
+COPY ./paddleocr/ /etc/csghub/
+RUN chmod +x /etc/csghub/*.sh
+
+WORKDIR /workspace/
+ENV HUGGINGFACE_HUB_CACHE=/workspace/ \
+    HF_HUB_ENABLE_HF_TRANSFER=0 \
+    PADDLEOCR_DEVICE=gpu
+
+EXPOSE 8000
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/etc/csghub/serve.sh"]

--- a/docker/inference/Dockerfile.paddleocr-cpu
+++ b/docker/inference/Dockerfile.paddleocr-cpu
@@ -1,0 +1,44 @@
+FROM docker.m.daocloud.io/python:3.10-slim
+SHELL ["/bin/bash", "-c"]
+
+LABEL maintainer="opencsg"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN sed -i \
+        -e 's|http://deb.debian.org/debian|http://mirrors.aliyun.com/debian|g' \
+        -e 's|http://security.debian.org/debian-security|http://mirrors.aliyun.com/debian-security|g' \
+        /etc/apt/sources.list.d/debian.sources && \
+    apt-get update && \
+    apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    git-lfs \
+    libgl1 \
+    libglib2.0-0 \
+    dumb-init && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /etc/csghub
+# paddlepaddle pinned to 3.2.2: 3.3.1 crashes on CPU in the PIR executor + oneDNN
+# path (PaddleOCR issue #18162, official workaround until PaddlePaddle fixes it)
+# huggingface-hub pinned <1.0: hf_hub 1.x snapshot_download lists files via the
+# /tree API, which CSGHub's /hf endpoint does not implement (0.x uses
+# model_info + siblings, which works).
+RUN pip config set global.index-url https://mirrors.aliyun.com/pypi/simple && \
+    pip install --no-cache-dir paddlepaddle==3.2.2 && \
+    pip install --no-cache-dir paddleocr==3.7.0 "paddlex[serving]==3.7.2" csghub-sdk==0.7.10 \
+        huggingface-hub==0.36.2
+
+COPY ./paddleocr/ /etc/csghub/
+RUN chmod +x /etc/csghub/*.sh
+
+WORKDIR /workspace/
+ENV HUGGINGFACE_HUB_CACHE=/workspace/ \
+    HF_HUB_ENABLE_HF_TRANSFER=0 \
+    PADDLEOCR_DEVICE=cpu
+
+EXPOSE 8000
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/etc/csghub/serve.sh"]

--- a/docker/inference/README.md
+++ b/docker/inference/README.md
@@ -91,6 +91,19 @@ docker buildx build --platform linux/amd64,linux/arm64 \
   -t ${OPENCSG_ACR}/opencsghq/funasr-cpu:${IMAGE_TAG} \
   -f Dockerfile.funasr-cpu \
   --push .
+# For PaddleOCR CUDA: opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/paddleocr:3.7.0
+export IMAGE_TAG=3.7.0
+docker buildx build --platform linux/amd64 \
+  -t ${OPENCSG_ACR}/opencsghq/paddleocr:${IMAGE_TAG} \
+  -f Dockerfile.paddleocr \
+  --push .
+# For PaddleOCR CPU: opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/paddleocr-cpu:3.7.0
+# (paddlepaddle pinned to 3.2.2: 3.3.1 crashes on CPU in the oneDNN path, PaddleOCR issue #18162)
+export IMAGE_TAG=3.7.0
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t ${OPENCSG_ACR}/opencsghq/paddleocr-cpu:${IMAGE_TAG} \
+  -f Dockerfile.paddleocr-cpu \
+  --push .
 # For Diffusers image generation and editing: opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/diffusers:0.39.0
 export IMAGE_TAG=0.39.0
 docker buildx build --platform linux/amd64 \

--- a/docker/inference/build.sh
+++ b/docker/inference/build.sh
@@ -58,6 +58,13 @@ case "${IMAGE%:*}" in
     PLATFORMS="linux/amd64"
     DOCKERFILE="Dockerfile.audiofly-rocm"
     ;;
+  paddleocr)
+    PLATFORMS="linux/amd64"
+    DOCKERFILE="Dockerfile.paddleocr"
+    ;;
+  paddleocr-cpu)
+    DOCKERFILE="Dockerfile.paddleocr-cpu"
+    ;;
 esac
 
 docker buildx build --platform ${PLATFORMS} \

--- a/docker/inference/paddleocr/entry.py
+++ b/docker/inference/paddleocr/entry.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import os
+import time
+
+from pycsghub.snapshot_download import snapshot_download
+from requests.exceptions import ConnectionError, HTTPError
+
+
+DOWNLOAD_DIR = "/workspace"
+REPO_ID = os.environ["REPO_ID"]
+REVISION = os.getenv("REVISION", "main")
+TOKEN = os.environ["ACCESS_TOKEN"]
+ENDPOINT = os.environ["HF_ENDPOINT"]
+os.environ["CSGHUB_DOMAIN"] = ENDPOINT
+
+max_retries = 15
+retry_count = 0
+local_dir = Path(DOWNLOAD_DIR) / REPO_ID
+
+while retry_count < max_retries:
+    try:
+        snapshot_download(
+            REPO_ID,
+            cache_dir=DOWNLOAD_DIR,
+            local_dir=local_dir,
+            endpoint=ENDPOINT,
+            token=TOKEN,
+            revision=REVISION,
+        )
+        break
+    except (ConnectionError, HTTPError) as e:
+        retry_count += 1
+        print(f"exception occurred: {e}. Retrying in 10 seconds... (Attempt {retry_count}/{max_retries})")
+        time.sleep(10)
+
+if not local_dir.exists():
+    raise RuntimeError(f"model download failed: {REPO_ID} was not downloaded to {local_dir}")

--- a/docker/inference/paddleocr/gen_pipeline.py
+++ b/docker/inference/paddleocr/gen_pipeline.py
@@ -1,0 +1,47 @@
+"""Patch a PaddleX OCR pipeline config to use the downloaded repo's weights.
+
+The CSGHub repo is a single recognition model (e.g. PP-OCRv6_small_rec):
+TextRecognition is pointed at the local weights and TextDetection is switched
+to the matching-tier det model name (still resolved from the model sources).
+Language-prefixed rec repos (latin_/korean_/eslav_) map to the unprefixed det.
+"""
+
+import argparse
+
+import yaml
+
+LANG_PREFIXES = ("latin_", "korean_", "eslav_")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--rec-name", required=True)
+    parser.add_argument("--rec-dir", required=True)
+    args = parser.parse_args()
+
+    with open(args.config) as f:
+        cfg = yaml.safe_load(f)
+
+    sub_modules = cfg.get("SubModules", {})
+
+    if "TextRecognition" in sub_modules:
+        sub_modules["TextRecognition"]["model_name"] = args.rec_name
+        sub_modules["TextRecognition"]["model_dir"] = args.rec_dir
+
+    det_name = args.rec_name
+    for prefix in LANG_PREFIXES:
+        if det_name.startswith(prefix):
+            det_name = det_name[len(prefix):]
+            break
+    det_name = det_name.replace("_rec", "_det")
+    if "TextDetection" in sub_modules and det_name != args.rec_name:
+        sub_modules["TextDetection"]["model_name"] = det_name
+        sub_modules["TextDetection"]["model_dir"] = None
+
+    with open(args.config, "w") as f:
+        yaml.safe_dump(cfg, f, sort_keys=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/inference/paddleocr/serve.sh
+++ b/docker/inference/paddleocr/serve.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+python /etc/csghub/entry.py
+
+PORT="${PORT:-8000}"
+DEVICE="${PADDLEOCR_DEVICE:-${DEVICE:-cpu}}"
+MODEL_DIR="/workspace/${REPO_ID}"
+MODEL_SOURCE="${PADDLEOCR_MODEL_SOURCE:-hub}"
+
+# Default ("hub"): sub-models are resolved by name from the HF-compatible
+# endpoint given by HF_ENDPOINT (PaddleX's HuggingFace hoster), with
+# PaddleX's built-in failover to its other official hosters when a sub-model
+# is missing there. "local-only" is the strict offline mode for air-gapped
+# deployments: no external sources, and the model repo must be a self-
+# contained PaddleX pipeline bundle.
+if [ "${MODEL_SOURCE}" = "local-only" ]; then
+  export PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK=True
+elif [ "${MODEL_SOURCE}" = "hub" ]; then
+  # CSGHub serves its HuggingFace-compatible API under the /hf subpath, so
+  # PaddleX's HF hoster must use ${HF_ENDPOINT}/hf, not ${HF_ENDPOINT}.
+  export PADDLE_PDX_HUGGING_FACE_ENDPOINT="${PADDLE_PDX_HUGGING_FACE_ENDPOINT:-${HF_ENDPOINT%/}/hf}"
+  export PADDLE_PDX_MODEL_SOURCE=huggingface
+  export HF_TOKEN="${HF_TOKEN:-${ACCESS_TOKEN}}"
+else
+  echo "ERROR: unknown PADDLEOCR_MODEL_SOURCE '${MODEL_SOURCE}' (expected hub|local-only)" >&2
+  exit 1
+fi
+
+PIPELINE="${PADDLEX_PIPELINE:-}"
+if [ -z "${PIPELINE}" ]; then
+  if [ -f "${MODEL_DIR}/pipeline.yaml" ]; then
+    PIPELINE="${MODEL_DIR}/pipeline.yaml"
+  elif [ -f "${MODEL_DIR}/OCR.yaml" ]; then
+    PIPELINE="${MODEL_DIR}/OCR.yaml"
+  elif [ "${MODEL_SOURCE}" = "local-only" ]; then
+    echo "ERROR: ${MODEL_DIR} contains no pipeline.yaml/OCR.yaml and PADDLEOCR_MODEL_SOURCE=local-only." >&2
+    echo "The model repo must be a PaddleX pipeline bundle (pipeline.yaml + local model_dir subdirs)." >&2
+    exit 1
+  else
+    REC_NAME="$(basename "${REPO_ID}")"
+    if [ -f "${MODEL_DIR}/inference.pdiparams" ] && [[ "${REC_NAME}" == *_rec ]]; then
+      # The repo is a single recognition model: generate the OCR pipeline
+      # config and point TextRecognition at the local weights (det/cls
+      # sub-models are still resolved by name from the model sources).
+      GEN_DIR="${MODEL_DIR}/.csghub"
+      paddlex --get_pipeline_config OCR --save_path "${GEN_DIR}"
+      PIPELINE="$(find "${GEN_DIR}" -name '*.yaml' | head -1)"
+      python /etc/csghub/gen_pipeline.py --config "${PIPELINE}" --rec-name "${REC_NAME}" --rec-dir "${MODEL_DIR}"
+    else
+      # Sub-models are resolved by name from the configured model sources.
+      PIPELINE="OCR"
+    fi
+  fi
+fi
+
+echo "Starting PaddleX serving: pipeline=${PIPELINE} device=${DEVICE} port=${PORT} model_source=${MODEL_SOURCE}"
+
+exec paddlex --serve \
+    --pipeline "${PIPELINE}" \
+    --host 0.0.0.0 \
+    --port "${PORT}" \
+    --device "${DEVICE}" \
+    ${ENGINE_ARGS:-}


### PR DESCRIPTION
Summary:
- Adds a new `POST /v1/ocr` endpoint and PaddleX serving runtime to enable OCR inference capabilities within AIGateway, supporting direct deployment of PaddleOCR official recognition models.
- Implements a dedicated OCR adapter, response wrapper, and usage counter that normalizes PaddleX responses into `OCRResponse` format and tracks usage by page count for serverless billing.
- Introduces new inference configurations, Docker images (GPU/CPU), and pipeline logic to handle model source resolution via CSGHub's HF-compatible API and auto-generate detection/recognition pipelines for supported model variants.