### PR TITLE
Fix paddleocr image

### DIFF
--- a/docker/inference/Dockerfile.paddleocr
+++ b/docker/inference/Dockerfile.paddleocr
@@ -25,6 +25,10 @@ RUN pip config set global.index-url https://mirrors.aliyun.com/pypi/simple && \
         --extra-index-url https://mirrors.aliyun.com/pypi/simple && \
     pip install --no-cache-dir paddleocr==3.7.0 "paddlex[serving]==3.7.2" csghub-sdk==0.7.10 \
         huggingface-hub==0.36.2
+# paddlepaddle-gpu==3.3.1 downgrades nvidia-nccl-cu12 to 2.25.1, but torch 2.9.1
+# in the base image needs 2.27.5 (ncclCommWindowRegister); restore it (NCCL 2.x
+# is backward-compatible, so paddle runs fine on 2.27.5).
+RUN pip install --no-cache-dir nvidia-nccl-cu12==2.27.5
 
 COPY ./paddleocr/ /etc/csghub/
 RUN chmod +x /etc/csghub/*.sh

--- a/docker/inference/paddleocr/serve.sh
+++ b/docker/inference/paddleocr/serve.sh
@@ -21,6 +21,12 @@ elif [ "${MODEL_SOURCE}" = "hub" ]; then
   # PaddleX's HF hoster must use ${HF_ENDPOINT}/hf, not ${HF_ENDPOINT}.
   export PADDLE_PDX_HUGGING_FACE_ENDPOINT="${PADDLE_PDX_HUGGING_FACE_ENDPOINT:-${HF_ENDPOINT%/}/hf}"
   export PADDLE_PDX_MODEL_SOURCE=huggingface
+  # PaddleX health-checks the HF hoster with HEAD on the endpoint root, which
+  # 404s for the /hf subpath and would silently drop the hoster; skip it.
+  export PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK=True
+  # The platform sets HF_HUB_OFFLINE=1, which makes hf_hub refuse all HTTP;
+  # re-enable it here since the endpoint is our own hub, not huggingface.co.
+  export HF_HUB_OFFLINE=0
   export HF_TOKEN="${HF_TOKEN:-${ACCESS_TOKEN}}"
 else
   echo "ERROR: unknown PADDLEOCR_MODEL_SOURCE '${MODEL_SOURCE}' (expected hub|local-only)" >&2
@@ -44,8 +50,15 @@ if [ -z "${PIPELINE}" ]; then
       # config and point TextRecognition at the local weights (det/cls
       # sub-models are still resolved by name from the model sources).
       GEN_DIR="${MODEL_DIR}/.csghub"
+      PIPELINE="${GEN_DIR}/OCR.yaml"
+      # /workspace persists across restarts; remove the stale copy or paddlex
+      # prompts to overwrite and crashes on EOF (no TTY in the pod).
+      rm -f "${PIPELINE}"
       paddlex --get_pipeline_config OCR --save_path "${GEN_DIR}"
-      PIPELINE="$(find "${GEN_DIR}" -name '*.yaml' | head -1)"
+      [ -f "${PIPELINE}" ] || {
+        echo "ERROR: failed to generate PaddleX pipeline config at ${PIPELINE}" >&2
+        exit 1
+      }
       python /etc/csghub/gen_pipeline.py --config "${PIPELINE}" --rec-name "${REC_NAME}" --rec-dir "${MODEL_DIR}"
     else
       # Sub-models are resolved by name from the configured model sources.


### PR DESCRIPTION
Summary:
- Upgraded `nvidia-nccl-cu12` to version 2.27.5 in the Dockerfile to resolve NCCL version mismatches causing `ImportError` during GPU model initialization.
- Modified `serve.sh` to pre-remove existing OCR configuration files and disable model source checks to prevent EOF errors and ensure successful model downloads from the `/hf` endpoint.