### PR TITLE
Add target namespace check for change path

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_DataviewerStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_DataviewerStore.go
@@ -175,6 +175,65 @@ func (_c *MockDataviewerStore_GetJob_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
+// GetLastSuccessfulJobByRepoID provides a mock function with given fields: ctx, repoID
+func (_m *MockDataviewerStore) GetLastSuccessfulJobByRepoID(ctx context.Context, repoID int64) (*database.DataviewerJob, error) {
+	ret := _m.Called(ctx, repoID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLastSuccessfulJobByRepoID")
+	}
+
+	var r0 *database.DataviewerJob
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64) (*database.DataviewerJob, error)); ok {
+		return rf(ctx, repoID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int64) *database.DataviewerJob); ok {
+		r0 = rf(ctx, repoID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.DataviewerJob)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = rf(ctx, repoID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockDataviewerStore_GetLastSuccessfulJobByRepoID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLastSuccessfulJobByRepoID'
+type MockDataviewerStore_GetLastSuccessfulJobByRepoID_Call struct {
+	*mock.Call
+}
+
+// GetLastSuccessfulJobByRepoID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repoID int64
+func (_e *MockDataviewerStore_Expecter) GetLastSuccessfulJobByRepoID(ctx interface{}, repoID interface{}) *MockDataviewerStore_GetLastSuccessfulJobByRepoID_Call {
+	return &MockDataviewerStore_GetLastSuccessfulJobByRepoID_Call{Call: _e.mock.On("GetLastSuccessfulJobByRepoID", ctx, repoID)}
+}
+
+func (_c *MockDataviewerStore_GetLastSuccessfulJobByRepoID_Call) Run(run func(ctx context.Context, repoID int64)) *MockDataviewerStore_GetLastSuccessfulJobByRepoID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *MockDataviewerStore_GetLastSuccessfulJobByRepoID_Call) Return(_a0 *database.DataviewerJob, _a1 error) *MockDataviewerStore_GetLastSuccessfulJobByRepoID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockDataviewerStore_GetLastSuccessfulJobByRepoID_Call) RunAndReturn(run func(context.Context, int64) (*database.DataviewerJob, error)) *MockDataviewerStore_GetLastSuccessfulJobByRepoID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRunningJobsByRepoID provides a mock function with given fields: ctx, repoID
 func (_m *MockDataviewerStore) GetRunningJobsByRepoID(ctx context.Context, repoID int64) ([]database.DataviewerJob, error) {
 	ret := _m.Called(ctx, repoID)

--- a/api/handler/repo.go
+++ b/api/handler/repo.go
@@ -1958,7 +1958,7 @@ func (h *RepoHandler) ChangePath(ctx *gin.Context) {
 
 	err = h.c.ChangePath(ctx.Request.Context(), req)
 	if err != nil {
-		if errors.Is(err, errorx.ErrBadRequest) || errors.Is(err, errorx.ErrChangePathBlocked) {
+		if errors.Is(err, errorx.ErrBadRequest) || errors.Is(err, errorx.ErrChangePathBlocked) || errors.Is(err, errorx.ErrTargetNamespaceNotFound) {
 			slog.ErrorContext(ctx.Request.Context(), "invalid request", slog.Any("error", err))
 			httpbase.BadRequestWithExt(ctx, err)
 			return

--- a/builder/store/database/dataviewer.go
+++ b/builder/store/database/dataviewer.go
@@ -44,6 +44,7 @@ type DataviewerStore interface {
 	GetJob(ctx context.Context, workflowID string) (*DataviewerJob, error)
 	UpdateJob(ctx context.Context, job DataviewerJob) (*DataviewerJob, error)
 	GetRunningJobsByRepoID(ctx context.Context, repoID int64) ([]DataviewerJob, error)
+	GetLastSuccessfulJobByRepoID(ctx context.Context, repoID int64) (*DataviewerJob, error)
 }
 
 type dataviewerStoreImpl struct {
@@ -140,4 +141,21 @@ func (s *dataviewerStoreImpl) GetRunningJobsByRepoID(ctx context.Context, repoID
 		return nil, fmt.Errorf("select running viewer jobs by repo_id %d, error: %w", repoID, err)
 	}
 	return jobs, nil
+}
+
+func (s *dataviewerStoreImpl) GetLastSuccessfulJobByRepoID(ctx context.Context, repoID int64) (*DataviewerJob, error) {
+	var job DataviewerJob
+	err := s.db.Operator.Core.NewSelect().Model(&job).
+		Where("repo_id = ?", repoID).
+		Where("status = ?", types.WorkflowDone).
+		Order("id DESC").
+		Limit(1).
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("select last successful viewer job by repo_id %d, error: %w", repoID, err)
+	}
+	return &job, nil
 }

--- a/builder/store/database/dataviewer_test.go
+++ b/builder/store/database/dataviewer_test.go
@@ -89,3 +89,75 @@ func TestDataviewerStore_GetRunningJobsByRepoID(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, len(jobs), 2)
 }
+
+func TestDataviewerStore_GetLastSuccessfulJobByRepoID(t *testing.T) {
+	db := tests.InitTestDB()
+	defer db.Close()
+	ctx := context.TODO()
+
+	dv := database.NewDataViewerStoreWithDB(db)
+
+	// Create jobs with different statuses
+	jobPending := database.DataviewerJob{
+		RepoID:     1,
+		Status:     0, // WorkflowPending
+		WorkflowID: "pending-workflow",
+		CardData:   "pending-data",
+	}
+	jobRunning := database.DataviewerJob{
+		RepoID:     1,
+		Status:     1, // WorkflowRunning
+		WorkflowID: "running-workflow",
+		CardData:   "running-data",
+	}
+	jobDone := database.DataviewerJob{
+		RepoID:     1,
+		Status:     2, // WorkflowDone
+		WorkflowID: "done-workflow",
+		CardData:   "done-data",
+	}
+	jobFailed := database.DataviewerJob{
+		RepoID:     1,
+		Status:     3, // WorkflowFailed
+		WorkflowID: "failed-workflow",
+		CardData:   "failed-data",
+	}
+
+	err := dv.CreateJob(ctx, jobPending)
+	require.Nil(t, err)
+	err = dv.CreateJob(ctx, jobRunning)
+	require.Nil(t, err)
+	err = dv.CreateJob(ctx, jobDone)
+	require.Nil(t, err)
+	err = dv.CreateJob(ctx, jobFailed)
+	require.Nil(t, err)
+
+	// Should return only the last successful job (status=2)
+	job, err := dv.GetLastSuccessfulJobByRepoID(ctx, int64(1))
+	require.Nil(t, err)
+	require.NotNil(t, job)
+	require.Equal(t, 2, job.Status)
+	require.Equal(t, "done-workflow", job.WorkflowID)
+	require.Equal(t, "done-data", job.CardData)
+}
+
+func TestDataviewerStore_GetLastSuccessfulJobByRepoID_NoMatch(t *testing.T) {
+	db := tests.InitTestDB()
+	defer db.Close()
+	ctx := context.TODO()
+
+	dv := database.NewDataViewerStoreWithDB(db)
+
+	// Only pending and running jobs, no successful one
+	jobPending := database.DataviewerJob{
+		RepoID:     2,
+		Status:     0, // WorkflowPending
+		WorkflowID: "pending-workflow-2",
+	}
+	err := dv.CreateJob(ctx, jobPending)
+	require.Nil(t, err)
+
+	job, err := dv.GetLastSuccessfulJobByRepoID(ctx, int64(2))
+	require.Nil(t, err)
+	require.Nil(t, job) // Should return nil when no matching job
+}

--- a/component/repo.go
+++ b/component/repo.go
@@ -381,8 +381,8 @@ func (c *repoComponentImpl) UpdateRepo(ctx context.Context, req types.UpdateRepo
 				// Additional check if making the repository public.
 				if !*req.Private {
 					if err := c.allowPublic(repo); err != nil {
-					return nil, err
-				}
+						return nil, err
+					}
 				}
 				repo.Private = *req.Private
 			}
@@ -2927,6 +2927,15 @@ func (c *repoComponentImpl) ChangePath(ctx context.Context, req types.ChangePath
 		return fmt.Errorf("failed to get namespace and name from new path, error: %w", err)
 	}
 
+	// Check new namespace exists
+	nsExists, err := c.namespaceStore.Exists(ctx, newNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to check if new namespace exists, error: %w", err)
+	}
+	if !nsExists {
+		return errorx.TargetNamespaceNotFound(newNamespace)
+	}
+
 	// Check new path exists
 	_, err = c.repoStore.FindByPath(ctx, req.RepoType, newNamespace, newName)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -3043,11 +3052,11 @@ func (c *repoComponentImpl) checkChangePathDependencies(ctx context.Context, rep
 		return blocker
 	}
 	blocker = checkOne(func() (bool, error) {
-		v, err := c.dataviewerStore.GetViewerByRepoID(ctx, repo.ID)
-		if errors.Is(err, sql.ErrNoRows) {
-			return false, nil
+		job, err := c.dataviewerStore.GetLastSuccessfulJobByRepoID(ctx, repo.ID)
+		if err != nil || job == nil {
+			return false, err
 		}
-		return v != nil, err
+		return job.CardData != "", nil
 	}, "dataviewers", repo)
 	if blocker != nil {
 		return blocker

--- a/component/repo_test.go
+++ b/component/repo_test.go
@@ -3412,13 +3412,15 @@ func TestRepoComponent_ChangePath(t *testing.T) {
 	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "namespace", "name").
 		Return(&database.Repository{ID: 1, Path: "namespace/name", RepositoryType: types.ModelRepo}, nil)
 
+	repoComp.mocks.stores.NamespaceMock().EXPECT().Exists(ctx, "new").Return(true, nil)
+
 	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "new", "path").
 		Return(nil, sql.ErrNoRows)
 
 	// Dependency checks
 	repoComp.mocks.stores.DeployTaskMock().EXPECT().CountByRepoID(ctx, int64(1)).Return(0, nil)
 	repoComp.mocks.stores.WorkflowMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(0, nil)
-	repoComp.mocks.stores.ViewerMock().EXPECT().GetViewerByRepoID(ctx, int64(1)).Return(nil, sql.ErrNoRows)
+	repoComp.mocks.stores.ViewerMock().EXPECT().GetLastSuccessfulJobByRepoID(ctx, int64(1)).Return(nil, nil)
 	repoComp.mocks.stores.AccountSyncQuotaStatementMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(0, nil)
 	repoComp.mocks.stores.AccountPriceMock().EXPECT().CountByResourceIDs(ctx, mock.Anything).Return(0, nil)
 
@@ -3440,13 +3442,15 @@ func TestRepoComponent_ChangePath_RepoHashed(t *testing.T) {
 	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "namespace", "name").
 		Return(&database.Repository{ID: 1, Hashed: true, Path: "namespace/name", RepositoryType: types.ModelRepo}, nil)
 
+	repoComp.mocks.stores.NamespaceMock().EXPECT().Exists(ctx, "new").Return(true, nil)
+
 	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "new", "path").
 		Return(nil, sql.ErrNoRows)
 
 	// Dependency checks - no blocking entities
 	repoComp.mocks.stores.DeployTaskMock().EXPECT().CountByRepoID(ctx, int64(1)).Return(0, nil)
 	repoComp.mocks.stores.WorkflowMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(0, nil)
-	repoComp.mocks.stores.ViewerMock().EXPECT().GetViewerByRepoID(ctx, int64(1)).Return(nil, sql.ErrNoRows)
+	repoComp.mocks.stores.ViewerMock().EXPECT().GetLastSuccessfulJobByRepoID(ctx, int64(1)).Return(nil, nil)
 	repoComp.mocks.stores.AccountSyncQuotaStatementMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(0, nil)
 	repoComp.mocks.stores.AccountPriceMock().EXPECT().CountByResourceIDs(ctx, mock.Anything).Return(0, nil)
 
@@ -3482,6 +3486,8 @@ func TestRepoComponent_ChangePath_NewNamespaceExists(t *testing.T) {
 	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "namespace", "name").
 		Return(&database.Repository{ID: 1}, nil)
 
+	repoComp.mocks.stores.NamespaceMock().EXPECT().Exists(ctx, "new").Return(true, nil)
+
 	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "new", "path").
 		Return(&database.Repository{ID: 2}, nil)
 
@@ -3493,6 +3499,27 @@ func TestRepoComponent_ChangePath_NewNamespaceExists(t *testing.T) {
 	})
 
 	require.NotNil(t, err)
+}
+
+func TestRepoComponent_ChangePath_NamespaceNotExist(t *testing.T) {
+	ctx := context.Background()
+
+	repoComp := initializeTestRepoComponent(ctx, t)
+
+	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "namespace", "name").
+		Return(&database.Repository{ID: 1}, nil)
+
+	repoComp.mocks.stores.NamespaceMock().EXPECT().Exists(ctx, "newns").Return(false, nil)
+
+	err := repoComp.ChangePath(ctx, types.ChangePathReq{
+		RepoType:  types.ModelRepo,
+		Namespace: "namespace",
+		Name:      "name",
+		NewPath:   "newns/path",
+	})
+
+	require.NotNil(t, err)
+	require.True(t, errors.Is(err, errorx.ErrTargetNamespaceNotFound))
 }
 
 func TestRepoComponent_TransferOwnership_Success(t *testing.T) {
@@ -3522,7 +3549,7 @@ func TestRepoComponent_TransferOwnership_Success(t *testing.T) {
 	// Dependency checks - no blocking entities
 	repoComp.mocks.stores.DeployTaskMock().EXPECT().CountByRepoID(ctx, int64(1)).Return(0, nil)
 	repoComp.mocks.stores.WorkflowMock().EXPECT().CountByRepoPath(ctx, "sourceuser/reponame").Return(0, nil)
-	repoComp.mocks.stores.ViewerMock().EXPECT().GetViewerByRepoID(ctx, int64(1)).Return(nil, sql.ErrNoRows)
+	repoComp.mocks.stores.ViewerMock().EXPECT().GetLastSuccessfulJobByRepoID(ctx, int64(1)).Return(nil, nil)
 	repoComp.mocks.stores.AccountSyncQuotaStatementMock().EXPECT().CountByRepoPath(ctx, "sourceuser/reponame").Return(0, nil)
 	repoComp.mocks.stores.AccountPriceMock().EXPECT().CountByResourceIDs(ctx, mock.Anything).Return(0, nil)
 
@@ -3751,6 +3778,8 @@ func TestRepoComponent_ChangePath_DependencyExists(t *testing.T) {
 	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "namespace", "name").
 		Return(&database.Repository{ID: 1, Hashed: true, Path: "namespace/name", RepositoryType: types.ModelRepo}, nil)
 
+	repoComp.mocks.stores.NamespaceMock().EXPECT().Exists(ctx, "new").Return(true, nil)
+
 	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "new", "path").
 		Return(nil, sql.ErrNoRows)
 
@@ -3778,13 +3807,15 @@ func TestRepoComponent_ChangePath_DependencyShortCircuits(t *testing.T) {
 	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "namespace", "name").
 		Return(&database.Repository{ID: 1, Hashed: true, Path: "namespace/name", RepositoryType: types.ModelRepo}, nil)
 
+	repoComp.mocks.stores.NamespaceMock().EXPECT().Exists(ctx, "new").Return(true, nil)
+
 	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "new", "path").
 		Return(nil, sql.ErrNoRows)
 
 	// Deploy passes
 	repoComp.mocks.stores.DeployTaskMock().EXPECT().CountByRepoID(ctx, int64(1)).Return(0, nil)
-		// Argo workflows block - should return immediately, skipping remaining checks
-		repoComp.mocks.stores.WorkflowMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(5, nil)
+	// Argo workflows block - should return immediately, skipping remaining checks
+	repoComp.mocks.stores.WorkflowMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(5, nil)
 
 	err := repoComp.ChangePath(ctx, types.ChangePathReq{
 		RepoType:  types.ModelRepo,
@@ -3807,6 +3838,8 @@ func TestRepoComponent_ChangePath_DependencyCheckError(t *testing.T) {
 	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "namespace", "name").
 		Return(&database.Repository{ID: 1, Hashed: true, Path: "namespace/name", RepositoryType: types.ModelRepo}, nil)
 
+	repoComp.mocks.stores.NamespaceMock().EXPECT().Exists(ctx, "new").Return(true, nil)
+
 	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "new", "path").
 		Return(nil, sql.ErrNoRows)
 
@@ -3822,6 +3855,78 @@ func TestRepoComponent_ChangePath_DependencyCheckError(t *testing.T) {
 
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "failed to check deploy tasks")
+}
+
+func TestRepoComponent_ChangePath_DataviewerJobBlocked(t *testing.T) {
+	ctx := context.Background()
+
+	repoComp := initializeTestRepoComponent(ctx, t)
+
+	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "namespace", "name").
+		Return(&database.Repository{ID: 1, Hashed: true, Path: "namespace/name", RepositoryType: types.ModelRepo}, nil)
+
+	repoComp.mocks.stores.NamespaceMock().EXPECT().Exists(ctx, "new").Return(true, nil)
+
+	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "new", "path").
+		Return(nil, sql.ErrNoRows)
+
+	// Deploy tasks - not blocked
+	repoComp.mocks.stores.DeployTaskMock().EXPECT().CountByRepoID(ctx, int64(1)).Return(0, nil)
+	// Argo workflows - not blocked
+	repoComp.mocks.stores.WorkflowMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(0, nil)
+	// Dataviewer job - last successful job has non-empty card_data, blocks path change
+	repoComp.mocks.stores.ViewerMock().EXPECT().GetLastSuccessfulJobByRepoID(ctx, int64(1)).
+		Return(&database.DataviewerJob{ID: 1, RepoID: 1, Status: 2, CardData: "has-data"}, nil)
+
+	err := repoComp.ChangePath(ctx, types.ChangePathReq{
+		RepoType:  types.ModelRepo,
+		Namespace: "namespace",
+		Name:      "name",
+		NewPath:   "new/path",
+	})
+
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "cannot change path")
+	require.Contains(t, err.Error(), "the following dependent entities exist: dataviewers")
+	require.True(t, errors.Is(err, errorx.ErrChangePathBlocked))
+}
+
+func TestRepoComponent_ChangePath_DataviewerJobEmptyCardData(t *testing.T) {
+	ctx := context.Background()
+
+	repoComp := initializeTestRepoComponent(ctx, t)
+
+	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "namespace", "name").
+		Return(&database.Repository{ID: 1, Hashed: true, Path: "namespace/name", RepositoryType: types.ModelRepo}, nil)
+
+	repoComp.mocks.stores.NamespaceMock().EXPECT().Exists(ctx, "new").Return(true, nil)
+
+	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "new", "path").
+		Return(nil, sql.ErrNoRows)
+
+	// Deploy tasks - not blocked
+	repoComp.mocks.stores.DeployTaskMock().EXPECT().CountByRepoID(ctx, int64(1)).Return(0, nil)
+	// Argo workflows - not blocked
+	repoComp.mocks.stores.WorkflowMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(0, nil)
+	// Dataviewer job - last successful job has empty card_data, path change allowed
+	repoComp.mocks.stores.ViewerMock().EXPECT().GetLastSuccessfulJobByRepoID(ctx, int64(1)).
+		Return(&database.DataviewerJob{ID: 1, RepoID: 1, Status: 2, CardData: ""}, nil)
+	// Still passes dataviewer check, running remaining checks
+	repoComp.mocks.stores.AccountSyncQuotaStatementMock().EXPECT().CountByRepoPath(ctx, "namespace/name").Return(0, nil)
+	repoComp.mocks.stores.AccountPriceMock().EXPECT().CountByResourceIDs(ctx, mock.Anything).Return(0, nil)
+
+	repoComp.mocks.stores.RepoMock().EXPECT().UpdateRepo(ctx, mock.Anything).Return(&database.Repository{
+		ID: 1, Path: "new/path", GitPath: "models_new/path", Hashed: true, RepositoryType: types.ModelRepo,
+	}, nil)
+
+	err := repoComp.ChangePath(ctx, types.ChangePathReq{
+		RepoType:  types.ModelRepo,
+		Namespace: "namespace",
+		Name:      "name",
+		NewPath:   "new/path",
+	})
+
+	require.Nil(t, err)
 }
 
 func TestRepoComponent_BatchMigrateRepoToHashedPath_AutoFalse(t *testing.T) {


### PR DESCRIPTION
Summary:
- Added target namespace validation to the change path API to prevent transfers to non-existent namespaces.
- Addresses issue #2396 by ensuring the destination namespace exists before allowing an owner change.