### PR TITLE
Add unit type to query bills detail

### DIFF
--- a/builder/store/database/account_bill.go
+++ b/builder/store/database/account_bill.go
@@ -191,6 +191,8 @@ func (s *accountBillStoreImpl) ListBillsDetailByUserID(ctx context.Context, req 
 		q = q.Where("customer_id = ?", req.InstanceName)
 	}
 
+	q = q.Where("unit_type = ?", req.UnitType)
+
 	count, err := q.Count(ctx)
 	if err != nil {
 		return AccountBillDetailRes{}, errorx.HandleDBError(err, nil)

--- a/common/types/accounting.go
+++ b/common/types/accounting.go
@@ -272,14 +272,15 @@ type AcctBillsReq struct {
 }
 
 type AcctBillsDetailReq struct {
-	CurrentUser  string `json:"current_user"`
-	TargetUUID   string `json:"target_uuid"`
-	Scene        int    `json:"scene"`
-	StartDate    string `json:"start_date"`
-	EndDate      string `json:"end_date"`
-	InstanceName string `json:"instance_name"`
-	Per          int    `json:"per"`
-	Page         int    `json:"page"`
+	CurrentUser  string      `json:"current_user"`
+	TargetUUID   string      `json:"target_uuid"`
+	Scene        int         `json:"scene"`
+	StartDate    string      `json:"start_date"`
+	EndDate      string      `json:"end_date"`
+	InstanceName string      `json:"instance_name"`
+	Per          int         `json:"per"`
+	Page         int         `json:"page"`
+	UnitType     SkuUnitType `json:"unit_type"`
 }
 
 type AcctStatementsRes struct {


### PR DESCRIPTION
Summary:
- Main scope: 账单明细查询接口（`QueryBillsDetailByUserID`）缺少按计费单位类型（`unit_type`）筛选的能力，无法区分不同类型的计费项（如 token、GPU 时长等），需要新增 `unit_type` 查询参数支持按单位.
- Additional context: issue: https://git-devops.opencsg.com/product/starhub/starhub-server/-/work_items/1364.