### PR TITLE
Use the same metrix for request count and latency on monitor

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/git/gitserver/mock_GitServer.go
+++ b/_mocks/opencsg.com/csghub-server/builder/git/gitserver/mock_GitServer.go
@@ -4,11 +4,14 @@ package gitserver
 
 import (
 	context "context"
+
+	gitserver "opencsg.com/csghub-server/builder/git/gitserver"
+	database "opencsg.com/csghub-server/builder/store/database"
+
 	io "io"
 
 	mock "github.com/stretchr/testify/mock"
-	gitserver "opencsg.com/csghub-server/builder/git/gitserver"
-	database "opencsg.com/csghub-server/builder/store/database"
+
 	types "opencsg.com/csghub-server/common/types"
 )
 

--- a/_mocks/opencsg.com/csghub-server/builder/prometheus/mock_PrometheusClient.go
+++ b/_mocks/opencsg.com/csghub-server/builder/prometheus/mock_PrometheusClient.go
@@ -21,9 +21,9 @@ func (_m *MockPrometheusClient) EXPECT() *MockPrometheusClient_Expecter {
 	return &MockPrometheusClient_Expecter{mock: &_m.Mock}
 }
 
-// SerialData provides a mock function with given fields: query
-func (_m *MockPrometheusClient) SerialData(query string) (*types.PrometheusResponse, error) {
-	ret := _m.Called(query)
+// SerialData provides a mock function with given fields: query, apiSuffix
+func (_m *MockPrometheusClient) SerialData(query string, apiSuffix string) (*types.PrometheusResponse, error) {
+	ret := _m.Called(query, apiSuffix)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SerialData")
@@ -31,19 +31,19 @@ func (_m *MockPrometheusClient) SerialData(query string) (*types.PrometheusRespo
 
 	var r0 *types.PrometheusResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*types.PrometheusResponse, error)); ok {
-		return rf(query)
+	if rf, ok := ret.Get(0).(func(string, string) (*types.PrometheusResponse, error)); ok {
+		return rf(query, apiSuffix)
 	}
-	if rf, ok := ret.Get(0).(func(string) *types.PrometheusResponse); ok {
-		r0 = rf(query)
+	if rf, ok := ret.Get(0).(func(string, string) *types.PrometheusResponse); ok {
+		r0 = rf(query, apiSuffix)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.PrometheusResponse)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(query)
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(query, apiSuffix)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -58,13 +58,14 @@ type MockPrometheusClient_SerialData_Call struct {
 
 // SerialData is a helper method to define mock.On call
 //   - query string
-func (_e *MockPrometheusClient_Expecter) SerialData(query interface{}) *MockPrometheusClient_SerialData_Call {
-	return &MockPrometheusClient_SerialData_Call{Call: _e.mock.On("SerialData", query)}
+//   - apiSuffix string
+func (_e *MockPrometheusClient_Expecter) SerialData(query interface{}, apiSuffix interface{}) *MockPrometheusClient_SerialData_Call {
+	return &MockPrometheusClient_SerialData_Call{Call: _e.mock.On("SerialData", query, apiSuffix)}
 }
 
-func (_c *MockPrometheusClient_SerialData_Call) Run(run func(query string)) *MockPrometheusClient_SerialData_Call {
+func (_c *MockPrometheusClient_SerialData_Call) Run(run func(query string, apiSuffix string)) *MockPrometheusClient_SerialData_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(string), args[1].(string))
 	})
 	return _c
 }
@@ -74,7 +75,7 @@ func (_c *MockPrometheusClient_SerialData_Call) Return(_a0 *types.PrometheusResp
 	return _c
 }
 
-func (_c *MockPrometheusClient_SerialData_Call) RunAndReturn(run func(string) (*types.PrometheusResponse, error)) *MockPrometheusClient_SerialData_Call {
+func (_c *MockPrometheusClient_SerialData_Call) RunAndReturn(run func(string, string) (*types.PrometheusResponse, error)) *MockPrometheusClient_SerialData_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_MirrorStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_MirrorStore.go
@@ -7,6 +7,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	database "opencsg.com/csghub-server/builder/store/database"
+
 	types "opencsg.com/csghub-server/common/types"
 )
 

--- a/_mocks/opencsg.com/csghub-server/component/mock_MirrorComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_MirrorComponent.go
@@ -7,6 +7,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	database "opencsg.com/csghub-server/builder/store/database"
+
 	types "opencsg.com/csghub-server/common/types"
 )
 

--- a/builder/prometheus/client.go
+++ b/builder/prometheus/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"opencsg.com/csghub-server/common/config"
@@ -13,7 +12,7 @@ import (
 )
 
 type PrometheusClient interface {
-	SerialData(query string) (*types.PrometheusResponse, error)
+	SerialData(query string, apiSuffix string) (*types.PrometheusResponse, error)
 }
 
 type prometheusClientImpl struct {
@@ -37,11 +36,11 @@ func NewPrometheusClient(cfg *config.Config) PrometheusClient {
 	}
 }
 
-func (p *prometheusClientImpl) SerialData(query string) (*types.PrometheusResponse, error) {
+func (p *prometheusClientImpl) SerialData(query string, apiSuffix string) (*types.PrometheusResponse, error) {
 	if len(p.apiURL) < 1 {
 		return nil, fmt.Errorf("prometheus api address is not configured")
 	}
-	url := fmt.Sprintf("%s?query=%s", p.apiURL, url.QueryEscape(query))
+	url := fmt.Sprintf("%s%s?query=%s", p.apiURL, apiSuffix, query)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err

--- a/common/utils/common/params.go
+++ b/common/utils/common/params.go
@@ -160,3 +160,40 @@ func RepoTypeFromString(path string) (types.RepositoryType, error) {
 func ParseDate(dateStr string) (time.Time, error) {
 	return time.Parse("2006-01-02", dateStr)
 }
+
+// ParseTimeRange calculates the start and end time for a given time range string
+// in RFC3339 format (UTC)
+func ParseTimeRange(rangeStr string) (start, end string) {
+	now := time.Now().UTC()
+
+	var duration time.Duration
+	switch rangeStr {
+	case "30m":
+		duration = 30 * time.Minute
+	case "1h":
+		duration = 1 * time.Hour
+	case "3h":
+		duration = 3 * time.Hour
+	case "6h":
+		duration = 6 * time.Hour
+	case "12h":
+		duration = 12 * time.Hour
+	case "1d":
+		duration = 24 * time.Hour
+	case "3d":
+		duration = 3 * 24 * time.Hour
+	case "1w":
+		duration = 7 * 24 * time.Hour
+	default:
+		duration = 30 * time.Minute
+	}
+
+	startTime := now.Add(-duration)
+	endTime := now
+
+	// Format the time range in RFC3339 format
+	start = startTime.Format("2006-01-02T15:04:05Z")
+	end = endTime.Format("2006-01-02T15:04:05Z")
+
+	return start, end
+}

--- a/component/monitor.go
+++ b/component/monitor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -15,6 +16,7 @@ import (
 	"opencsg.com/csghub-server/common/config"
 	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
+	"opencsg.com/csghub-server/common/utils/common"
 	rtypes "opencsg.com/csghub-server/runner/types"
 )
 
@@ -81,7 +83,7 @@ func (m *monitorComponentImpl) CPUUsage(ctx context.Context, req *types.MonitorR
 	slog.InfoContext(ctx, "cpu-usage", slog.Any("query", query),
 		slog.Any("metricKeys", m.metrics.metricKeys), slog.Any("len", len(m.metrics.metricKeys)))
 
-	promeResp, err := m.client.SerialData(query)
+	promeResp, err := m.client.SerialData(url.QueryEscape(query), "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cpu usage error: %w", err)
 	}
@@ -122,7 +124,7 @@ func (m *monitorComponentImpl) CPULimit(ctx context.Context, req *types.MonitorR
 	query := fmt.Sprintf("%s{pod='%s',namespace='%s',resource='cpu'}", m.metrics.cpuLimit, req.Instance, m.k8sNameSpace)
 	slog.InfoContext(ctx, "cpu-limit", slog.Any("query", query))
 
-	promeResp, err := m.client.SerialData(query)
+	promeResp, err := m.client.SerialData(url.QueryEscape(query), "")
 	if err != nil {
 		return 0, fmt.Errorf("failed to get cpu limit error: %w", err)
 	}
@@ -159,7 +161,7 @@ func (m *monitorComponentImpl) MemoryUsage(ctx context.Context, req *types.Monit
 	slog.InfoContext(ctx, "memory-usage", slog.Any("query", query),
 		slog.Any("metricKeys", m.metrics.metricKeys), slog.Any("len", len(m.metrics.metricKeys)))
 
-	promeResp, err := m.client.SerialData(query)
+	promeResp, err := m.client.SerialData(url.QueryEscape(query), "")
 	if err != nil {
 		return nil, fmt.Errorf("fail to get memory usage error: %w", err)
 	}
@@ -199,15 +201,28 @@ func (m *monitorComponentImpl) RequestCount(ctx context.Context, req *types.Moni
 		return nil, fmt.Errorf("user %s has no permission to access request count", req.CurrentUser)
 	}
 
-	// issue: github.com/knative/serving/issues/14925
-	query := fmt.Sprintf("avg_over_time(%s{pod_name='%s',namespace='%s'}[%s:])[%s:%s]",
-		m.metrics.requestCount, req.Instance, namespace, req.LastDuration, req.LastDuration, req.TimeRange)
+	query := ""
+	apiSuffix := ""
+	if m.metrics.requestCount == "revision_request_count" {
+		// back compatibility
+		query = fmt.Sprintf("avg_over_time(%s{pod_name='%s',namespace='%s'}[%s:])[%s:%s]",
+			m.metrics.requestCount, req.Instance, namespace, req.LastDuration, req.LastDuration, req.TimeRange)
+		query = url.QueryEscape(query)
+	} else {
+		apiSuffix = "_range"
+		query = fmt.Sprintf("%s{pod_name='%s',namespace='%s',le='+Inf'}",
+			m.metrics.requestCount, req.Instance, namespace)
+		start, end := common.ParseTimeRange(req.LastDuration)
+		step := req.TimeRange
+		query = fmt.Sprintf("%s&start=%s&end=%s&step=%s", url.QueryEscape(query), start, end, step)
+	}
+
 	slog.InfoContext(ctx, "request-count", slog.Any("query", query),
 		slog.Any("metricKeys", m.metrics.metricKeys), slog.Any("len", len(m.metrics.metricKeys)))
+	promeResp, err := m.client.SerialData(query, apiSuffix)
 
-	promeResp, err := m.client.SerialData(query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get memory limit error: %w", err)
+		return nil, fmt.Errorf("failed to get request count error: %w", err)
 	}
 	slog.Debug("get request count", slog.Any("promeResp", promeResp))
 	resp := types.MonitorRequestCountResp{}
@@ -258,12 +273,12 @@ func (m *monitorComponentImpl) RequestLatency(ctx context.Context, req *types.Mo
 		return nil, fmt.Errorf("user %s has no permission to access request latency", req.CurrentUser)
 	}
 
-	query := fmt.Sprintf("sum(increase(%s{pod_name='%s',namespace='%s'}[%s:])) by (le)",
+	query := fmt.Sprintf("sum by (le) (increase(%s{pod_name='%s',namespace='%s'}[%s]))",
 		m.metrics.requestLatency, req.Instance, namespace, req.LastDuration)
 	slog.InfoContext(ctx, "request-latency", slog.Any("query", query),
 		slog.Any("metricKeys", m.metrics.metricKeys), slog.Any("len", len(m.metrics.metricKeys)))
 
-	promeResp, err := m.client.SerialData(query)
+	promeResp, err := m.client.SerialData(url.QueryEscape(query), "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get request latency error: %w", err)
 	}

--- a/component/monitor_test.go
+++ b/component/monitor_test.go
@@ -3,6 +3,7 @@ package component
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,12 +19,12 @@ import (
 )
 
 var defaultTestMetrics = metricNames{
-	cpuUsage:          "container_cpu_usage_seconds_total",
-	cpuLimit:          "kube_pod_container_resource_limits",
-	memoryUsage:       "container_memory_usage_bytes",
-	requestCount:      "revision_request_count",
-	requestLatency:    "revision_app_request_latencies_bucket",
-	metricKeys:        []string{"pod", "service_name", "namespace", "response_code_class", "le"},
+	cpuUsage:       "container_cpu_usage_seconds_total",
+	cpuLimit:       "kube_pod_container_resource_limits",
+	memoryUsage:    "container_memory_usage_bytes",
+	requestCount:   "revision_request_count",
+	requestLatency: "revision_app_request_latencies_bucket",
+	metricKeys:     []string{"pod", "service_name", "namespace", "response_code_class", "le"},
 }
 
 func TestMonitorComponent_getMetrics(t *testing.T) {
@@ -37,25 +38,25 @@ func TestMonitorComponent_getMetrics(t *testing.T) {
 		expected map[string]string
 	}{
 		{
-			name:  "default metric keys - all present",
+			name: "default metric keys - all present",
 			input: map[string]string{
-				"pod":                "my-pod",
-				"service_name":       "my-service",
-				"namespace":          "my-ns",
+				"pod":                 "my-pod",
+				"service_name":        "my-service",
+				"namespace":           "my-ns",
 				"response_code_class": "2xx",
-				"le":                 "0.5",
+				"le":                  "0.5",
 			},
 			expected: map[string]string{
-				"pod":                "my-pod",
-				"instance":           "my-pod",
-				"service_name":       "my-service",
-				"namespace":          "my-ns",
+				"pod":                 "my-pod",
+				"instance":            "my-pod",
+				"service_name":        "my-service",
+				"namespace":           "my-ns",
 				"response_code_class": "2xx",
-				"le":                 "0.5",
+				"le":                  "0.5",
 			},
 		},
 		{
-			name:  "pod key adds instance alias",
+			name: "pod key adds instance alias",
 			input: map[string]string{
 				"pod":       "my-pod",
 				"namespace": "my-ns",
@@ -67,10 +68,10 @@ func TestMonitorComponent_getMetrics(t *testing.T) {
 			},
 		},
 		{
-			name:  "missing keys are skipped",
+			name: "missing keys are skipped",
 			input: map[string]string{
-				"pod":  "my-pod",
-				"le":   "0.5",
+				"pod":       "my-pod",
+				"le":        "0.5",
 				"other_key": "other_value",
 			},
 			expected: map[string]string{
@@ -80,12 +81,12 @@ func TestMonitorComponent_getMetrics(t *testing.T) {
 			},
 		},
 		{
-			name:  "empty input returns empty result",
-			input: map[string]string{},
+			name:     "empty input returns empty result",
+			input:    map[string]string{},
 			expected: map[string]string{},
 		},
 		{
-			name:  "extra keys not in metricKeys are ignored",
+			name: "extra keys not in metricKeys are ignored",
 			input: map[string]string{
 				"pod":       "my-pod",
 				"container": "user-container",
@@ -97,10 +98,10 @@ func TestMonitorComponent_getMetrics(t *testing.T) {
 			},
 		},
 		{
-			name:  "no pod key - no instance alias",
+			name: "no pod key - no instance alias",
 			input: map[string]string{
-				"namespace":  "my-ns",
-				"le":         "0.5",
+				"namespace": "my-ns",
+				"le":        "0.5",
 			},
 			expected: map[string]string{
 				"namespace": "my-ns",
@@ -108,7 +109,7 @@ func TestMonitorComponent_getMetrics(t *testing.T) {
 			},
 		},
 		{
-			name:  "custom metricKeys - only specified keys extracted",
+			name: "custom metricKeys - only specified keys extracted",
 			input: map[string]string{
 				"pod":       "my-pod",
 				"namespace": "my-ns",
@@ -196,10 +197,10 @@ func TestMonitor_RequestLatency(t *testing.T) {
 		UserID:  1,
 	}, nil)
 
-	query := fmt.Sprintf("sum(increase(revision_app_request_latencies_bucket{pod_name='%s',namespace='%s'}[%s:])) by (le)",
-		req.Instance, "", req.LastDuration)
+	query := fmt.Sprintf("sum by (le) (increase(%s{pod_name='%s',namespace='%s'}[%s]))",
+		"revision_app_request_latencies_bucket", req.Instance, "", req.LastDuration)
 
-	client.EXPECT().SerialData(query).Return(&types.PrometheusResponse{
+	client.EXPECT().SerialData(url.QueryEscape(query), "").Return(&types.PrometheusResponse{
 		Data: types.PrometheusData{
 			ResultType: "vector",
 			Result: []types.PrometheusResult{
@@ -277,7 +278,7 @@ func TestMonitor_RequestCount(t *testing.T) {
 	query := fmt.Sprintf("avg_over_time(revision_request_count{pod_name='%s',namespace='%s'}[%s:])[%s:%s]",
 		req.Instance, "", req.LastDuration, req.LastDuration, req.TimeRange)
 
-	client.EXPECT().SerialData(query).Return(&types.PrometheusResponse{
+	client.EXPECT().SerialData(url.QueryEscape(query), "").Return(&types.PrometheusResponse{
 		Data: types.PrometheusData{
 			ResultType: "vector",
 			Result: []types.PrometheusResult{
@@ -361,7 +362,7 @@ func TestMonitor_MemoryUsage(t *testing.T) {
 	query := fmt.Sprintf("avg_over_time(container_memory_usage_bytes{pod='%s',namespace='%s',container='user-container'}[%s:])[%s:%s]",
 		req.Instance, "", req.LastDuration, req.LastDuration, req.TimeRange)
 
-	client.EXPECT().SerialData(query).Return(&types.PrometheusResponse{
+	client.EXPECT().SerialData(url.QueryEscape(query), "").Return(&types.PrometheusResponse{
 		Data: types.PrometheusData{
 			ResultType: "vector",
 			Result: []types.PrometheusResult{
@@ -446,7 +447,7 @@ func TestMonitor_MemoryUsage_Evaluation(t *testing.T) {
 	query := fmt.Sprintf("avg_over_time(container_memory_usage_bytes{pod='%s',namespace='%s',container='main'}[%s:])[%s:%s]",
 		req.Instance, "", req.LastDuration, req.LastDuration, req.TimeRange)
 
-	client.EXPECT().SerialData(query).Return(&types.PrometheusResponse{
+	client.EXPECT().SerialData(url.QueryEscape(query), "").Return(&types.PrometheusResponse{
 		Data: types.PrometheusData{
 			ResultType: "vector",
 			Result: []types.PrometheusResult{
@@ -528,7 +529,7 @@ func TestMonitor_CPUUsage(t *testing.T) {
 
 	query := fmt.Sprintf("kube_pod_container_resource_limits{pod='%s',namespace='%s',resource='cpu'}", req.Instance, "")
 
-	client.EXPECT().SerialData(query).Return(&types.PrometheusResponse{
+	client.EXPECT().SerialData(url.QueryEscape(query), "").Return(&types.PrometheusResponse{
 		Data: types.PrometheusData{
 			ResultType: "vector",
 			Result: []types.PrometheusResult{
@@ -547,7 +548,7 @@ func TestMonitor_CPUUsage(t *testing.T) {
 
 	query = fmt.Sprintf("avg_over_time(rate(container_cpu_usage_seconds_total{pod='%s',namespace='%s',container='user-container'}[1m])[%s:])[%s:%s]", req.Instance, "", req.LastDuration, req.LastDuration, req.TimeRange)
 
-	client.EXPECT().SerialData(query).Return(&types.PrometheusResponse{
+	client.EXPECT().SerialData(url.QueryEscape(query), "").Return(&types.PrometheusResponse{
 		Data: types.PrometheusData{
 			ResultType: "vector",
 			Result: []types.PrometheusResult{


### PR DESCRIPTION
Summary:
- Refactored `PrometheusClient.SerialData` to support the `query_range` API for retrieving time-series data, enabling the Monitor component to query both legacy and new Prometheus metrics for RequestCount and RequestLatency.
- Updated PromQL syntax for RequestLatency and unified URL encoding logic across metrics to ensure compatibility with the new data source while maintaining backward compatibility with existing configurations.