### PR TITLE
Support paddle_static model format in metadata scan

### DIFF
--- a/builder/store/database/repository.go
+++ b/builder/store/database/repository.go
@@ -274,6 +274,11 @@ func (r Repository) Format() string {
 	}
 	for _, tag := range r.Tags {
 		if tag.Category == "framework" {
+			// Paddle inference weights are served in the paddle_static format
+			// declared by the paddleocr runtime framework config.
+			if tag.Name == "paddlepaddle" {
+				return string(types.PaddleStatic)
+			}
 			return tag.Name
 		}
 	}

--- a/common/types/model.go
+++ b/common/types/model.go
@@ -255,9 +255,10 @@ const (
 type ModelType string
 
 const (
-	GGUF        ModelType = "gguf"
-	Safetensors ModelType = "safetensors"
-	Unknown     ModelType = "unknown"
+	GGUF         ModelType = "gguf"
+	Safetensors  ModelType = "safetensors"
+	PaddleStatic ModelType = "paddle_static"
+	Unknown      ModelType = "unknown"
 )
 
 const (
@@ -448,6 +449,8 @@ type ModelInfo struct {
 	ModelWeightsGB    float32 `json:"model_weights_gb"`
 	//qwen2
 	ModelType string `json:"model_type"`
+	//the model's self-declared name from its native config, e.g. PP-OCRv6_medium_rec
+	ModelName string `json:"model_name"`
 	//Qwen2ForCausalLM
 	Architecture      string         `json:"architecture"`
 	ClassName         string         `json:"class_name"`

--- a/component/model.go
+++ b/component/model.go
@@ -1517,6 +1517,9 @@ func GetBuiltInTaskFromTags(tags []database.Tag) string {
 		if tag.Name == string(types.AutomaticSpeechRecognition) || tag.Name == string(types.AutoSpeechRecognition) {
 			return string(types.AutomaticSpeechRecognition)
 		}
+		if tag.Name == string(types.OpticalCharacterRecognition) {
+			return tag.Name
+		}
 	}
 	return string(types.TextGeneration)
 }

--- a/component/model_task_test.go
+++ b/component/model_task_test.go
@@ -47,3 +47,9 @@ func TestGetBuiltInTaskFromTags_TextToAudio(t *testing.T) {
 
 	require.Equal(t, string(types.TextToAudio), task)
 }
+
+func TestGetBuiltInTaskFromTags_OpticalCharacterRecognition(t *testing.T) {
+	task := GetBuiltInTaskFromTags([]database.Tag{{Name: string(types.OpticalCharacterRecognition)}})
+
+	require.Equal(t, string(types.OpticalCharacterRecognition), task)
+}

--- a/component/runtime_architecture.go
+++ b/component/runtime_architecture.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	gguf "github.com/gpustack/gguf-parser-go"
+	"gopkg.in/yaml.v3"
 	"opencsg.com/csghub-server/builder/git"
 	"opencsg.com/csghub-server/builder/git/gitserver"
 	"opencsg.com/csghub-server/builder/store/cache"
@@ -31,6 +32,7 @@ var (
 	MasterBranch          string = "master"
 	ConfigFileName        string = "config.json"
 	ModelIndexFileName    string = "model_index.json"
+	PaddleInferConfigName string = "inference.yml"
 	ModelSafetensorsIndex string = "model.safetensors.index.json"
 	ScanLock              sync.Mutex
 )
@@ -295,6 +297,8 @@ func (c *runtimeArchitectureComponentImpl) UpdateModelMetadata(ctx context.Conte
 		modelInfo, err = c.GetMetadataFromSafetensors(ctx, repo)
 	case string(types.GGUF):
 		modelInfo, err = c.GetMetadataFromGGUF(ctx, repo)
+	case string(types.PaddleStatic):
+		modelInfo, err = c.GetMetadataFromPaddleStatic(ctx, repo)
 	default:
 		return nil, fmt.Errorf("unsupported model format %s", modelFormat)
 	}
@@ -341,7 +345,7 @@ func (c *runtimeArchitectureComponentImpl) UpdateRuntimeFrameworkTag(ctx context
 	if modelInfo.ModelType != "" {
 		archs = append(archs, modelInfo.ModelType)
 	}
-	if len(archs) == 0 {
+	if len(archs) == 0 && modelInfo.ModelName == "" {
 		return fmt.Errorf("fail to get architecture from model info")
 	}
 	modelFormat := repo.Format()
@@ -600,6 +604,67 @@ func (c *runtimeArchitectureComponentImpl) GetMetadataFromSafetensors(ctx contex
 	}
 
 	return nil, fmt.Errorf("no model_index.json or config.json found, repo: %v", repo.Path)
+}
+
+// GetMetadataFromPaddleStatic extracts metadata from a Paddle static
+// inference model repo. The weights carry no config.json/gguf-style header,
+// but every PaddleX-exported model ships inference.yml declaring its name:
+//
+//	Global:
+//	  model_name: PP-OCRv6_medium_rec
+//
+// The declared name feeds framework matching, which for such repos relies on
+// the exact model_name rows seeded from engine configs.
+func (c *runtimeArchitectureComponentImpl) GetMetadataFromPaddleStatic(ctx context.Context, repo *database.Repository) (*types.ModelInfo, error) {
+	content, err := c.getConfigContent(ctx, PaddleInferConfigName, repo)
+	if err != nil {
+		return nil, fmt.Errorf("fail to get %s, %w", PaddleInferConfigName, err)
+	}
+	modelName, err := parsePaddleInferModelName(content)
+	if err != nil {
+		return nil, fmt.Errorf("fail to parse %s, %w", PaddleInferConfigName, err)
+	}
+	return &types.ModelInfo{ModelName: modelName}, nil
+}
+
+// parsePaddleInferModelName reads only the Global block of inference.yml,
+// skipping the rest of the file (PostProcess holds a character_dict with
+// thousands of lines that a full unmarshal would needlessly parse).
+func parsePaddleInferModelName(content string) (string, error) {
+	var block strings.Builder
+	block.Grow(1024)
+	inGlobal := false
+	for line := range strings.Lines(content) {
+		line = strings.TrimRight(line, "\r\n")
+		if !inGlobal {
+			// anchored at the line start to skip nested keys named Global
+			if strings.HasPrefix(line, "Global:") {
+				inGlobal = true
+				block.WriteString(line + "\n")
+			}
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && line[0] != ' ' && line[0] != '\t' && trimmed[0] != '#' {
+			break
+		}
+		block.WriteString(line + "\n")
+	}
+	if !inGlobal {
+		return "", fmt.Errorf("no Global section found")
+	}
+	var cfg struct {
+		Global struct {
+			ModelName string `yaml:"model_name"`
+		} `yaml:"Global"`
+	}
+	if err := yaml.Unmarshal([]byte(block.String()), &cfg); err != nil {
+		return "", err
+	}
+	if cfg.Global.ModelName == "" {
+		return "", fmt.Errorf("no model_name found in Global section")
+	}
+	return cfg.Global.ModelName, nil
 }
 
 func (c *runtimeArchitectureComponentImpl) getConfigContent(ctx context.Context, configFileName string, repo *database.Repository) (string, error) {

--- a/component/runtime_architecture_ce_test.go
+++ b/component/runtime_architecture_ce_test.go
@@ -1,0 +1,7 @@
+//go:build !ee && !saas
+
+package component
+
+import "context"
+
+func expectUpdateModelArchType(_ context.Context, _ *testRuntimeArchWithMocks) {}

--- a/component/runtime_architecture_test.go
+++ b/component/runtime_architecture_test.go
@@ -247,6 +247,117 @@ func TestGetMetadataFromSafetensors_className(t *testing.T) {
 	require.NotNil(t, modelInfo)
 }
 
+const paddleInferTestConfig = `Global:
+  model_name: PP-OCRv6_medium_rec
+PreProcess:
+  transform_ops:
+  - DecodeImage:
+      channel_first: false
+PostProcess:
+  name: CTCLabelDecode
+  character_dict:
+  - a
+  - b
+`
+
+func TestParsePaddleInferModelName(t *testing.T) {
+	name, err := parsePaddleInferModelName(paddleInferTestConfig)
+	require.NoError(t, err)
+	require.Equal(t, "PP-OCRv6_medium_rec", name)
+
+	// trailing spaces/comment after the Global key
+	name, err = parsePaddleInferModelName("Global:  # OCR model\n  model_name: PP-OCRv6_medium_rec\nPostProcess:\n")
+	require.NoError(t, err)
+	require.Equal(t, "PP-OCRv6_medium_rec", name)
+
+	// top-level comment inside the Global block must not end it
+	name, err = parsePaddleInferModelName("Global:\n# exported by paddlex\n  model_name: PP-OCRv6_medium_rec\nPostProcess:\n")
+	require.NoError(t, err)
+	require.Equal(t, "PP-OCRv6_medium_rec", name)
+
+	// a nested Global key must not be picked up
+	_, err = parsePaddleInferModelName("PreProcess:\n  Global:\n    model_name: fake\n")
+	require.ErrorContains(t, err, "no Global section")
+
+	_, err = parsePaddleInferModelName("PreProcess:\n  transform_ops: []\n")
+	require.ErrorContains(t, err, "no Global section")
+
+	_, err = parsePaddleInferModelName("Global:\n  other_key: 1\n")
+	require.ErrorContains(t, err, "no model_name")
+}
+
+func TestRuntimeArchComponent_GetMetadataFromPaddleStatic(t *testing.T) {
+	ctx := context.TODO()
+	rc := initializeTestRuntimeArchComponent(ctx, t)
+	repo := &database.Repository{
+		Name: "PP-OCRv6_medium_rec",
+		Path: "PaddlePaddle/PP-OCRv6_medium_rec",
+	}
+	rc.mocks.gitServer.EXPECT().GetRepoFileRaw(ctx, mock.Anything).Return(paddleInferTestConfig, nil).Once()
+
+	modelInfo, err := rc.GetMetadataFromPaddleStatic(ctx, repo)
+
+	require.NoError(t, err)
+	require.Equal(t, "PP-OCRv6_medium_rec", modelInfo.ModelName)
+}
+
+func TestRuntimeArchComponent_UpdateModelMetadata_PaddleStatic(t *testing.T) {
+	ctx := context.TODO()
+	rc := initializeTestRuntimeArchComponent(ctx, t)
+
+	repo := &database.Repository{
+		ID:   1,
+		Name: "PP-OCRv6_medium_rec",
+		Path: "PaddlePaddle/PP-OCRv6_medium_rec",
+		Tags: []database.Tag{{Name: "paddlepaddle", Category: "framework"}},
+	}
+	rc.mocks.gitServer.EXPECT().GetRepoFileRaw(ctx, mock.Anything).Return(paddleInferTestConfig, nil).Once()
+	rc.mocks.stores.MetadataMock().EXPECT().Upsert(ctx, mock.MatchedBy(func(m *database.Metadata) bool {
+		return m.RepositoryID == 1 && m.ModelType == ""
+	})).Return(nil).Once()
+	expectUpdateModelArchType(ctx, rc)
+
+	modelInfo, err := rc.UpdateModelMetadata(ctx, repo)
+
+	require.NoError(t, err)
+	require.Equal(t, "PP-OCRv6_medium_rec", modelInfo.ModelName)
+}
+
+func TestRuntimeArchComponent_UpdateRuntimeFrameworkTag_PaddleStatic(t *testing.T) {
+	ctx := context.TODO()
+	rc := initializeTestRuntimeArchComponent(ctx, t)
+
+	repo := &database.Repository{
+		ID:   1,
+		Name: "PP-OCRv6_medium_rec",
+		Path: "PaddlePaddle/PP-OCRv6_medium_rec",
+		Tags: []database.Tag{{Name: "paddlepaddle", Category: "framework"}},
+	}
+	frame := database.RuntimeFramework{
+		ID:          7,
+		FrameName:   "paddleocr",
+		FrameImage:  "opencsghq/paddleocr:3.7.0",
+		ModelFormat: "paddle_static",
+	}
+
+	rc.mocks.stores.TagMock().EXPECT().AllTags(ctx, mock.Anything).Return(
+		[]*database.Tag{{Name: "paddleocr", ID: 1}}, nil)
+	// ModelName stays out of archs; supported_models matching relies on the repo name
+	rc.mocks.stores.RuntimeArchMock().EXPECT().
+		ListByArchNameAndModel(ctx, []string(nil), "PP-OCRv6_medium_rec").
+		Return([]database.RuntimeArchitecture{{RuntimeFrameworkID: 7}}, nil)
+	rc.mocks.stores.RuntimeFrameworkMock().EXPECT().ListByIDs(ctx, []int64{7}).Return(
+		[]database.RuntimeFramework{frame}, nil)
+	rc.mocks.stores.TagMock().EXPECT().
+		RemoveRepoTagsByCategory(ctx, int64(1), []string{"runtime_framework", "resource"}).Return(nil)
+	rc.mocks.stores.RuntimeFrameworkMock().EXPECT().FindByID(ctx, int64(7)).Return(&frame, nil)
+	rc.mocks.stores.TagMock().EXPECT().UpsertRepoTags(ctx, int64(1), []int64{}, []int64{1}).Return(nil)
+
+	err := rc.UpdateRuntimeFrameworkTag(ctx, &types.ModelInfo{ModelName: "PP-OCRv6_medium_rec"}, repo)
+
+	require.NoError(t, err)
+}
+
 func TestRuntimeArchComponent_ScanModel_Success(t *testing.T) {
 	ctx := context.TODO()
 	rc := initializeTestRuntimeArchComponent(ctx, t)

--- a/component/tagparser/nameparser.go
+++ b/component/tagparser/nameparser.go
@@ -24,7 +24,8 @@ func LibraryTag(filePath string) string {
 		return "jax"
 	case strings.HasSuffix(filename, ".onnx"):
 		return "onnx"
-	case strings.HasSuffix(filename, ".pdparams"):
+	case strings.HasSuffix(filename, ".pdparams"),
+		strings.HasSuffix(filename, ".pdiparams"):
 		return "paddlepaddle"
 	case strings.HasSuffix(filename, ".joblib"):
 		return "joblib"

--- a/component/tagparser/nameparser_test.go
+++ b/component/tagparser/nameparser_test.go
@@ -41,6 +41,7 @@ func TestLibraryTag(t *testing.T) {
 		{name: "not onnx", args: args{filePath: "flax_model-onnx"}, want: ""},
 
 		{name: "paddlepaddle", args: args{filePath: "flax_model.pdparams"}, want: "paddlepaddle"},
+		{name: "paddlepaddle inference", args: args{filePath: "inference.pdiparams"}, want: "paddlepaddle"},
 		{name: "joblib", args: args{filePath: "flax_model.joblib"}, want: "joblib"},
 		{name: "gguf", args: args{filePath: "flax_model.gguf"}, want: "gguf"},
 	}

--- a/configs/inference/paddleocr.json
+++ b/configs/inference/paddleocr.json
@@ -17,10 +17,6 @@
       "engine_version": "3.7.0"
     }
   ],
-  "supported_archs": [
-    "PaddleOCRPipeline",
-    "OCR"
-  ],
   "supported_models": [
     "PP-OCRv6_tiny_rec",
     "PP-OCRv6_small_rec",


### PR DESCRIPTION
Summary:
- Fixes 500 errors and missing engine options for PaddleOCR models by recognizing `.pdiparams` files as the `paddlepaddle` framework and mapping them to the `paddle_static` model format.
- Optimizes metadata scanning for Paddle Static models by parsing only the `Global` section of `inference.yml` to extract model names, avoiding performance overhead from full YAML parsing.
- Aligns engine matching logic with the new `paddle_static` format to ensure `EnableInference` is correctly set and PaddleOCR engines become selectable in the deployment UI.