### PR TITLE
Hide serverless endpoints and expose deploy type in inference detail

### DIFF
--- a/api/handler/model.go
+++ b/api/handler/model.go
@@ -1823,8 +1823,18 @@ func (h *ModelHandler) GetDeployServerless(ctx *gin.Context) {
 		httpbase.ServerError(ctx, err)
 		return
 	}
+	if response != nil {
+		response = hideDeployEndpoint(response)
+	}
 
 	httpbase.OK(ctx, response)
+}
+
+func hideDeployEndpoint(deploy *types.DeployRequest) *types.DeployRequest {
+	response := *deploy
+	response.Endpoint = ""
+	response.ProxyEndpoint = ""
+	return &response
 }
 
 // ListQuantization      godoc

--- a/api/handler/model_ce_test.go
+++ b/api/handler/model_ce_test.go
@@ -794,9 +794,13 @@ func TestModelHandler_GetDeployServerless(t *testing.T) {
 	})
 
 	tester.mocks.model.EXPECT().GetServerless(tester.Ctx(), "u", "r", "u").Return(&types.DeployRequest{
-		DeployID: 1,
+		DeployID:      1,
+		Endpoint:      "https://endpoint.example.com",
+		ProxyEndpoint: "https://proxy.example.com",
 	}, nil)
 	tester.WithUser().Execute()
 
 	tester.ResponseEq(t, 200, tester.OKText, &types.DeployRequest{DeployID: 1})
+	require.NotContains(t, tester.Response().Body.String(), "endpoint")
+	require.NotContains(t, tester.Response().Body.String(), "proxy_endpoint")
 }

--- a/component/repo_deploy.go
+++ b/component/repo_deploy.go
@@ -584,6 +584,7 @@ func (c *repoComponentImpl) DeployDetail(ctx context.Context, detailReq types.De
 		Instances:           instList,
 		Private:             endpointPrivate,
 		Path:                repoPath,
+		Type:                deploy.Type,
 		ProxyEndpoint:       proxyEndPoint,
 		SKU:                 deploy.SKU,
 		Task:                string(deploy.Task),

--- a/component/repo_test.go
+++ b/component/repo_test.go
@@ -1253,6 +1253,7 @@ func TestRepoComponent_DeployDetail(t *testing.T) {
 		ClusterID:     "cluster",
 		SvcName:       "svc",
 		Status:        deployStatus.Running,
+		Type:          types.InferenceType,
 	}, nil)
 
 	repo.mocks.deployer.EXPECT().GetReplica(ctx, types.DeployRequest{
@@ -1292,6 +1293,7 @@ func TestRepoComponent_DeployDetail(t *testing.T) {
 		Private:        true,
 		SvcName:        "svc",
 		Endpoint:       "endpoint/svc",
+		Type:           types.InferenceType,
 		UserUUID:       "uuid",
 		OwnerNamespace: "",
 	}, *dp)


### PR DESCRIPTION
Summary:
- Main scope: 变更原因：.
- Additional context: Serverless 模型详情接口不应暴露 endpoint URL。.