### PR TITLE
fix: Pagination on the AllTags homepage results in incomplete data.

### DIFF
--- a/api/handler/tag.go
+++ b/api/handler/tag.go
@@ -40,7 +40,7 @@ type TagsHandler struct {
 // @Param		 scope query string false "scope name" Enums(model, dataset, code, space, prompt, skill)
 // @Param		 built_in query bool false "built_in"
 // @Param		 search query string false "search on name and show_name fields"
-// @Param		 per query int false "Page size, default 50, max 100" default(50)
+// @Param		 per query int false "Page size, default 50, max 100. When omitted and scope is set, all tags are returned without pagination" default(50)
 // @Param		 page query int false "Page number, default 1" default(1)
 // @Success      200  {object}  types.Response{data=[]types.RepoTag} "tags"
 // @Failure      400  {object}  types.APIBadRequest "Bad request"
@@ -53,7 +53,8 @@ func (t *TagsHandler) AllTags(ctx *gin.Context) {
 		httpbase.BadRequest(ctx, err.Error())
 		return
 	}
-	per, page, err := common.GetPerAndPageFromContext(ctx)
+
+	per, page, err := resolveTagPerPage(ctx, filter)
 	if err != nil {
 		httpbase.BadRequest(ctx, err.Error())
 		return
@@ -66,6 +67,21 @@ func (t *TagsHandler) AllTags(ctx *gin.Context) {
 		return
 	}
 	httpbase.OKWithTotal(ctx, tags, total)
+}
+
+// resolveTagPerPage resolves the per/page values for AllTags.
+//
+// A homepage request is identified by having a scope filter set. The homepage
+// needs all tags in a single request to avoid multiple round trips, so when the
+// caller does not send a "per" query parameter and the request filters by scope,
+// per and page are both set to 0 which makes AllTagsWithPagination return all
+// tags without pagination. In all other cases the standard pagination rules
+// (default 50, max 100) from common.GetPerAndPageFromContext apply.
+func resolveTagPerPage(ctx *gin.Context, filter *types.TagFilter) (per, page int, err error) {
+	if len(filter.Scopes) != 0 && ctx.Query("per") == "" {
+		return 0, 0, nil
+	}
+	return common.GetPerAndPageFromContext(ctx)
 }
 
 // CreateTag     godoc

--- a/api/handler/tag_test.go
+++ b/api/handler/tag_test.go
@@ -46,7 +46,7 @@ func TestTagHandler_AllTags(t *testing.T) {
 			Scopes:     []types.TagScope{types.TagScope("model")},
 			Categories: []string{"task"},
 			BuiltIn:    nil,
-		}, 50, 1).Return(tags, 1, nil)
+		}, 0, 0).Return(tags, 1, nil)
 
 		tagHandler, err := NewTestTagHandler(tagComp)
 		require.Nil(t, err)
@@ -190,6 +190,374 @@ func TestTagHandler_AllTags(t *testing.T) {
 		err = json.Unmarshal(hr.Body.Bytes(), &resp)
 		require.Nil(t, err)
 		require.Equal(t, 0, resp.Total)
+	})
+}
+
+// makeTags builds a slice of n []*types.RepoTag for test fixtures.
+func makeTags(n int) []*types.RepoTag {
+	tags := make([]*types.RepoTag, n)
+	for i := 0; i < n; i++ {
+		tags[i] = &types.RepoTag{Name: fmt.Sprintf("tag%d", i)}
+	}
+	return tags
+}
+
+// requireTagsLen unmarshals the response envelope from hr, re-marshals the
+// Data field and unmarshals it into []types.RepoTag, then asserts that the
+// number of returned tags equals wantLen.
+func requireTagsLen(t *testing.T, hr *httptest.ResponseRecorder, wantLen int) {
+	t.Helper()
+	var resp httpbase.R
+	err := json.Unmarshal(hr.Body.Bytes(), &resp)
+	require.Nil(t, err)
+
+	dataBytes, err := json.Marshal(resp.Data)
+	require.Nil(t, err)
+
+	var tags []types.RepoTag
+	err = json.Unmarshal(dataBytes, &tags)
+	require.Nil(t, err)
+
+	require.Len(t, tags, wantLen)
+}
+
+// TestTagHandler_AllTags_HomepagePagination covers the boundary cases around
+// the homepage "fetch all" behavior. A homepage request is identified by having
+// a scope filter set. When "per" is not sent on such a request, per and page
+// are both 0 so AllTagsWithPagination returns all tags without pagination.
+// When "per" is explicitly sent, or when no scope is set, standard pagination
+// applies.
+//
+// Each subtest verifies both the total count and the actual number of tags
+// returned in resp.Data to ensure the per/page values are passed through
+// correctly to the component layer.
+func TestTagHandler_AllTags_HomepagePagination(t *testing.T) {
+	t.Run("scope set, no per -> fetch all (per=0,page=0)", func(t *testing.T) {
+		// 23 tags total, no pagination applied -> all 23 returned
+		tags := makeTags(23)
+
+		values := url.Values{}
+		values.Add("scope", "model")
+		req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), &types.TagFilter{
+			Scopes: []types.TagScope{types.TagScope("model")},
+		}, 0, 0).Return(tags, 23, nil)
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+
+		require.Equal(t, http.StatusOK, hr.Code, hr.Body.String())
+
+		var resp httpbase.R
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
+		require.Equal(t, 23, resp.Total)
+		requireTagsLen(t, hr, 23)
+	})
+
+	t.Run("scope set, with per -> standard pagination, full page", func(t *testing.T) {
+		// per=10, page=2, total=23 -> page 2 returns a full page of 10 tags
+		tags := makeTags(10)
+
+		values := url.Values{}
+		values.Add("scope", "model")
+		values.Add("per", "10")
+		values.Add("page", "2")
+		req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), &types.TagFilter{
+			Scopes: []types.TagScope{types.TagScope("model")},
+		}, 10, 2).Return(tags, 23, nil)
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+
+		require.Equal(t, http.StatusOK, hr.Code, hr.Body.String())
+
+		var resp httpbase.R
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
+		require.Equal(t, 23, resp.Total)
+		requireTagsLen(t, hr, 10)
+	})
+
+	t.Run("scope set, with per -> last page returns remainder", func(t *testing.T) {
+		// per=10, page=3, total=23 -> page 3 returns only 3 tags (23-20=3)
+		tags := makeTags(3)
+
+		values := url.Values{}
+		values.Add("scope", "model")
+		values.Add("per", "10")
+		values.Add("page", "3")
+		req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), &types.TagFilter{
+			Scopes: []types.TagScope{types.TagScope("model")},
+		}, 10, 3).Return(tags, 23, nil)
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+
+		require.Equal(t, http.StatusOK, hr.Code, hr.Body.String())
+
+		var resp httpbase.R
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
+		require.Equal(t, 23, resp.Total)
+		requireTagsLen(t, hr, 3)
+	})
+
+	t.Run("scope set, with per -> first page of single page", func(t *testing.T) {
+		// per=10, page=1, total=5 -> only 5 tags, less than per
+		tags := makeTags(5)
+
+		values := url.Values{}
+		values.Add("scope", "model")
+		values.Add("per", "10")
+		values.Add("page", "1")
+		req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), &types.TagFilter{
+			Scopes: []types.TagScope{types.TagScope("model")},
+		}, 10, 1).Return(tags, 5, nil)
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+
+		require.Equal(t, http.StatusOK, hr.Code, hr.Body.String())
+
+		var resp httpbase.R
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
+		require.Equal(t, 5, resp.Total)
+		requireTagsLen(t, hr, 5)
+	})
+
+	t.Run("no scope, no per -> standard pagination (default 50, page 1)", func(t *testing.T) {
+		// default per=50, page=1, total=30 -> all 30 fit in one page
+		tags := makeTags(30)
+
+		req := httptest.NewRequest("get", "/api/v1/tags", nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), &types.TagFilter{}, 50, 1).Return(tags, 30, nil)
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+
+		require.Equal(t, http.StatusOK, hr.Code, hr.Body.String())
+
+		var resp httpbase.R
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
+		require.Equal(t, 30, resp.Total)
+		requireTagsLen(t, hr, 30)
+	})
+
+	t.Run("no scope, with per -> standard pagination", func(t *testing.T) {
+		// per=10, page=2, total=15 -> page 2 returns 5 tags (15-10=5)
+		tags := makeTags(5)
+
+		values := url.Values{}
+		values.Add("per", "10")
+		values.Add("page", "2")
+		req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), &types.TagFilter{}, 10, 2).Return(tags, 15, nil)
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+
+		require.Equal(t, http.StatusOK, hr.Code, hr.Body.String())
+
+		var resp httpbase.R
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
+		require.Equal(t, 15, resp.Total)
+		requireTagsLen(t, hr, 5)
+	})
+
+	t.Run("built_in set, no scope, no per -> standard pagination", func(t *testing.T) {
+		// default per=50, page=1, total=8 -> all 8 returned
+		tags := makeTags(8)
+
+		values := url.Values{}
+		values.Add("built_in", "true")
+		req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		builtin := true
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), &types.TagFilter{
+			BuiltIn: &builtin,
+		}, 50, 1).Return(tags, 8, nil)
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+
+		require.Equal(t, http.StatusOK, hr.Code, hr.Body.String())
+
+		var resp httpbase.R
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
+		require.Equal(t, 8, resp.Total)
+		requireTagsLen(t, hr, 8)
+	})
+
+	t.Run("scope and built_in set, no per -> fetch all (per=0,page=0)", func(t *testing.T) {
+		// 12 tags total, no pagination -> all 12 returned
+		tags := makeTags(12)
+
+		values := url.Values{}
+		values.Add("scope", "dataset")
+		values.Add("built_in", "false")
+		req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		builtin := false
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), &types.TagFilter{
+			Scopes:  []types.TagScope{types.TagScope("dataset")},
+			BuiltIn: &builtin,
+		}, 0, 0).Return(tags, 12, nil)
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+
+		require.Equal(t, http.StatusOK, hr.Code, hr.Body.String())
+
+		var resp httpbase.R
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
+		require.Equal(t, 12, resp.Total)
+		requireTagsLen(t, hr, 12)
+	})
+
+	t.Run("scope set, per exceeds max -> bad request", func(t *testing.T) {
+		values := url.Values{}
+		values.Add("scope", "model")
+		values.Add("per", "101")
+		req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+		require.Equal(t, http.StatusBadRequest, hr.Code)
+	})
+
+	t.Run("multiple scopes set, no per -> fetch all (per=0,page=0)", func(t *testing.T) {
+		// 7 tags total, no pagination -> all 7 returned
+		tags := makeTags(7)
+
+		values := url.Values{}
+		values.Add("scope", "model")
+		values.Add("scope", "dataset")
+		req := httptest.NewRequest("get", "/api/v1/tags?"+values.Encode(), nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), &types.TagFilter{
+			Scopes: []types.TagScope{types.TagScope("model"), types.TagScope("dataset")},
+		}, 0, 0).Return(tags, 7, nil)
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+
+		require.Equal(t, http.StatusOK, hr.Code, hr.Body.String())
+
+		var resp httpbase.R
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
+		require.Equal(t, 7, resp.Total)
+		requireTagsLen(t, hr, 7)
+	})
+
+	t.Run("empty result -> 0 tags in data", func(t *testing.T) {
+		// per=10, page=1, total=0 -> no tags returned
+		req := httptest.NewRequest("get", "/api/v1/tags?per=10&page=1", nil)
+
+		hr := httptest.NewRecorder()
+		ginContext, _ := gin.CreateTestContext(hr)
+		ginContext.Request = req
+
+		tagComp := mockcom.NewMockTagComponent(t)
+		tagComp.EXPECT().AllTagsWithPagination(ginContext.Request.Context(), mock.Anything, 10, 1).Return(nil, 0, nil)
+
+		tagHandler, err := NewTestTagHandler(tagComp)
+		require.Nil(t, err)
+
+		tagHandler.AllTags(ginContext)
+
+		require.Equal(t, http.StatusOK, hr.Code, hr.Body.String())
+
+		var resp httpbase.R
+		err = json.Unmarshal(hr.Body.Bytes(), &resp)
+		require.Nil(t, err)
+		require.Equal(t, 0, resp.Total)
+		requireTagsLen(t, hr, 0)
 	})
 }
 


### PR DESCRIPTION
Summary:
- Main scope: 变更原因：`AllTags` 接口改为分页后，首页关联该接口只返回部分数据（默认 per=50），导致首页数据不全。首页不想分页（不想多次请求），需要一次性拉取所有数据。.
- Additional context: 主要改动点：.