### PR TITLE
Fix FunASR adapter to recognize amd-funasr runtime framework.

### DIFF
--- a/aigateway/component/adapter/audio/adapter_test.go
+++ b/aigateway/component/adapter/audio/adapter_test.go
@@ -14,11 +14,63 @@ func TestRegistryGetAdapter(t *testing.T) {
 	funasr := registry.GetAdapter(&types.Model{InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "FunASR"}})
 	require.Equal(t, "funasr", funasr.Name())
 
+	amdFunasr := registry.GetAdapter(&types.Model{InternalModelInfo: types.InternalModelInfo{RuntimeFramework: frameworkAMDFunASR}})
+	require.Equal(t, "funasr", amdFunasr.Name())
+
+	normalizedAMDFunasr := registry.GetAdapter(&types.Model{InternalModelInfo: types.InternalModelInfo{RuntimeFramework: " AMD-FunASR "}})
+	require.Equal(t, "funasr", normalizedAMDFunasr.Name())
+
 	opencsg := registry.GetAdapter(&types.Model{ExternalModelInfo: types.ExternalModelInfo{Provider: " OpenCSG "}})
 	require.Equal(t, "funasr", opencsg.Name())
 
 	openaiCompatible := registry.GetAdapter(&types.Model{})
 	require.Equal(t, "openai-compatible", openaiCompatible.Name())
+}
+
+func TestFunASRAdapter_CanHandle(t *testing.T) {
+	adapter := NewFunASRAdapter()
+
+	tests := []struct {
+		name  string
+		model *types.Model
+		want  bool
+	}{
+		{
+			name:  "funasr runtime framework",
+			model: &types.Model{InternalModelInfo: types.InternalModelInfo{RuntimeFramework: frameworkFunASR}},
+			want:  true,
+		},
+		{
+			name:  "amd-funasr runtime framework",
+			model: &types.Model{InternalModelInfo: types.InternalModelInfo{RuntimeFramework: frameworkAMDFunASR}},
+			want:  true,
+		},
+		{
+			name:  "runtime framework matching is normalized",
+			model: &types.Model{InternalModelInfo: types.InternalModelInfo{RuntimeFramework: " AMD-FunASR "}},
+			want:  true,
+		},
+		{
+			name:  "opencsg provider",
+			model: &types.Model{ExternalModelInfo: types.ExternalModelInfo{Provider: "opencsg"}},
+			want:  true,
+		},
+		{
+			name:  "reject nil model",
+			model: nil,
+			want:  false,
+		},
+		{
+			name:  "reject unknown runtime framework",
+			model: &types.Model{InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "whisper"}},
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, adapter.CanHandle(tt.model))
+		})
+	}
 }
 
 func TestFunASRAdapterDurationFromHeader(t *testing.T) {

--- a/aigateway/component/adapter/audio/funasr.go
+++ b/aigateway/component/adapter/audio/funasr.go
@@ -8,7 +8,11 @@ import (
 	"opencsg.com/csghub-server/aigateway/types"
 )
 
-const audioDurationHeader = "Audio-Duration-Seconds"
+const (
+	audioDurationHeader = "Audio-Duration-Seconds"
+	frameworkFunASR     = "funasr"
+	frameworkAMDFunASR  = "amd-funasr"
+)
 
 type FunASRAdapter struct{}
 
@@ -21,7 +25,16 @@ func (a *FunASRAdapter) Name() string {
 }
 
 func (a *FunASRAdapter) CanHandle(model *types.Model) bool {
-	return model != nil && (isValue(model.RuntimeFramework, "funasr") || isValue(model.Provider, "opencsg"))
+	return model != nil && (isFunASRFramework(model.RuntimeFramework) || isValue(model.Provider, "opencsg"))
+}
+
+func isFunASRFramework(runtimeFramework string) bool {
+	switch strings.ToLower(strings.TrimSpace(runtimeFramework)) {
+	case frameworkFunASR, frameworkAMDFunASR:
+		return true
+	default:
+		return false
+	}
 }
 
 func (a *FunASRAdapter) DurationFromHeader(header http.Header) (float64, bool) {


### PR DESCRIPTION
Summary:
- Fixes FunASR adapter to recognize the `amd-funasr` runtime framework, preventing fallback to the generic openai-compatible adapter.
- Ensures the `Audio-Duration-Seconds` response header is correctly captured for accurate audio duration billing.
- Unifies framework detection logic in `isFunASRFramework` to handle case sensitivity and whitespace while preserving existing `funasr` and `opencsg` matching behavior.