### PR TITLE
fix(moderation): check image by stream instead of URL to avoid dataset 401

### DIFF
--- a/builder/sensitive/chain.go
+++ b/builder/sensitive/chain.go
@@ -2,6 +2,7 @@ package sensitive
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -123,7 +124,17 @@ func (c *chainImpl) PassImageURLCheck(ctx context.Context, scenario types.Sensit
 }
 
 func (c *chainImpl) PassImageStreamCheck(ctx context.Context, scenario types.SensitiveScenario, reader io.Reader) (*CheckResult, error) {
+	// If the reader is seekable, rewind it before each checker so every
+	// checker receives the full, identical content. Without this, the first
+	// checker consumes the stream and subsequent checkers read empty content.
+	seeker, canSeek := reader.(io.Seeker)
+
 	for _, checker := range c.checkers {
+		if canSeek {
+			if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+				return nil, fmt.Errorf("failed to seek image reader before checker: %w", err)
+			}
+		}
 		res, err := checker.PassImageStreamCheck(ctx, scenario, reader)
 		if err != nil {
 			return nil, err

--- a/builder/sensitive/chain_test.go
+++ b/builder/sensitive/chain_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,6 +14,7 @@ import (
 	green20220302 "github.com/alibabacloud-go/green-20220302/v2/client"
 	util "github.com/alibabacloud-go/tea-utils/v2/service"
 	"github.com/alibabacloud-go/tea/tea"
+	"github.com/stretchr/testify/mock"
 	mockgreen "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/sensitive"
 	"opencsg.com/csghub-server/builder/sensitive"
 	"opencsg.com/csghub-server/common/config"
@@ -431,5 +435,183 @@ func TestNewChainCheckerFromConfig_WithAdvanceOptions(t *testing.T) {
 	}
 	if calledProviders[1] != "another_custom" {
 		t.Fatalf("expected second provider 'another_custom', got '%s'", calledProviders[1])
+	}
+}
+
+// TestChainImpl_PassImageStreamCheck_SeekableReader verifies that when the
+// chain has multiple checkers, each checker receives the full image content.
+// The reader is seekable (strings.NewReader), so the chain rewinds it before
+// each checker. Both checkers read the stream and must see identical content.
+func TestChainImpl_PassImageStreamCheck_SeekableReader(t *testing.T) {
+	imageContent := "fake-image-bytes"
+
+	checker1 := mockgreen.NewMockSensitiveChecker(t)
+	checker2 := mockgreen.NewMockSensitiveChecker(t)
+	chain := sensitive.NewChainCheckerWithCheckers(checker1, checker2)
+
+	ctx := context.Background()
+	scenario := types.ScenarioImageBaseLineCheck
+
+	var mu sync.Mutex
+	var contents []string
+
+	checker1.EXPECT().PassImageStreamCheck(mock.Anything, scenario, mock.Anything).
+		RunAndReturn(func(ctx context.Context, s types.SensitiveScenario, r io.Reader) (*sensitive.CheckResult, error) {
+			b, _ := io.ReadAll(r)
+			mu.Lock()
+			contents = append(contents, string(b))
+			mu.Unlock()
+			return &sensitive.CheckResult{IsSensitive: false}, nil
+		}).Once()
+
+	checker2.EXPECT().PassImageStreamCheck(mock.Anything, scenario, mock.Anything).
+		RunAndReturn(func(ctx context.Context, s types.SensitiveScenario, r io.Reader) (*sensitive.CheckResult, error) {
+			b, _ := io.ReadAll(r)
+			mu.Lock()
+			contents = append(contents, string(b))
+			mu.Unlock()
+			return &sensitive.CheckResult{IsSensitive: false}, nil
+		}).Once()
+
+	result, err := chain.PassImageStreamCheck(ctx, scenario, strings.NewReader(imageContent))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil || result.IsSensitive {
+		t.Fatalf("expected non-sensitive result, got %+v", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(contents) != 2 {
+		t.Fatalf("expected 2 checker calls, got %d", len(contents))
+	}
+	for i, got := range contents {
+		if got != imageContent {
+			t.Fatalf("checker %d: expected content %q, got %q", i, imageContent, got)
+		}
+	}
+}
+
+// TestChainImpl_PassImageStreamCheck_SeekableReader_ShortCircuit verifies that
+// when the first checker detects sensitive content, the chain returns
+// immediately and does not call the second checker.
+func TestChainImpl_PassImageStreamCheck_SeekableReader_ShortCircuit(t *testing.T) {
+	imageContent := "sensitive-image-bytes"
+
+	checker1 := mockgreen.NewMockSensitiveChecker(t)
+	checker2 := mockgreen.NewMockSensitiveChecker(t)
+	chain := sensitive.NewChainCheckerWithCheckers(checker1, checker2)
+
+	ctx := context.Background()
+	scenario := types.ScenarioImageBaseLineCheck
+
+	checker1.EXPECT().PassImageStreamCheck(mock.Anything, scenario, mock.Anything).
+		RunAndReturn(func(ctx context.Context, s types.SensitiveScenario, r io.Reader) (*sensitive.CheckResult, error) {
+			_, _ = io.ReadAll(r) // consume the stream
+			return &sensitive.CheckResult{IsSensitive: true, Reason: "porn"}, nil
+		}).Once()
+	// checker2 must NOT be called
+	checker2.AssertNotCalled(t, "PassImageStreamCheck", mock.Anything, mock.Anything, mock.Anything)
+
+	result, err := chain.PassImageStreamCheck(ctx, scenario, strings.NewReader(imageContent))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil || !result.IsSensitive {
+		t.Fatalf("expected sensitive result, got %+v", result)
+	}
+	if result.Reason != "porn" {
+		t.Fatalf("expected reason 'porn', got '%s'", result.Reason)
+	}
+}
+
+// TestChainImpl_PassImageStreamCheck_NonSeekableReader verifies the behavior
+// when the reader does not implement io.Seeker. The first checker consumes the
+// stream; the second checker reads empty content. This is the known limitation
+// — the test documents the boundary behavior.
+func TestChainImpl_PassImageStreamCheck_NonSeekableReader(t *testing.T) {
+	imageContent := "fake-image-bytes"
+
+	checker1 := mockgreen.NewMockSensitiveChecker(t)
+	checker2 := mockgreen.NewMockSensitiveChecker(t)
+	chain := sensitive.NewChainCheckerWithCheckers(checker1, checker2)
+
+	ctx := context.Background()
+	scenario := types.ScenarioImageBaseLineCheck
+
+	var mu sync.Mutex
+	var contents []string
+
+	checker1.EXPECT().PassImageStreamCheck(mock.Anything, scenario, mock.Anything).
+		RunAndReturn(func(ctx context.Context, s types.SensitiveScenario, r io.Reader) (*sensitive.CheckResult, error) {
+			b, _ := io.ReadAll(r)
+			mu.Lock()
+			contents = append(contents, string(b))
+			mu.Unlock()
+			return &sensitive.CheckResult{IsSensitive: false}, nil
+		}).Once()
+
+	checker2.EXPECT().PassImageStreamCheck(mock.Anything, scenario, mock.Anything).
+		RunAndReturn(func(ctx context.Context, s types.SensitiveScenario, r io.Reader) (*sensitive.CheckResult, error) {
+			b, _ := io.ReadAll(r)
+			mu.Lock()
+			contents = append(contents, string(b))
+			mu.Unlock()
+			return &sensitive.CheckResult{IsSensitive: false}, nil
+		}).Once()
+
+	// Wrap in a struct that only exposes Read, hiding Seek.
+	nonSeekable := struct{ io.Reader }{strings.NewReader(imageContent)}
+
+	result, err := chain.PassImageStreamCheck(ctx, scenario, nonSeekable)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil || result.IsSensitive {
+		t.Fatalf("expected non-sensitive result, got %+v", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(contents) != 2 {
+		t.Fatalf("expected 2 checker calls, got %d", len(contents))
+	}
+	// First checker gets full content
+	if contents[0] != imageContent {
+		t.Fatalf("checker 0: expected %q, got %q", imageContent, contents[0])
+	}
+	// Second checker gets empty content (non-seekable, stream consumed)
+	if contents[1] != "" {
+		t.Fatalf("checker 1: expected empty (non-seekable stream consumed), got %q", contents[1])
+	}
+}
+
+// TestChainImpl_PassImageStreamCheck_SingleChecker verifies that a single
+// checker works correctly with a seekable reader (no unnecessary seek issues).
+func TestChainImpl_PassImageStreamCheck_SingleChecker(t *testing.T) {
+	imageContent := "single-checker-bytes"
+
+	checker1 := mockgreen.NewMockSensitiveChecker(t)
+	chain := sensitive.NewChainCheckerWithCheckers(checker1)
+
+	ctx := context.Background()
+	scenario := types.ScenarioImageBaseLineCheck
+
+	checker1.EXPECT().PassImageStreamCheck(mock.Anything, scenario, mock.Anything).
+		RunAndReturn(func(ctx context.Context, s types.SensitiveScenario, r io.Reader) (*sensitive.CheckResult, error) {
+			b, _ := io.ReadAll(r)
+			if string(b) != imageContent {
+				t.Fatalf("expected %q, got %q", imageContent, string(b))
+			}
+			return &sensitive.CheckResult{IsSensitive: false}, nil
+		}).Once()
+
+	result, err := chain.PassImageStreamCheck(ctx, scenario, strings.NewReader(imageContent))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil || result.IsSensitive {
+		t.Fatalf("expected non-sensitive result, got %+v", result)
 	}
 }

--- a/moderation/checker/file_checker.go
+++ b/moderation/checker/file_checker.go
@@ -96,10 +96,15 @@ func (c *ImageFileChecker) Run(ctx context.Context, fctx FileCheckContext) (type
 	if fctx.ImageURL != "" {
 		return c.checkByURL(ctx, fctx.ImageURL)
 	}
-	if fctx.Reader != nil {
-		return c.checkByStream(ctx, fctx.Reader)
+	if fctx.Reader == nil {
+		return types.SensitiveCheckException, "image url is empty and no stream available"
 	}
-	return types.SensitiveCheckException, "image url is empty and no stream available"
+	// The stream-based check uploads the image to OSS and retries on failure.
+	// Retries require rewinding the reader, so only seekable readers are accepted.
+	if _, seekable := fctx.Reader.(io.ReadSeeker); !seekable {
+		return types.SensitiveCheckException, "image stream reader is not seekable, cannot retry on failure"
+	}
+	return c.checkByStream(ctx, fctx.Reader)
 }
 
 // checkByURL checks an image via its publicly-accessible URL.
@@ -137,7 +142,15 @@ func (c *ImageFileChecker) checkByURL(ctx context.Context, imageURL string) (typ
 
 // checkByStream checks an image by uploading its stream to S3 and generating
 // a presigned URL. Used for private repos where no public URL is available.
+//
+// Retries are only enabled when the reader is seekable (io.ReadSeeker), because
+// the first attempt consumes the stream and retries need a rewind to upload the
+// full content again. The actual rewind before each attempt is handled by
+// chainImpl.PassImageStreamCheck, which seeks the reader to the start before
+// every checker call.
 func (c *ImageFileChecker) checkByStream(ctx context.Context, reader io.Reader) (types.SensitiveCheckStatus, string) {
+	_, seekable := reader.(io.ReadSeeker)
+
 	res, err := retry.DoWithData(
 		func() (*sensitive.CheckResult, error) {
 			reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -145,7 +158,9 @@ func (c *ImageFileChecker) checkByStream(ctx context.Context, reader io.Reader) 
 			return c.checker.PassImageStreamCheck(reqCtx, c.scenario, reader)
 		}, retry.Attempts(3), retry.DelayType(retry.BackOffDelay), retry.LastErrorOnly(true),
 		retry.RetryIf(func(error) bool {
-			return ctx.Err() == nil
+			// Only retry when the reader is seekable; otherwise the stream
+			// has been consumed and retries would upload empty content.
+			return seekable && ctx.Err() == nil
 		}))
 
 	if err != nil {

--- a/moderation/checker/file_checker_test.go
+++ b/moderation/checker/file_checker_test.go
@@ -3,7 +3,9 @@ package checker
 import (
 	"context"
 	"errors"
+	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -228,6 +230,79 @@ func TestImageFileChecker_Run(t *testing.T) {
 		if message != "call sensitive image stream checker api failed" {
 			t.Errorf("Expected message '%s', got '%s'", "call sensitive image stream checker api failed", message)
 		}
+	})
+
+	// "stream check retry receives identical content" verifies that retries
+	// work correctly when the reader is seekable. checkByStream only retries
+	// when the reader implements io.ReadSeeker; the actual rewind before each
+	// attempt is handled by chainImpl.PassImageStreamCheck (which seeks before
+	// each checker). This mock simulates that behavior by seeking the reader
+	// to the start before reading on each attempt. The first attempt fails and
+	// the second succeeds; both must receive the exact same bytes.
+	t.Run("stream check retry receives identical content", func(t *testing.T) {
+		imageContent := "the-quick-brown-fox"
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+
+		// Track the content read on each call.
+		var contents []string
+		var mu sync.Mutex
+		mockChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).
+			RunAndReturn(func(ctx context.Context, scenario types.SensitiveScenario, r io.Reader) (*sensitive.CheckResult, error) {
+				// Simulate chain layer: seek to start before reading.
+				if seeker, ok := r.(io.Seeker); ok {
+					_, _ = seeker.Seek(0, io.SeekStart)
+				}
+				b, _ := io.ReadAll(r)
+				mu.Lock()
+				contents = append(contents, string(b))
+				mu.Unlock()
+				// First attempt fails, forcing a retry.
+				if len(contents) == 1 {
+					return nil, errors.New("transient upload error")
+				}
+				return &sensitive.CheckResult{IsSensitive: false}, nil
+			}).Twice()
+
+		c := newEnabledChecker(true, mockChecker)
+		status, message := c.Run(context.Background(), FileCheckContext{Reader: strings.NewReader(imageContent)})
+		if status != types.SensitiveCheckPass {
+			t.Errorf("Expected status %v, got %v", types.SensitiveCheckPass, status)
+		}
+		if message != "" {
+			t.Errorf("Expected empty message, got '%s'", message)
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if len(contents) != 2 {
+			t.Fatalf("expected 2 stream check attempts, got %d", len(contents))
+		}
+		for i, got := range contents {
+			if got != imageContent {
+				t.Errorf("attempt %d: expected content %q, got %q", i, imageContent, got)
+			}
+		}
+	})
+
+	// "stream check non-seekable reader returns exception" verifies that
+	// when the reader does not implement io.ReadSeeker, Run rejects it
+	// immediately without calling the sensitive checker, because retries
+	// require a seekable reader to rewind the stream.
+	t.Run("stream check non-seekable reader returns exception", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+
+		c := newEnabledChecker(true, mockChecker)
+		// Wrap a seekable reader to hide Seek, making it non-seekable.
+		nonSeekable := struct{ io.Reader }{strings.NewReader("image-bytes")}
+		status, message := c.Run(context.Background(), FileCheckContext{Reader: nonSeekable})
+		if status != types.SensitiveCheckException {
+			t.Errorf("Expected status %v, got %v", types.SensitiveCheckException, status)
+		}
+		if message != "image stream reader is not seekable, cannot retry on failure" {
+			t.Errorf("Expected message '%s', got '%s'", "image stream reader is not seekable, cannot retry on failure", message)
+		}
+		// The sensitive checker should never be called.
+		mockChecker.AssertNotCalled(t, "PassImageStreamCheck")
 	})
 }
 

--- a/moderation/checker/unknown_file_checker.go
+++ b/moderation/checker/unknown_file_checker.go
@@ -32,6 +32,7 @@ func (c *UnkownFileChecker) Run(ctx context.Context, fctx FileCheckContext) (typ
 	buffer = buffer[:n]
 	// Detect the file content type like text/plain, image/jpeg, etc
 	detectedType := http.DetectContentType(buffer)
+
 	switch {
 	case strings.HasPrefix(detectedType, "text"):
 		slog.Debug("use text file checker for unknown file", slog.String("content_type", detectedType))
@@ -41,8 +42,19 @@ func (c *UnkownFileChecker) Run(ctx context.Context, fctx FileCheckContext) (typ
 	case strings.HasPrefix(detectedType, "image"):
 		slog.Debug("use image file checker for unknown file", slog.String("content_type", detectedType))
 		ic := NewImageFileChecker()
-		mreader := io.MultiReader(bytes.NewReader(buffer), reader)
-		return ic.Run(ctx, FileCheckContext{Reader: mreader, ImageURL: fctx.ImageURL})
+		// When a URL is available, the Aliyun service fetches the image directly,
+		// so the reader is not needed. Only rewind the reader for stream-based
+		// checks (no URL). If the reader is not seekable, rewindReader returns
+		// nil — short-circuit with an exception instead of passing an
+		// un-rewindable reader downstream.
+		if fctx.ImageURL != "" {
+			return ic.Run(ctx, FileCheckContext{ImageURL: fctx.ImageURL})
+		}
+		rewoundReader := rewindReader(reader, buffer)
+		if rewoundReader == nil {
+			return types.SensitiveCheckException, "image stream reader is not seekable, cannot retry on failure"
+		}
+		return ic.Run(ctx, FileCheckContext{Reader: rewoundReader})
 	case strings.HasPrefix(detectedType, "audio"):
 		slog.Debug("skip audio checker for unknown file", slog.String("content_type", detectedType))
 		return types.SensitiveCheckSkip, "skip binary audio file"
@@ -54,4 +66,21 @@ func (c *UnkownFileChecker) Run(ctx context.Context, fctx FileCheckContext) (typ
 		return types.SensitiveCheckSkip, "skip binary file"
 	}
 
+}
+
+// rewindReader resets the reader to the beginning after 512 bytes have been
+// consumed for content-type detection. If the reader implements io.Seeker,
+// it is seeked back to position 0 and returned directly — this preserves
+// seekability for downstream retry/chain logic. If the reader is not seekable,
+// nil is returned so the caller can short-circuit instead of passing an
+// un-rewindable reader downstream.
+func rewindReader(reader io.Reader, consumed []byte) io.Reader {
+	if seeker, ok := reader.(io.Seeker); ok {
+		if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+			slog.Error("failed to seek reader back to start", slog.Any("error", err))
+			return nil
+		}
+		return reader
+	}
+	return nil
 }

--- a/moderation/checker/unknown_file_checker_test.go
+++ b/moderation/checker/unknown_file_checker_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"image"
 	"image/png"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -76,8 +77,9 @@ func TestUnkownFileChecker_Run(t *testing.T) {
 		mockChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).
 			Return(&sensitive.CheckResult{IsSensitive: false}, nil)
 
+		// bytes.Reader implements io.ReadSeeker so rewindReader can seek it back.
 		c := &UnkownFileChecker{}
-		status, msg := c.Run(context.Background(), FileCheckContext{Reader: &pngBuf})
+		status, msg := c.Run(context.Background(), FileCheckContext{Reader: bytes.NewReader(pngBuf.Bytes())})
 		require.Equal(t, types.SensitiveCheckPass, status)
 		require.Empty(t, msg)
 	})
@@ -97,8 +99,72 @@ func TestUnkownFileChecker_Run(t *testing.T) {
 			Return(&sensitive.CheckResult{IsSensitive: true, Reason: "label:porn"}, nil)
 
 		c := &UnkownFileChecker{}
-		status, msg := c.Run(context.Background(), FileCheckContext{Reader: &pngBuf})
+		status, msg := c.Run(context.Background(), FileCheckContext{Reader: bytes.NewReader(pngBuf.Bytes())})
 		require.Equal(t, types.SensitiveCheckFail, status)
 		require.Equal(t, "label:porn", msg)
+	})
+
+	// "image detected with seekable reader rewinds and passes full content"
+	// verifies that when the reader is seekable (e.g. RepoFileContentReader),
+	// UnkownFileChecker seeks it back to the start after detecting content type,
+	// so the downstream ImageFileChecker receives the full file content from
+	// the beginning. The mock reads the stream and verifies it starts with the
+	// PNG magic header (proving the reader was rewound past the 512-byte
+	// detection read).
+	t.Run("image detected with seekable reader rewinds and passes full content", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		cfg := &config.Config{}
+		cfg.SensitiveCheck.Enable = true
+		cfg.SensitiveCheck.ImageCheckEnable = true
+		InitWithContentChecker(cfg, mockChecker)
+
+		var pngBuf bytes.Buffer
+		err := png.Encode(&pngBuf, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+		require.NoError(t, err)
+		pngData := pngBuf.Bytes()
+
+		var readContent []byte
+		mockChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).
+			RunAndReturn(func(ctx context.Context, scenario types.SensitiveScenario, r io.Reader) (*sensitive.CheckResult, error) {
+				readContent, _ = io.ReadAll(r)
+				return &sensitive.CheckResult{IsSensitive: false}, nil
+			}).Once()
+
+		// bytes.Reader implements io.ReadSeeker
+		c := &UnkownFileChecker{}
+		status, msg := c.Run(context.Background(), FileCheckContext{Reader: bytes.NewReader(pngData)})
+		require.Equal(t, types.SensitiveCheckPass, status)
+		require.Empty(t, msg)
+
+		// The content read by the checker must be the full PNG data, including
+		// the magic header that was consumed during detection.
+		require.Equal(t, pngData, readContent, "downstream checker should receive full content from start")
+	})
+
+	// "image detected with non-seekable reader returns exception"
+	// verifies that when the reader is NOT seekable, rewindReader returns nil
+	// and ImageFileChecker.Run returns an exception instead of passing an
+	// un-rewindable reader downstream.
+	t.Run("image detected with non-seekable reader returns exception", func(t *testing.T) {
+		mockChecker := mocksens.NewMockSensitiveChecker(t)
+		cfg := &config.Config{}
+		cfg.SensitiveCheck.Enable = true
+		cfg.SensitiveCheck.ImageCheckEnable = true
+		InitWithContentChecker(cfg, mockChecker)
+
+		var pngBuf bytes.Buffer
+		err := png.Encode(&pngBuf, image.NewRGBA(image.Rect(0, 0, 1, 1)))
+		require.NoError(t, err)
+		pngData := pngBuf.Bytes()
+
+		// Wrap in a struct that only exposes Read (not Seek)
+		nonSeekable := struct{ io.Reader }{bytes.NewReader(pngData)}
+		c := &UnkownFileChecker{}
+		status, msg := c.Run(context.Background(), FileCheckContext{Reader: nonSeekable})
+		require.Equal(t, types.SensitiveCheckException, status)
+		require.Equal(t, "image stream reader is not seekable, cannot retry on failure", msg)
+
+		// The sensitive checker should never be called.
+		mockChecker.AssertNotCalled(t, "PassImageStreamCheck")
 	})
 }

--- a/moderation/component/repo.go
+++ b/moderation/component/repo.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/url"
-	"strings"
 	"sync"
 	"time"
 
@@ -177,11 +175,15 @@ func (c *repoComponentImpl) CheckRepoFiles(ctx context.Context, repoID int64, op
 }
 
 func (c *repoComponentImpl) processFile(ctx context.Context, file *database.RepositoryFile) {
-	reader := NewRepoFileContentReader(file, c.git)
+	reader := NewRepoFileContentReader(ctx, file, c.git)
 	defer reader.Close()
-	imageURL := c.buildImageURL(file)
 	fc := checker.GetFileChecker(file.FileType, file.Path, file.LfsRelativePath)
-	status, msg := fc.Run(ctx, checker.FileCheckContext{Reader: reader, ImageURL: imageURL})
+	// Datasets (even public ones) require authentication to access their files,
+	// so the Aliyun moderation service cannot fetch them via the download URL
+	// (it gets a 401). Therefore we only pass the Reader so that
+	// ImageFileChecker checks image content by stream (upload to S3 +
+	// presigned URL).
+	status, msg := fc.Run(ctx, checker.FileCheckContext{Reader: reader})
 	if status == types.SensitiveCheckException {
 		slog.ErrorContext(ctx, "failed to check repo file content", slog.Int64("repo_id", file.RepositoryID), slog.Int64("repo_file_id", file.ID), slog.String("file", file.Path),
 			slog.String("err", msg))
@@ -191,61 +193,6 @@ func (c *repoComponentImpl) processFile(ctx context.Context, file *database.Repo
 	if err != nil {
 		slog.ErrorContext(ctx, "save check result failed", slog.Any("error", err))
 	}
-}
-
-// repoTypeURLPath maps a repository type to the URL path segment used by the
-// public API routes (e.g. "model" -> "models", "mcpserver" -> "mcps").
-func repoTypeURLPath(repoType types.RepositoryType) string {
-	if repoType == types.MCPServerRepo {
-		return "mcps"
-	}
-	return string(repoType) + "s"
-}
-
-// buildImageURL constructs a publicly-accessible URL for an image file so that
-// the remote moderation service (e.g. Aliyun Green) can fetch it. The URL uses
-// the download endpoint which streams raw bytes.
-//
-// Returns an empty string for non-image files, private repos (the URL would not
-// be accessible without auth), or when repository metadata is missing.
-func (c *repoComponentImpl) buildImageURL(file *database.RepositoryFile) string {
-	if file == nil || file.Repository == nil {
-		return ""
-	}
-
-	if !types.IsImageFile(file.Path) {
-		return ""
-	}
-
-	// For private repos, the download URL requires authentication and cannot
-	// be fetched by the remote moderation service. Return empty so that
-	// ImageFileChecker falls back to checkByStream (upload to S3 + presigned URL).
-	if file.Repository.Private {
-		return ""
-	}
-
-	namespace, name := file.Repository.NamespaceAndName()
-	if namespace == "" || name == "" {
-		slog.Warn("failed to build image url, invalid repository path", slog.String("path", file.Repository.Path))
-		return ""
-	}
-
-	ref := file.Repository.DefaultBranch
-	if ref == "" {
-		ref = "main"
-	}
-
-	domain := strings.TrimSuffix(c.config.APIServer.PublicDomain, "/")
-	// e.g. https://opencsg.com/api/v1/codes/cemeng/sensitive-test/download/example.jpg
-	imageURL := fmt.Sprintf("%s/api/v1/%s/%s/%s/download/%s?ref=%s",
-		domain,
-		repoTypeURLPath(file.Repository.RepositoryType),
-		namespace,
-		name,
-		file.Path,
-		url.QueryEscape(ref),
-	)
-	return imageURL
 }
 
 func (c *repoComponentImpl) saveCheckResult(ctx context.Context, file *database.RepositoryFile, status types.SensitiveCheckStatus, msg string) error {

--- a/moderation/component/repo_file_content_reader.go
+++ b/moderation/component/repo_file_content_reader.go
@@ -12,25 +12,32 @@ import (
 )
 
 type RepoFileContentReader struct {
+	initCtx     context.Context
 	file        *database.RepositoryFile
 	git         gitserver.GitServer
 	innerReader io.ReadCloser
 	once        *sync.Once
+	closeOnce   *sync.Once
+	closeErr    error
 }
 
-var _ io.ReadCloser = (*RepoFileContentReader)(nil)
+var _ io.ReadSeekCloser = (*RepoFileContentReader)(nil)
 
-func NewRepoFileContentReader(file *database.RepositoryFile, git gitserver.GitServer) *RepoFileContentReader {
+func NewRepoFileContentReader(ctx context.Context, file *database.RepositoryFile, git gitserver.GitServer) *RepoFileContentReader {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	return &RepoFileContentReader{
-		file: file,
-		git:  git,
-		once: &sync.Once{},
+		initCtx:   ctx,
+		file:      file,
+		git:       git,
+		once:      &sync.Once{},
+		closeOnce: &sync.Once{},
 	}
 }
 
 func (c *RepoFileContentReader) Read(p []byte) (n int, err error) {
 	c.lazyInit()
-
 	if c.innerReader == nil {
 		return 0, errors.New("failed to read file content as git file reader not initialized")
 	}
@@ -38,10 +45,40 @@ func (c *RepoFileContentReader) Read(p []byte) (n int, err error) {
 }
 
 func (c *RepoFileContentReader) Close() error {
-	if c.innerReader == nil {
-		return errors.New("failed to close reader as git file reader not initialized")
+	c.closeOnce.Do(func() {
+		if c.innerReader != nil {
+			c.closeErr = c.innerReader.Close()
+		}
+	})
+	return c.closeErr
+}
+
+// Seek implements io.ReadSeeker. Only Seek(0, io.SeekStart) is supported — it
+// closes the current underlying stream and resets the reader so that the next
+// Read re-opens the file from the git server. This allows retry logic (e.g. in
+// ImageFileChecker.checkByStream) to rewind and re-read the full content after
+// a transient failure. Any other offset returns an error.
+func (c *RepoFileContentReader) Seek(offset int64, whence int) (int64, error) {
+	if offset != 0 || whence != io.SeekStart {
+		return 0, errors.New("only Seek(0, io.SeekStart) is supported")
 	}
-	return c.innerReader.Close()
+
+	// Close the current inner reader if it was opened. A close failure (e.g.
+	// RST, broken pipe) can signal a git-server issue relevant to diagnosing
+	// 401 or transient failures, so log it instead of silently discarding.
+	if c.innerReader != nil {
+		if err := c.innerReader.Close(); err != nil {
+			slog.ErrorContext(context.Background(), "failed to close inner reader during seek",
+				slog.Any("error", err), slog.String("path", c.file.Path))
+		}
+		c.innerReader = nil
+	}
+
+	// Reset so lazyInit re-opens the stream on the next Read.
+	c.once = &sync.Once{}
+	c.closeOnce = &sync.Once{}
+	c.closeErr = nil
+	return 0, nil
 }
 
 func (c *RepoFileContentReader) lazyInit() {
@@ -54,12 +91,10 @@ func (c *RepoFileContentReader) lazyInit() {
 			RepoType:  c.file.Repository.RepositoryType,
 			Ref:       c.file.Repository.DefaultBranch,
 		}
-
-		ctx := context.Background()
 		var err error
-		c.innerReader, _, err = c.git.GetRepoFileReader(ctx, req)
+		c.innerReader, _, err = c.git.GetRepoFileReader(c.initCtx, req)
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to create git file reader", slog.Any("error", err), slog.String("path", c.file.Path), slog.Int64("repository_file_id", c.file.ID))
+			slog.ErrorContext(c.initCtx, "failed to create git file reader", slog.Any("error", err), slog.String("path", c.file.Path), slog.Int64("repository_file_id", c.file.ID))
 		}
 	})
 }

--- a/moderation/component/repo_file_content_reader_test.go
+++ b/moderation/component/repo_file_content_reader_test.go
@@ -1,0 +1,216 @@
+package component_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	mock_gitserver "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/git/gitserver"
+	"opencsg.com/csghub-server/builder/git/gitserver"
+	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/moderation/component"
+)
+
+// mockReadCloser is a mock for io.ReadCloser that simulates behavior of a real file reader.
+type mockReadCloser struct {
+	reader     io.Reader
+	mu         sync.Mutex
+	closed     bool
+	closeCount int
+}
+
+func newMockReadCloser(content string) *mockReadCloser {
+	return &mockReadCloser{
+		reader: strings.NewReader(content),
+	}
+}
+
+func (m *mockReadCloser) Read(p []byte) (n int, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return 0, io.ErrClosedPipe
+	}
+	return m.reader.Read(p)
+}
+
+func (m *mockReadCloser) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return io.ErrClosedPipe
+	}
+	m.closed = true
+	m.closeCount++
+	return nil
+}
+
+func (m *mockReadCloser) GetCloseCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closeCount
+}
+
+func TestRepoFileContentReader(t *testing.T) {
+	dummyRepoFile := &database.RepositoryFile{
+		Repository: &database.Repository{
+			Path: "test_ns/test_repo",
+			Name: "test_repo",
+		},
+		Path: "test_file.txt",
+	}
+	req := gitserver.GetRepoInfoByPathReq{
+		Namespace: "test_ns",
+		Name:      "test_repo",
+		Path:      "test_file.txt",
+		RepoType:  dummyRepoFile.Repository.RepositoryType,
+		Ref:       dummyRepoFile.Repository.DefaultBranch,
+	}
+
+	t.Run("Read and Close", func(t *testing.T) {
+		assert := assert.New(t)
+		mockCloser := newMockReadCloser("file content")
+		mockGit := mock_gitserver.NewMockGitServer(t)
+		mockGit.EXPECT().GetRepoFileReader(mock.Anything, req).Return(mockCloser, 0, nil).Once()
+		reader := component.NewRepoFileContentReader(context.Background(), dummyRepoFile, mockGit)
+
+		buf := make([]byte, 12)
+		n, err := reader.Read(buf)
+		assert.NoError(err)
+		assert.Equal(12, n)
+		assert.Equal("file content", string(buf))
+
+		err = reader.Close()
+		assert.NoError(err)
+		assert.Equal(1, mockCloser.GetCloseCount())
+
+		// Read after close
+		n, err = reader.Read(buf)
+		assert.Error(err)
+		assert.ErrorIs(err, io.ErrClosedPipe)
+		assert.Equal(0, n)
+	})
+
+	t.Run("Close is idempotent", func(t *testing.T) {
+		assert := assert.New(t)
+		mockCloser := newMockReadCloser("file content")
+		mockGit := mock_gitserver.NewMockGitServer(t)
+		mockGit.EXPECT().GetRepoFileReader(mock.Anything, req).Return(mockCloser, 0, nil).Once()
+		reader := component.NewRepoFileContentReader(context.Background(), dummyRepoFile, mockGit)
+
+		// Read to initialize
+		_, err := io.Copy(io.Discard, reader)
+		assert.NoError(err)
+
+		// Close multiple times
+		assert.NoError(reader.Close())
+		assert.NoError(reader.Close())
+
+		assert.Equal(1, mockCloser.GetCloseCount(), "Close should be called only once")
+	})
+
+	t.Run("Close is thread-safe", func(t *testing.T) {
+		assert := assert.New(t)
+		mockCloser := newMockReadCloser("file content")
+		mockGit := mock_gitserver.NewMockGitServer(t)
+		mockGit.EXPECT().GetRepoFileReader(mock.Anything, req).Return(mockCloser, 0, nil).Once()
+		reader := component.NewRepoFileContentReader(context.Background(), dummyRepoFile, mockGit)
+
+		// Read to initialize
+		_, err := io.Copy(io.Discard, reader)
+		assert.NoError(err)
+
+		// Concurrently close
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				assert.NoError(reader.Close())
+			}()
+		}
+		wg.Wait()
+
+		assert.Equal(1, mockCloser.GetCloseCount(), "Close should be called only once in concurrent situation")
+	})
+
+	t.Run("Close before reader init returns no error", func(t *testing.T) {
+		assert := assert.New(t)
+		mockGit := mock_gitserver.NewMockGitServer(t)
+		reader := component.NewRepoFileContentReader(context.Background(), dummyRepoFile, mockGit)
+
+		err := reader.Close()
+		assert.NoError(err)
+	})
+
+	t.Run("Initialization failure", func(t *testing.T) {
+		assert := assert.New(t)
+		initErr := errors.New("init failed")
+		mockGit := mock_gitserver.NewMockGitServer(t)
+		mockGit.EXPECT().GetRepoFileReader(mock.Anything, req).Return(nil, 0, initErr).Once()
+		reader := component.NewRepoFileContentReader(context.Background(), dummyRepoFile, mockGit)
+
+		// Read should fail
+		buf := make([]byte, 10)
+		n, err := reader.Read(buf)
+		assert.Error(err)
+		assert.Equal(0, n)
+		assert.Contains(err.Error(), "not initialized")
+
+		// Close should succeed (as in, not error) because there's nothing to close
+		err = reader.Close()
+		assert.NoError(err)
+	})
+
+	t.Run("Seek(0, Start) reopens stream for retry", func(t *testing.T) {
+		assert := assert.New(t)
+		content := "file content"
+
+		// First GetRepoFileReader call for initial read
+		mockCloser1 := newMockReadCloser(content)
+		// Second GetRepoFileReader call after Seek reopens
+		mockCloser2 := newMockReadCloser(content)
+		mockGit := mock_gitserver.NewMockGitServer(t)
+		mockGit.EXPECT().GetRepoFileReader(mock.Anything, req).Return(mockCloser1, 0, nil).Once()
+		mockGit.EXPECT().GetRepoFileReader(mock.Anything, req).Return(mockCloser2, 0, nil).Once()
+		reader := component.NewRepoFileContentReader(context.Background(), dummyRepoFile, mockGit)
+
+		// First read consumes the stream
+		buf, err := io.ReadAll(reader)
+		assert.NoError(err)
+		assert.Equal(content, string(buf))
+
+		// Seek(0, Start) should close the old stream and reset for reopen
+		pos, err := reader.Seek(0, io.SeekStart)
+		assert.NoError(err)
+		assert.Equal(int64(0), pos)
+		// Old stream should be closed
+		assert.Equal(1, mockCloser1.GetCloseCount())
+
+		// Read again — should get the same content from the reopened stream
+		buf2, err := io.ReadAll(reader)
+		assert.NoError(err)
+		assert.Equal(content, string(buf2))
+
+		assert.NoError(reader.Close())
+		assert.Equal(1, mockCloser2.GetCloseCount())
+	})
+
+	t.Run("Seek with unsupported offset returns error", func(t *testing.T) {
+		assert := assert.New(t)
+		mockGit := mock_gitserver.NewMockGitServer(t)
+		reader := component.NewRepoFileContentReader(context.Background(), dummyRepoFile, mockGit)
+
+		_, err := reader.Seek(1, io.SeekStart)
+		assert.Error(err)
+
+		_, err = reader.Seek(0, io.SeekCurrent)
+		assert.Error(err)
+	})
+
+}

--- a/moderation/component/repo_test.go
+++ b/moderation/component/repo_test.go
@@ -363,6 +363,294 @@ func TestRepoComponent_CheckRepoFiles(t *testing.T) {
 	require.True(t, failFound, "Check for failed file not found")
 }
 
+// TestRepoComponent_CheckRepoFiles_ImageByStream is a regression test for the
+// 401 issue when the Aliyun moderation service fetches image files via the
+// public download URL. Datasets require login to access file downloads even
+// when public, so the remote checker gets a 401.
+//
+// processFile must NOT pass ImageURL to the file checker; image files must be
+// checked by stream (upload to S3 + presigned URL) instead, regardless of
+// whether the repo is public or private, or whether it is a dataset or not.
+// Each subtest asserts that PassImageStreamCheck is called and
+// PassImageURLCheck is never called.
+func TestRepoComponent_CheckRepoFiles_ImageByStream(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		repo     *database.Repository
+		imageExt string
+	}{
+		{
+			name: "public dataset image checked by stream",
+			repo: &database.Repository{
+				ID:                   1,
+				Name:                 "test-dataset",
+				Path:                 "root/test-dataset",
+				DefaultBranch:        "main",
+				SensitiveCheckStatus: types.SensitiveCheckPass,
+				RepositoryType:       types.DatasetRepo,
+				Private:              false,
+			},
+			imageExt: "png",
+		},
+		{
+			name: "private dataset image checked by stream",
+			repo: &database.Repository{
+				ID:                   2,
+				Name:                 "private-dataset",
+				Path:                 "root/private-dataset",
+				DefaultBranch:        "main",
+				SensitiveCheckStatus: types.SensitiveCheckPass,
+				RepositoryType:       types.DatasetRepo,
+				Private:              true,
+			},
+			imageExt: "jpg",
+		},
+		{
+			name: "public model image checked by stream",
+			repo: &database.Repository{
+				ID:                   3,
+				Name:                 "test-model",
+				Path:                 "root/test-model",
+				DefaultBranch:        "main",
+				SensitiveCheckStatus: types.SensitiveCheckPass,
+				RepositoryType:       types.ModelRepo,
+				Private:              false,
+			},
+			imageExt: "jpeg",
+		},
+		{
+			name: "private model image checked by stream",
+			repo: &database.Repository{
+				ID:                   4,
+				Name:                 "private-model",
+				Path:                 "root/private-model",
+				DefaultBranch:        "main",
+				SensitiveCheckStatus: types.SensitiveCheckPass,
+				RepositoryType:       types.ModelRepo,
+				Private:              true,
+			},
+			imageExt: "gif",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepoStore := mockdb.NewMockRepoStore(t)
+			mockRepoFileStore := mockdb.NewMockRepoFileStore(t)
+			mockRepoFileCheckStore := mockdb.NewMockRepoFileCheckStore(t)
+			mockGitServer := mockgit.NewMockGitServer(t)
+			repoComp := &repoComponentImpl{
+				rs:               mockRepoStore,
+				rfs:              mockRepoFileStore,
+				rfcs:             mockRepoFileCheckStore,
+				git:              mockGitServer,
+				concurrencyLimit: 10,
+			}
+			repoComp.config = &config.Config{}
+			repoComp.config.APIServer.PublicDomain = "https://hub.opencsg.com"
+
+			imageFile := &database.RepositoryFile{
+				ID:           1,
+				RepositoryID: tt.repo.ID,
+				Path:         "screenshot." + tt.imageExt,
+				FileType:     "file",
+				Repository:   tt.repo,
+			}
+
+			// One batch returning the image file. Since count(1) < BatchSize(10),
+			// the loop breaks after the first batch — no second batch call.
+			mockRepoFileStore.EXPECT().BatchGetUnchcked(mock.Anything, tt.repo.ID, int64(0), int64(10)).Once().
+				Return([]*database.RepositoryFile{imageFile}, nil)
+
+			cfg := &config.Config{}
+			cfg.SensitiveCheck.Enable = true
+			cfg.SensitiveCheck.ImageCheckEnable = true
+			mockSensitiveChecker := mockSensit.NewMockSensitiveChecker(t)
+			// Stream check should be invoked (path that uploads to S3 +
+			// presigned URL). The mock does not read from the reader, so the
+			// lazy git reader (GetRepoFileReader) is never opened.
+			mockSensitiveChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).
+				Return(&sensitive.CheckResult{IsSensitive: false}, nil).Once()
+			// URL check must never be called — this is the core of the
+			// regression, for both public and private repos.
+			mockSensitiveChecker.AssertNotCalled(t, "PassImageURLCheck", mock.Anything, mock.Anything, mock.Anything)
+			checker.InitWithContentChecker(cfg, mockSensitiveChecker)
+
+			mockRepoFileCheckStore.EXPECT().Upsert(mock.Anything, mock.Anything).Return(nil).Once()
+
+			err := repoComp.CheckRepoFiles(ctx, tt.repo.ID, CheckOption{
+				BatchSize: 10,
+			})
+			require.Nil(t, err)
+		})
+	}
+
+	// "stream check reads actual content from git reader" verifies the
+	// end-to-end path where the sensitive checker actually reads the image
+	// stream from the git reader (GetRepoFileReader). This covers the review
+	// feedback that the mock should read the stream instead of ignoring it.
+	t.Run("stream check reads actual content from git reader", func(t *testing.T) {
+		mockRepoStore := mockdb.NewMockRepoStore(t)
+		mockRepoFileStore := mockdb.NewMockRepoFileStore(t)
+		mockRepoFileCheckStore := mockdb.NewMockRepoFileCheckStore(t)
+		mockGitServer := mockgit.NewMockGitServer(t)
+		repoComp := &repoComponentImpl{
+			rs:               mockRepoStore,
+			rfs:              mockRepoFileStore,
+			rfcs:             mockRepoFileCheckStore,
+			git:              mockGitServer,
+			concurrencyLimit: 10,
+		}
+		repoComp.config = &config.Config{}
+		repoComp.config.APIServer.PublicDomain = "https://hub.opencsg.com"
+
+		repo := &database.Repository{
+			ID:                   1,
+			Name:                 "test-dataset",
+			Path:                 "root/test-dataset",
+			DefaultBranch:        "main",
+			SensitiveCheckStatus: types.SensitiveCheckPass,
+			RepositoryType:       types.DatasetRepo,
+			Private:              false,
+		}
+		imageFile := &database.RepositoryFile{
+			ID:           1,
+			RepositoryID: 1,
+			Path:         "screenshot.png",
+			FileType:     "file",
+			Repository:   repo,
+		}
+
+		mockRepoFileStore.EXPECT().BatchGetUnchcked(mock.Anything, repo.ID, int64(0), int64(10)).Once().
+			Return([]*database.RepositoryFile{imageFile}, nil)
+
+		// Provide real image bytes via the git reader.
+		imageContent := "png-image-bytes"
+		mockGitServer.EXPECT().GetRepoFileReader(mock.Anything, mock.MatchedBy(func(req gitserver.GetRepoInfoByPathReq) bool {
+			return req.Path == imageFile.Path
+		})).Return(io.NopCloser(strings.NewReader(imageContent)), int64(len(imageContent)), nil).Once()
+
+		cfg := &config.Config{}
+		cfg.SensitiveCheck.Enable = true
+		cfg.SensitiveCheck.ImageCheckEnable = true
+		mockSensitiveChecker := mockSensit.NewMockSensitiveChecker(t)
+		// The mock actually reads the stream and verifies the content matches
+		// what GetRepoFileReader returned.
+		mockSensitiveChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).
+			RunAndReturn(func(ctx context.Context, scenario types.SensitiveScenario, r io.Reader) (*sensitive.CheckResult, error) {
+				b, err := io.ReadAll(r)
+				require.NoError(t, err)
+				require.Equal(t, imageContent, string(b))
+				return &sensitive.CheckResult{IsSensitive: false}, nil
+			}).Once()
+		mockSensitiveChecker.AssertNotCalled(t, "PassImageURLCheck", mock.Anything, mock.Anything, mock.Anything)
+		checker.InitWithContentChecker(cfg, mockSensitiveChecker)
+
+		mockRepoFileCheckStore.EXPECT().Upsert(mock.Anything, mock.Anything).Return(nil).Once()
+
+		err := repoComp.CheckRepoFiles(ctx, repo.ID, CheckOption{
+			BatchSize: 10,
+		})
+		require.Nil(t, err)
+	})
+
+	// "stream check retry reopens git reader with identical content" verifies
+	// the full retry path: the first PassImageStreamCheck fails, checkByStream
+	// retries by calling Seek(0) on RepoFileContentReader (which reopens the
+	// git stream), and the second attempt succeeds. Both attempts must receive
+	// the exact same image bytes. GetRepoFileReader is called twice (once per
+	// open). This directly addresses the review feedback.
+	t.Run("stream check retry reopens git reader with identical content", func(t *testing.T) {
+		mockRepoStore := mockdb.NewMockRepoStore(t)
+		mockRepoFileStore := mockdb.NewMockRepoFileStore(t)
+		mockRepoFileCheckStore := mockdb.NewMockRepoFileCheckStore(t)
+		mockGitServer := mockgit.NewMockGitServer(t)
+		repoComp := &repoComponentImpl{
+			rs:               mockRepoStore,
+			rfs:              mockRepoFileStore,
+			rfcs:             mockRepoFileCheckStore,
+			git:              mockGitServer,
+			concurrencyLimit: 10,
+		}
+		repoComp.config = &config.Config{}
+		repoComp.config.APIServer.PublicDomain = "https://hub.opencsg.com"
+
+		repo := &database.Repository{
+			ID:                   1,
+			Name:                 "test-dataset",
+			Path:                 "root/test-dataset",
+			DefaultBranch:        "main",
+			SensitiveCheckStatus: types.SensitiveCheckPass,
+			RepositoryType:       types.DatasetRepo,
+			Private:              false,
+		}
+		imageFile := &database.RepositoryFile{
+			ID:           1,
+			RepositoryID: 1,
+			Path:         "screenshot.png",
+			FileType:     "file",
+			Repository:   repo,
+		}
+
+		mockRepoFileStore.EXPECT().BatchGetUnchcked(mock.Anything, repo.ID, int64(0), int64(10)).Once().
+			Return([]*database.RepositoryFile{imageFile}, nil)
+
+		imageContent := "png-image-bytes-for-retry"
+		// GetRepoFileReader called twice: initial open + reopen after Seek.
+		// Use RunAndReturn so each call returns a fresh reader (the previous
+		// one is consumed/closed by the first attempt).
+		mockGitServer.EXPECT().GetRepoFileReader(mock.Anything, mock.MatchedBy(func(req gitserver.GetRepoInfoByPathReq) bool {
+			return req.Path == imageFile.Path
+		})).RunAndReturn(func(ctx context.Context, req gitserver.GetRepoInfoByPathReq) (io.ReadCloser, int64, error) {
+			return io.NopCloser(strings.NewReader(imageContent)), int64(len(imageContent)), nil
+		}).Twice()
+
+		cfg := &config.Config{}
+		cfg.SensitiveCheck.Enable = true
+		cfg.SensitiveCheck.ImageCheckEnable = true
+		mockSensitiveChecker := mockSensit.NewMockSensitiveChecker(t)
+
+		var contents []string
+		var mu sync.Mutex
+		mockSensitiveChecker.EXPECT().PassImageStreamCheck(mock.Anything, types.ScenarioImageBaseLineCheck, mock.Anything).
+			RunAndReturn(func(ctx context.Context, scenario types.SensitiveScenario, r io.Reader) (*sensitive.CheckResult, error) {
+				// Simulate chain layer: seek to start before reading. This
+				// triggers RepoFileContentReader.Seek(0) which reopens the
+				// git stream, so the retry gets full content.
+				if seeker, ok := r.(io.Seeker); ok {
+					_, _ = seeker.Seek(0, io.SeekStart)
+				}
+				b, _ := io.ReadAll(r)
+				mu.Lock()
+				contents = append(contents, string(b))
+				mu.Unlock()
+				// First attempt fails, forcing a retry.
+				if len(contents) == 1 {
+					return nil, errors.New("transient upload error")
+				}
+				return &sensitive.CheckResult{IsSensitive: false}, nil
+			}).Twice()
+		mockSensitiveChecker.AssertNotCalled(t, "PassImageURLCheck", mock.Anything, mock.Anything, mock.Anything)
+		checker.InitWithContentChecker(cfg, mockSensitiveChecker)
+
+		mockRepoFileCheckStore.EXPECT().Upsert(mock.Anything, mock.Anything).Return(nil).Once()
+
+		err := repoComp.CheckRepoFiles(ctx, repo.ID, CheckOption{
+			BatchSize: 10,
+		})
+		require.Nil(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, contents, 2, "expected 2 stream check attempts")
+		for i, got := range contents {
+			require.Equal(t, imageContent, got, "attempt %d: expected identical content", i)
+		}
+	})
+}
+
 func TestRepoComponent_GetNamespaceWhiteList(t *testing.T) {
 	ctx := context.Background()
 
@@ -397,145 +685,4 @@ func TestRepoComponent_GetNamespaceWhiteList(t *testing.T) {
 		require.ErrorIs(t, err, expectedErr)
 		require.Nil(t, patterns)
 	})
-}
-
-func TestRepoComponent_buildImageURL(t *testing.T) {
-	cfg := &config.Config{}
-	cfg.APIServer.PublicDomain = "https://hub.opencsg.com"
-
-	tests := []struct {
-		name     string
-		file     *database.RepositoryFile
-		wantURL  string
-		wantEmpty bool
-	}{
-		{
-			name: "model repo image file",
-			file: &database.RepositoryFile{
-				Path: "images/banner.png",
-				Repository: &database.Repository{
-					Path:           "alice/my-model",
-					RepositoryType: types.ModelRepo,
-					DefaultBranch:  "main",
-				},
-			},
-			wantURL: "https://hub.opencsg.com/api/v1/models/alice/my-model/download/images/banner.png?ref=main",
-		},
-		{
-			name: "dataset repo image file",
-			file: &database.RepositoryFile{
-				Path: "preview/img.jpg",
-				Repository: &database.Repository{
-					Path:           "bob/my-dataset",
-					RepositoryType: types.DatasetRepo,
-					DefaultBranch:  "dev",
-				},
-			},
-			wantURL: "https://hub.opencsg.com/api/v1/datasets/bob/my-dataset/download/preview/img.jpg?ref=dev",
-		},
-		{
-			name: "mcpserver repo image file",
-			file: &database.RepositoryFile{
-				Path: "logo.png",
-				Repository: &database.Repository{
-					Path:           "carol/my-mcp",
-					RepositoryType: types.MCPServerRepo,
-					DefaultBranch:  "main",
-				},
-			},
-			wantURL: "https://hub.opencsg.com/api/v1/mcps/carol/my-mcp/download/logo.png?ref=main",
-		},
-		{
-			name: "code repo image with special chars in ref",
-			file: &database.RepositoryFile{
-				Path: "docs/arch.png",
-				Repository: &database.Repository{
-					Path:           "dave/my-code",
-					RepositoryType: types.CodeRepo,
-					DefaultBranch:  "feature/branch",
-				},
-			},
-			wantURL: "https://hub.opencsg.com/api/v1/codes/dave/my-code/download/docs/arch.png?ref=feature%2Fbranch",
-		},
-		{
-			name: "private repo returns empty",
-			file: &database.RepositoryFile{
-				Path: "images/banner.png",
-				Repository: &database.Repository{
-					Path:           "alice/private-model",
-					RepositoryType: types.ModelRepo,
-					DefaultBranch:  "main",
-					Private:        true,
-				},
-			},
-			wantEmpty: true,
-		},
-		{
-			name: "non-image file returns empty",
-			file: &database.RepositoryFile{
-				Path: "readme.txt",
-				Repository: &database.Repository{
-					Path:           "alice/my-model",
-					RepositoryType: types.ModelRepo,
-					DefaultBranch:  "main",
-				},
-			},
-			wantEmpty: true,
-		},
-		{
-			name:      "nil file returns empty",
-			file:      nil,
-			wantEmpty: true,
-		},
-		{
-			name: "nil repository returns empty",
-			file: &database.RepositoryFile{
-				Path:       "image.png",
-				Repository: nil,
-			},
-			wantEmpty: true,
-		},
-		{
-			name: "empty default branch falls back to main",
-			file: &database.RepositoryFile{
-				Path: "img.png",
-				Repository: &database.Repository{
-					Path:           "eve/repo",
-					RepositoryType: types.SpaceRepo,
-					DefaultBranch:  "",
-				},
-			},
-			wantURL: "https://hub.opencsg.com/api/v1/spaces/eve/repo/download/img.png?ref=main",
-		},
-		{
-			name: "public domain with trailing slash is trimmed",
-			file: &database.RepositoryFile{
-				Path: "img.png",
-				Repository: &database.Repository{
-					Path:           "eve/repo",
-					RepositoryType: types.SpaceRepo,
-					DefaultBranch:  "main",
-				},
-			},
-			wantURL: "https://hub.opencsg.com/api/v1/spaces/eve/repo/download/img.png?ref=main",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			comp := &repoComponentImpl{config: cfg}
-			// for the trailing-slash test, use a dedicated config
-			if tt.name == "public domain with trailing slash is trimmed" {
-				slashCfg := &config.Config{}
-				slashCfg.APIServer.PublicDomain = "https://hub.opencsg.com/"
-				comp.config = slashCfg
-			}
-			got := comp.buildImageURL(tt.file)
-			if tt.wantEmpty {
-				require.Empty(t, got)
-			} else {
-				require.Equal(t, tt.wantURL, got)
-			}
-		})
-	}
 }

--- a/moderation/workflow/activity/repo.go
+++ b/moderation/workflow/activity/repo.go
@@ -25,7 +25,7 @@ func GenRepoFileList(ctx context.Context, repo *database.Repository, config *con
 
 func CheckRepoFiles(ctx context.Context, repo *database.Repository, config *config.Config) error {
 	logger := activity.GetLogger(ctx)
-	logger.Info("check repo files start", "repo_path", repo.Path)
+	logger.Info("check repo files start", "repo_path", repo.Path, "is_private", repo.Private)
 
 	rc, err := component.NewRepoComponent(config)
 	if err != nil {


### PR DESCRIPTION
Summary:
- Main scope: 变更原因：Aliyun 内容审核服务在通过 URL 拉取 dataset 图片时返回 401。因为 datasets 即使是公开的，也需要登录才能访问文件下载接口，导致远程审核服务无法获取图片。.
- Additional context: 主要改动点：.