### PR TITLE
feat(api): support range repository downloads

### DIFF
--- a/api/handler/byte_range.go
+++ b/api/handler/byte_range.go
@@ -1,0 +1,95 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"net/textproto"
+	"strconv"
+	"strings"
+)
+
+// errNoOverlap indicates that none of the requested ranges overlap the representation.
+var errNoOverlap = errors.New("invalid range: failed to overlap")
+
+// httpRange specifies a byte range to be sent to the client.
+type httpRange struct {
+	start  int64
+	length int64
+}
+
+// contentRange formats the range for an HTTP Content-Range response header.
+func (r httpRange) contentRange(size int64) string {
+	return fmt.Sprintf("bytes %d-%d/%d", r.start, r.start+r.length-1, size)
+}
+
+// parseRange parses a Range header as defined by RFC 9110.
+// It is adapted from net/http.parseRange in the Go standard library (BSD-3-Clause).
+// Copyright 2009 The Go Authors.
+func parseRange(header string, size int64) ([]httpRange, error) {
+	if header == "" {
+		return nil, nil
+	}
+	const byteRangePrefix = "bytes="
+	if !strings.HasPrefix(header, byteRangePrefix) {
+		return nil, errors.New("invalid range")
+	}
+
+	var ranges []httpRange
+	noOverlap := false
+	for _, rangeSpec := range strings.Split(header[len(byteRangePrefix):], ",") {
+		rangeSpec = textproto.TrimString(rangeSpec)
+		if rangeSpec == "" {
+			continue
+		}
+
+		startText, endText, found := strings.Cut(rangeSpec, "-")
+		if !found {
+			return nil, errors.New("invalid range")
+		}
+		startText = textproto.TrimString(startText)
+		endText = textproto.TrimString(endText)
+
+		var requestedRange httpRange
+		if startText == "" {
+			if endText == "" || endText[0] == '-' {
+				return nil, errors.New("invalid range")
+			}
+			suffixLength, err := strconv.ParseInt(endText, 10, 64)
+			if suffixLength < 0 || err != nil {
+				return nil, errors.New("invalid range")
+			}
+			if suffixLength > size {
+				suffixLength = size
+			}
+			requestedRange.start = size - suffixLength
+			requestedRange.length = size - requestedRange.start
+		} else {
+			start, err := strconv.ParseInt(startText, 10, 64)
+			if err != nil || start < 0 {
+				return nil, errors.New("invalid range")
+			}
+			if start >= size {
+				noOverlap = true
+				continue
+			}
+			requestedRange.start = start
+			if endText == "" {
+				requestedRange.length = size - requestedRange.start
+			} else {
+				end, err := strconv.ParseInt(endText, 10, 64)
+				if err != nil || requestedRange.start > end {
+					return nil, errors.New("invalid range")
+				}
+				if end >= size {
+					end = size - 1
+				}
+				requestedRange.length = end - requestedRange.start + 1
+			}
+		}
+		ranges = append(ranges, requestedRange)
+	}
+	if noOverlap && len(ranges) == 0 {
+		return nil, errNoOverlap
+	}
+	return ranges, nil
+}

--- a/api/handler/byte_range_test.go
+++ b/api/handler/byte_range_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseRange verifies the behavior adapted from net/http.parseRange.
+func TestParseRange(t *testing.T) {
+	tests := []struct {
+		name          string
+		header        string
+		size          int64
+		want          []httpRange
+		wantErr       bool
+		wantNoOverlap bool
+	}{
+		{name: "no range", size: 100},
+		{name: "closed range", header: "bytes=10-19", size: 100, want: []httpRange{{start: 10, length: 10}}},
+		{name: "open ended range", header: "bytes=90-", size: 100, want: []httpRange{{start: 90, length: 10}}},
+		{name: "suffix range", header: "bytes=-10", size: 100, want: []httpRange{{start: 90, length: 10}}},
+		{name: "suffix larger than file", header: "bytes=-200", size: 100, want: []httpRange{{start: 0, length: 100}}},
+		{name: "end is clamped", header: "bytes=95-200", size: 100, want: []httpRange{{start: 95, length: 5}}},
+		{name: "multiple ranges", header: "bytes=0-1,4-5", size: 100, want: []httpRange{{start: 0, length: 2}, {start: 4, length: 2}}},
+		{name: "partially satisfiable ranges", header: "bytes=100-200,2-3", size: 100, want: []httpRange{{start: 2, length: 2}}},
+		{name: "missing value", header: "bytes=", size: 100},
+		{name: "zero suffix", header: "bytes=-0", size: 100, want: []httpRange{{start: 100, length: 0}}},
+		{name: "unsupported unit", header: "items=0-1", size: 100, wantErr: true},
+		{name: "case sensitive unit", header: "BYTES=0-0", size: 100, wantErr: true},
+		{name: "missing separator", header: "bytes", size: 100, wantErr: true},
+		{name: "invalid number", header: "bytes=a-10", size: 100, wantErr: true},
+		{name: "negative start", header: "bytes=-1-10", size: 100, wantErr: true},
+		{name: "start after end", header: "bytes=20-10", size: 100, wantErr: true},
+		{name: "integer overflow", header: "bytes=9223372036854775808-", size: 100, wantErr: true},
+		{name: "start at file size", header: "bytes=100-", size: 100, wantErr: true, wantNoOverlap: true},
+		{name: "empty file", header: "bytes=0-0", size: 0, wantErr: true, wantNoOverlap: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseRange(test.header, test.size)
+			require.Equal(t, test.want, got)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if test.wantNoOverlap {
+				require.ErrorIs(t, err, errNoOverlap)
+			}
+		})
+	}
+}

--- a/api/handler/repo.go
+++ b/api/handler/repo.go
@@ -1145,6 +1145,7 @@ func (h *RepoHandler) UploadFile(ctx *gin.Context) {
 	httpbase.OK(ctx, nil)
 }
 
+// SDKDownload serves a repository file through SDK-compatible routes.
 func (h *RepoHandler) SDKDownload(ctx *gin.Context) {
 	h.handleDownload(ctx, false)
 }
@@ -1154,21 +1155,26 @@ func (h *RepoHandler) SDKDownload(ctx *gin.Context) {
 // @Summary      Download a rep file
 // @Tags         Repository
 // @Accept       json
-// @Produce      json
+// @Produce      application/octet-stream
 // @Param		 repo_type path string true "models,dataset,codes or spaces" Enums(models,datasets,codes,spaces)
 // @Param		 namespace path string true "repo owner name"
 // @Param		 name path string true "repo name"
 // @Param		 file_path path string true "file path"
 // @Param		 ref query string true "branch or tag"
 // @Param		 current_user query string false "current user name"
-// @Success      200  {object}  types.ResponseWithTotal{data=string} "OK"
+// @Param        Range header string false "single byte range, for example bytes=0-1023"
+// @Param        If-Range header string false "strong ETag used to validate a range request"
+// @Success      200  {file}    file "OK"
+// @Success      206  {file}    file "Partial Content"
 // @Failure      400  {object}  types.APIBadRequest "Bad request"
+// @Failure      416  {string}  string "Range Not Satisfiable"
 // @Failure      500  {object}  types.APIInternalServerError "Internal server error"
 // @Router       /{repo_type}/{namespace}/{name}/resolve/{file_path} [get]
 func (h *RepoHandler) ResolveDownload(ctx *gin.Context) {
 	h.handleDownload(ctx, true)
 }
 
+// HeadSDKDownload returns SDK-compatible metadata for a repository file.
 func (h *RepoHandler) HeadSDKDownload(ctx *gin.Context) {
 	var repoCommit string
 	currentUser := httpbase.GetCurrentUser(ctx)
@@ -1197,7 +1203,17 @@ func (h *RepoHandler) HeadSDKDownload(ctx *gin.Context) {
 
 	file, commit, err := h.c.HeadDownloadFile(ctx.Request.Context(), req, currentUser)
 	if err != nil {
-		if errors.Is(err, errorx.ErrUnauthorized) {
+		if errors.Is(err, errorx.ErrForbidden) {
+			slog.ErrorContext(
+				ctx.Request.Context(),
+				"permission denied when accessing repo head",
+				slog.String("repo_type", string(req.RepoType)),
+				slog.Any("path", fmt.Sprintf("%s/%s", namespace, name)),
+			)
+			httpbase.ForbiddenError(ctx, err)
+			return
+		}
+		if errors.Is(err, errorx.ErrUnauthorized) || errors.Is(err, errorx.ErrUserNotFound) {
 			slog.ErrorContext(ctx.Request.Context(), "permission denied when accessing repo head", slog.String("repo_type", string(req.RepoType)), slog.Any("path", fmt.Sprintf("%s/%s", namespace, name)))
 			httpbase.UnauthorizedError(ctx, err)
 			return
@@ -1223,9 +1239,11 @@ func (h *RepoHandler) HeadSDKDownload(ctx *gin.Context) {
 		ctx.Header("X-Xet-Hash", file.LfsSHA256)
 		ctx.Header("X-Xet-Refresh-Route", h.xetRefreshRoute(req.RepoType, namespace, name, branch, action))
 	}
-	ctx.Header("Content-Length", strconv.Itoa(int(file.Size)))
+	ctx.Header("Content-Length", strconv.FormatInt(file.Size, 10))
 	ctx.Header("X-Repo-Commit", repoCommit)
-	ctx.Header("ETag", file.SHA)
+	// RFC 9110 requires entity-tags to use quoted-string syntax.
+	ctx.Header("ETag", strconv.Quote(file.SHA))
+	ctx.Header("Accept-Ranges", "bytes")
 	ctx.Status(http.StatusOK)
 }
 
@@ -1236,19 +1254,10 @@ func (h *RepoHandler) xetRefreshRoute(repoType types.RepositoryType, namespace, 
 	return fmt.Sprintf("%s/hf/%ss/%s/%s/xet-%s-token/%s", h.config.Model.DownloadEndpoint, repoType, namespace, name, action, ref)
 }
 
+// handleDownload serves full or single-range content for non-LFS files and redirects LFS files.
 func (h *RepoHandler) handleDownload(ctx *gin.Context, isResolve bool) {
 	currentUser := httpbase.GetCurrentUser(ctx)
-	var (
-		namespace     string
-		name          string
-		branch        string
-		reader        io.ReadCloser
-		size          int64
-		url           string
-		contentLength int64
-		err           error
-	)
-	namespace, name, err = common.GetNamespaceAndNameFromContext(ctx)
+	namespace, name, err := common.GetNamespaceAndNameFromContext(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx.Request.Context(), "Bad request format", "error", err)
 		httpbase.BadRequest(ctx, err.Error())
@@ -1257,26 +1266,26 @@ func (h *RepoHandler) handleDownload(ctx *gin.Context, isResolve bool) {
 
 	filePath := ctx.Param("file_path")
 	filePath = convertFilePathFromRoute(filePath)
+	var branch string
 	if isResolve {
 		branch = ctx.Query("ref")
 	} else {
 		branch = ctx.Param("branch")
 	}
-	mappedBranch := ctx.Param("branch_mapped")
-	if mappedBranch != "" {
+	if mappedBranch := ctx.Param("branch_mapped"); mappedBranch != "" {
 		branch = mappedBranch
 	}
 
 	req := &types.GetFileReq{
-		Namespace: namespace,
-		Name:      name,
-		Path:      filePath,
-		Ref:       branch,
-		Lfs:       false,
-		SaveAs:    filepath.Base(filePath),
-		RepoType:  common.RepoTypeFromContext(ctx),
+		Namespace:     namespace,
+		Name:          name,
+		Path:          filePath,
+		Ref:           branch,
+		Lfs:           false,
+		SaveAs:        filepath.Base(filePath),
+		RepoType:      common.RepoTypeFromContext(ctx),
+		CountDownload: true,
 	}
-	// TODO:move the check into SDKDownloadFile, and can return the file content as we get all the content before check lfs pointer
 	lfs, contentLength, err := h.c.IsLfs(ctx.Request.Context(), req)
 	if err != nil {
 		if errors.Is(err, errorx.ErrNotFound) {
@@ -1285,50 +1294,128 @@ func (h *RepoHandler) handleDownload(ctx *gin.Context, isResolve bool) {
 			return
 		}
 
-		slog.ErrorContext(ctx.Request.Context(), "Filed to lfs information", "error", err)
+		slog.ErrorContext(ctx.Request.Context(), "Failed to get LFS information", "error", err)
 		httpbase.ServerError(ctx, err)
 		return
 	}
 	req.Lfs = lfs
-
-	if contentLength > 0 {
-		// file content is not empty, download it directly
-		reader, size, url, err = h.c.SDKDownloadFile(ctx.Request.Context(), req, currentUser)
+	rangeHeader := ctx.GetHeader("Range")
+	ifRangeHeader := ctx.GetHeader("If-Range")
+	if !req.Lfs && rangeHeader != "" && ifRangeHeader != "" {
+		file, _, err := h.c.HeadDownloadFile(ctx.Request.Context(), req, currentUser)
 		if err != nil {
-			if errors.Is(err, errorx.ErrUnauthorized) {
-				slog.ErrorContext(ctx.Request.Context(), "permission denied when accessing repo", slog.String("repo_type", string(req.RepoType)), slog.Any("path", fmt.Sprintf("%s/%s", namespace, name)))
+			switch {
+			case errors.Is(err, errorx.ErrForbidden):
+				slog.ErrorContext(ctx.Request.Context(), "permission denied when accessing repo head", slog.String("repo_type", string(req.RepoType)), slog.Any("path", fmt.Sprintf("%s/%s", namespace, name)))
+				httpbase.ForbiddenError(ctx, err)
+			case errors.Is(err, errorx.ErrUnauthorized), errors.Is(err, errorx.ErrUserNotFound):
+				slog.ErrorContext(ctx.Request.Context(), "permission denied when accessing repo head", slog.String("repo_type", string(req.RepoType)), slog.Any("path", fmt.Sprintf("%s/%s", namespace, name)))
 				httpbase.UnauthorizedError(ctx, err)
-				return
-			}
-
-			if errors.Is(err, errorx.ErrNotFound) {
-				slog.ErrorContext(ctx.Request.Context(), "repo not found", slog.String("repo_type", string(common.RepoTypeFromContext(ctx))), slog.Any("path", fmt.Sprintf("%s/%s", namespace, name)))
+			case errors.Is(err, errorx.ErrNotFound):
+				slog.ErrorContext(ctx.Request.Context(), "repo not found head", slog.String("repo_type", string(req.RepoType)), slog.Any("path", fmt.Sprintf("%s/%s", namespace, name)))
 				httpbase.NotFoundError(ctx, err)
-				return
+			default:
+				slog.ErrorContext(ctx.Request.Context(), "Failed to get repo file metadata for If-Range", slog.String("repo_type", string(req.RepoType)), slog.Any("error", err))
+				httpbase.ServerError(ctx, err)
 			}
-
-			slog.ErrorContext(ctx.Request.Context(), "Failed to download repo file", slog.String("repo_type", string(req.RepoType)), slog.Any("error", err))
-			httpbase.ServerError(ctx, err)
 			return
+		}
+
+		etag := strconv.Quote(file.SHA)
+		ctx.Header("ETag", etag)
+		if ifRangeHeader != etag {
+			rangeHeader = ""
 		}
 	}
 
-	if req.Lfs {
-		ctx.Redirect(http.StatusMovedPermanently, url)
-	} else {
-		slog.Debug("Download repo file succeed", slog.String("repo_type", string(req.RepoType)), slog.String("name", name), slog.String("path", req.Path), slog.String("ref", req.Ref), slog.Any("Content-Length", size))
-		fileName := path.Base(req.Path)
-		ctx.Header("Content-Type", "application/octet-stream")
-		ctx.Header("Content-Disposition", `attachment; filename="`+fileName+`"`)
-		ctx.Header("Content-Length", strconv.FormatInt(size, 10))
-		if contentLength > 0 {
-			_, err = io.Copy(ctx.Writer, reader)
+	ranges, rangeErr := parseRange(rangeHeader, contentLength)
+	// Full responses, multiple ranges served as a full response, and ranges starting at byte zero count once.
+	req.CountDownload = rangeErr == nil && (len(ranges) != 1 || (ranges[0].length > 0 && ranges[0].start == 0))
+	if rangeErr == nil && len(ranges) == 1 && ranges[0].length > 0 {
+		limit := ranges[0].start + ranges[0].length
+		if limit < contentLength {
+			req.Limit = limit
 		}
-		if err != nil {
-			slog.ErrorContext(ctx.Request.Context(), "Failed to download repo file", slog.String("repo_type", string(req.RepoType)), slog.Any("error", err))
-			httpbase.ServerError(ctx, err)
+	}
+
+	reader, size, downloadURL, err := h.c.SDKDownloadFile(ctx.Request.Context(), req, currentUser)
+	if err != nil {
+		if errors.Is(err, errorx.ErrForbidden) {
+			slog.ErrorContext(ctx.Request.Context(), "permission denied when accessing repo", slog.String("repo_type", string(req.RepoType)), slog.Any("path", fmt.Sprintf("%s/%s", namespace, name)))
+			httpbase.ForbiddenError(ctx, err)
 			return
 		}
+		if errors.Is(err, errorx.ErrUnauthorized) || errors.Is(err, errorx.ErrUserNotFound) {
+			slog.ErrorContext(ctx.Request.Context(), "permission denied when accessing repo", slog.String("repo_type", string(req.RepoType)), slog.Any("path", fmt.Sprintf("%s/%s", namespace, name)))
+			httpbase.UnauthorizedError(ctx, err)
+			return
+		}
+
+		if errors.Is(err, errorx.ErrNotFound) {
+			slog.ErrorContext(ctx.Request.Context(), "repo not found", slog.String("repo_type", string(common.RepoTypeFromContext(ctx))), slog.Any("path", fmt.Sprintf("%s/%s", namespace, name)))
+			httpbase.NotFoundError(ctx, err)
+			return
+		}
+
+		slog.ErrorContext(ctx.Request.Context(), "Failed to download repo file", slog.String("repo_type", string(req.RepoType)), slog.Any("error", err))
+		httpbase.ServerError(ctx, err)
+		return
+	}
+	ctx.Header("Accept-Ranges", "bytes")
+	if lfs {
+		ctx.Redirect(http.StatusFound, downloadURL)
+		return
+	}
+	defer reader.Close()
+
+	if size != contentLength {
+		ranges, rangeErr = parseRange(rangeHeader, size)
+	}
+	var (
+		requestedRange httpRange
+		rangeRequested bool
+	)
+	if rangeErr != nil {
+		ctx.Header("Content-Range", fmt.Sprintf("bytes */%d", size))
+		ctx.AbortWithStatus(http.StatusRequestedRangeNotSatisfiable)
+		return
+	}
+	// Only a single range is supported; multiple ranges are ignored and served as a full 200 response.
+	if len(ranges) == 1 {
+		if ranges[0].length == 0 {
+			ctx.Header("Content-Range", fmt.Sprintf("bytes */%d", size))
+			ctx.AbortWithStatus(http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		requestedRange = ranges[0]
+		rangeRequested = true
+	}
+
+	slog.Debug("Download repo file succeed", slog.String("repo_type", string(req.RepoType)), slog.String("name", name), slog.String("path", req.Path), slog.String("ref", req.Ref), slog.Any("Content-Length", size))
+	fileName := path.Base(req.Path)
+	ctx.Header("Content-Type", "application/octet-stream")
+	ctx.Header("Content-Disposition", `attachment; filename="`+fileName+`"`)
+	if rangeRequested {
+		if requestedRange.start > 0 {
+			_, err = io.CopyN(io.Discard, reader, requestedRange.start)
+			if err != nil {
+				slog.ErrorContext(ctx.Request.Context(), "Failed to seek repository file range", slog.String("repo_type", string(req.RepoType)), slog.Any("error", err))
+				httpbase.ServerError(ctx, err)
+				return
+			}
+		}
+		ctx.Header("Content-Range", requestedRange.contentRange(size))
+		ctx.Header("Content-Length", strconv.FormatInt(requestedRange.length, 10))
+		ctx.Status(http.StatusPartialContent)
+		_, err = io.CopyN(ctx.Writer, reader, requestedRange.length)
+	} else {
+		ctx.Header("Content-Length", strconv.FormatInt(size, 10))
+		ctx.Status(http.StatusOK)
+		_, err = io.Copy(ctx.Writer, reader)
+	}
+	if err != nil {
+		slog.ErrorContext(ctx.Request.Context(), "Failed to stream repository file", slog.String("repo_type", string(req.RepoType)), slog.Any("error", err))
+		return
 	}
 }
 

--- a/api/handler/repo_test.go
+++ b/api/handler/repo_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -1018,44 +1019,69 @@ func TestRepoHandler_SDKListFiles(t *testing.T) {
 	tester.ResponseEqSimple(t, http.StatusOK, &types.SDKFiles{ID: "f1"})
 }
 
+// TestRepoHandler_HandleDownload verifies full, partial, and redirected repository downloads.
 func TestRepoHandler_HandleDownload(t *testing.T) {
+	lfsTests := []struct {
+		name              string
+		rangeHeader       string
+		ifRangeHeader     string
+		wantLimit         int64
+		wantDownloadCount bool
+	}{
+		{name: "full download", wantDownloadCount: true},
+		{name: "initial range", rangeHeader: "bytes=0-9", wantLimit: 10, wantDownloadCount: true},
+		{name: "subsequent range", rangeHeader: "bytes=10-19", wantLimit: 20},
+		{name: "invalid range", rangeHeader: "bytes=invalid", ifRangeHeader: `"old-sha"`},
+	}
+	for _, test := range lfsTests {
+		t.Run("lfs file "+test.name, func(t *testing.T) {
+			tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+				return rp.SDKDownload
+			})
 
-	t.Run("lfs file", func(t *testing.T) {
-		tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
-			return rp.SDKDownload
+			tester.WithUser()
+			tester.WithParam("ref", "main")
+			tester.WithParam("branch_mapped", "main_main")
+			tester.WithParam("file_path", "foo")
+			tester.WithKV("repo_type", types.ModelRepo)
+			tester.Gctx().Request.Method = http.MethodGet
+			if test.rangeHeader != "" {
+				tester.WithHeader("Range", test.rangeHeader)
+			}
+			if test.ifRangeHeader != "" {
+				tester.WithHeader("If-Range", test.ifRangeHeader)
+			}
+			req := &types.GetFileReq{
+				Namespace:     "u",
+				Name:          "r",
+				Path:          "foo",
+				Ref:           "main_main",
+				Lfs:           false,
+				SaveAs:        "foo",
+				RepoType:      types.ModelRepo,
+				CountDownload: true,
+			}
+			tester.mocks.repo.EXPECT().IsLfs(tester.Ctx(), req).Return(true, 100, nil)
+			downloadReq := *req
+			downloadReq.Lfs = true
+			downloadReq.Limit = test.wantLimit
+			downloadReq.CountDownload = test.wantDownloadCount
+			tester.mocks.repo.EXPECT().SDKDownloadFile(tester.Ctx(), &downloadReq, "u").Return(
+				nil, 100, "url", nil,
+			)
+
+			tester.Execute()
+
+			require.Equal(t, http.StatusFound, tester.Response().Code)
+			resp := tester.Response().Result()
+			defer resp.Body.Close()
+			location, err := resp.Location()
+			require.NoError(t, err)
+			require.Equal(t, "/url", location.String())
+			require.Equal(t, "bytes", tester.Response().Header().Get("Accept-Ranges"))
+			require.Empty(t, tester.Response().Header().Get("Content-Range"))
 		})
-
-		tester.WithUser()
-		tester.WithParam("ref", "main")
-		tester.WithParam("branch_mapped", "main_main")
-		tester.WithParam("file_path", "foo")
-		tester.WithKV("repo_type", types.ModelRepo)
-		req := &types.GetFileReq{
-			Namespace: "u",
-			Name:      "r",
-			Path:      "foo",
-			Ref:       "main_main",
-			Lfs:       false,
-			SaveAs:    "foo",
-			RepoType:  types.ModelRepo,
-		}
-		tester.mocks.repo.EXPECT().IsLfs(tester.Ctx(), req).Return(true, 100, nil)
-		reqnew := *req
-		reqnew.Lfs = true
-		tester.mocks.repo.EXPECT().SDKDownloadFile(tester.Ctx(), &reqnew, "u").Return(
-			nil, 100, "url", nil,
-		)
-
-		tester.Execute()
-
-		// redirected
-		require.Equal(t, http.StatusOK, tester.Response().Code)
-		resp := tester.Response().Result()
-		defer resp.Body.Close()
-		lc, err := resp.Location()
-		require.NoError(t, err)
-		require.Equal(t, "/url", lc.String())
-	})
+	}
 
 	t.Run("normal file", func(t *testing.T) {
 		tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
@@ -1068,16 +1094,18 @@ func TestRepoHandler_HandleDownload(t *testing.T) {
 		tester.WithParam("file_path", "foo")
 		tester.WithKV("repo_type", types.ModelRepo)
 		req := &types.GetFileReq{
-			Namespace: "u",
-			Name:      "r",
-			Path:      "foo",
-			Ref:       "main_main",
-			Lfs:       false,
-			SaveAs:    "foo",
-			RepoType:  types.ModelRepo,
+			Namespace:     "u",
+			Name:          "r",
+			Path:          "foo",
+			Ref:           "main_main",
+			Lfs:           false,
+			SaveAs:        "foo",
+			RepoType:      types.ModelRepo,
+			CountDownload: true,
 		}
 		tester.mocks.repo.EXPECT().IsLfs(tester.Ctx(), req).Return(false, 100, nil)
-		tester.mocks.repo.EXPECT().SDKDownloadFile(tester.Ctx(), req, "u").Return(
+		downloadReq := *req
+		tester.mocks.repo.EXPECT().SDKDownloadFile(tester.Ctx(), &downloadReq, "u").Return(
 			io.NopCloser(bytes.NewBuffer([]byte("bar"))), 100, "url", nil,
 		)
 
@@ -1087,8 +1115,307 @@ func TestRepoHandler_HandleDownload(t *testing.T) {
 		require.Equal(t, "application/octet-stream", headers.Get("Content-Type"))
 		require.Equal(t, `attachment; filename="foo"`, headers.Get("Content-Disposition"))
 		require.Equal(t, "100", headers.Get("Content-Length"))
+		require.Equal(t, "bytes", headers.Get("Accept-Ranges"))
 		r := tester.Response().Body.String()
 		require.Equal(t, "bar", r)
+	})
+
+	t.Run("repository not found", func(t *testing.T) {
+		tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+			return rp.SDKDownload
+		})
+
+		tester.WithUser()
+		tester.WithParam("branch", "main")
+		tester.WithParam("file_path", "missing")
+		tester.WithKV("repo_type", types.ModelRepo)
+		req := &types.GetFileReq{
+			Namespace:     "u",
+			Name:          "r",
+			Path:          "missing",
+			Ref:           "main",
+			Lfs:           false,
+			SaveAs:        "missing",
+			RepoType:      types.ModelRepo,
+			CountDownload: true,
+		}
+		tester.mocks.repo.EXPECT().IsLfs(tester.Ctx(), req).Return(
+			false, int64(-1), fmt.Errorf("component not-found error: %w", errorx.ErrNotFound),
+		)
+
+		tester.Execute()
+
+		require.Equal(t, http.StatusNotFound, tester.Response().Code)
+	})
+
+	t.Run("forbidden file", func(t *testing.T) {
+		tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+			return rp.SDKDownload
+		})
+
+		tester.WithUser()
+		tester.WithParam("branch", "main")
+		tester.WithParam("file_path", "private")
+		tester.WithKV("repo_type", types.ModelRepo)
+		tester.WithHeader("Range", "bytes=0-0")
+		req := &types.GetFileReq{
+			Namespace:     "u",
+			Name:          "r",
+			Path:          "private",
+			Ref:           "main",
+			Lfs:           false,
+			SaveAs:        "private",
+			RepoType:      types.ModelRepo,
+			CountDownload: true,
+		}
+		tester.mocks.repo.EXPECT().IsLfs(tester.Ctx(), req).Return(false, int64(100), nil)
+		downloadReq := *req
+		downloadReq.Limit = 1
+		tester.mocks.repo.EXPECT().SDKDownloadFile(tester.Ctx(), &downloadReq, "u").Return(
+			nil, int64(0), "", errorx.ErrForbiddenMsg("access denied"),
+		)
+
+		tester.Execute()
+
+		require.Equal(t, http.StatusForbidden, tester.Response().Code)
+		require.Empty(t, tester.Response().Header().Get("Content-Range"))
+	})
+
+	t.Run("user not found during download", func(t *testing.T) {
+		tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+			return rp.SDKDownload
+		})
+
+		tester.WithUser()
+		tester.WithParam("branch", "main")
+		tester.WithParam("file_path", "private")
+		tester.WithKV("repo_type", types.ModelRepo)
+		req := &types.GetFileReq{
+			Namespace:     "u",
+			Name:          "r",
+			Path:          "private",
+			Ref:           "main",
+			Lfs:           false,
+			SaveAs:        "private",
+			RepoType:      types.ModelRepo,
+			CountDownload: true,
+		}
+		tester.mocks.repo.EXPECT().IsLfs(tester.Ctx(), req).Return(false, int64(10), nil)
+		downloadReq := *req
+		tester.mocks.repo.EXPECT().SDKDownloadFile(tester.Ctx(), &downloadReq, "u").Return(
+			nil, int64(0), "", errorx.ErrUserNotFound,
+		)
+
+		tester.Execute()
+
+		require.Equal(t, http.StatusUnauthorized, tester.Response().Code)
+	})
+
+	t.Run("user not found during if-range validation", func(t *testing.T) {
+		tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+			return rp.SDKDownload
+		})
+
+		tester.WithUser()
+		tester.WithParam("branch", "main")
+		tester.WithParam("file_path", "private")
+		tester.WithKV("repo_type", types.ModelRepo)
+		tester.WithHeader("Range", "bytes=0-0")
+		tester.WithHeader("If-Range", `"sha"`)
+		req := &types.GetFileReq{
+			Namespace:     "u",
+			Name:          "r",
+			Path:          "private",
+			Ref:           "main",
+			Lfs:           false,
+			SaveAs:        "private",
+			RepoType:      types.ModelRepo,
+			CountDownload: true,
+		}
+		tester.mocks.repo.EXPECT().IsLfs(tester.Ctx(), req).Return(false, int64(10), nil)
+		tester.mocks.repo.EXPECT().HeadDownloadFile(tester.Ctx(), req, "u").Return(
+			nil, nil, errorx.ErrUserNotFound,
+		)
+
+		tester.Execute()
+
+		require.Equal(t, http.StatusUnauthorized, tester.Response().Code)
+	})
+
+	rangeTests := []struct {
+		name              string
+		rangeHeader       string
+		ifRangeHeader     string
+		wantStatus        int
+		wantBody          string
+		wantContentRange  string
+		wantLength        string
+		wantETag          string
+		wantLimit         int64
+		wantDownloadCount bool
+	}{
+		{name: "initial range", rangeHeader: "bytes=0-3", wantStatus: http.StatusPartialContent, wantBody: "0123", wantContentRange: "bytes 0-3/10", wantLength: "4", wantLimit: 4, wantDownloadCount: true},
+		{name: "closed range", rangeHeader: "bytes=2-5", wantStatus: http.StatusPartialContent, wantBody: "2345", wantContentRange: "bytes 2-5/10", wantLength: "4", wantLimit: 6},
+		{name: "matching if-range", rangeHeader: "bytes=2-5", ifRangeHeader: `"sha"`, wantStatus: http.StatusPartialContent, wantBody: "2345", wantContentRange: "bytes 2-5/10", wantLength: "4", wantETag: `"sha"`, wantLimit: 6},
+		{name: "mismatched if-range", rangeHeader: "bytes=2-5", ifRangeHeader: `"old-sha"`, wantStatus: http.StatusOK, wantBody: "0123456789", wantLength: "10", wantETag: `"sha"`, wantDownloadCount: true},
+		{name: "weak if-range", rangeHeader: "bytes=2-5", ifRangeHeader: `W/"sha"`, wantStatus: http.StatusOK, wantBody: "0123456789", wantLength: "10", wantETag: `"sha"`, wantDownloadCount: true},
+		{name: "date if-range", rangeHeader: "bytes=2-5", ifRangeHeader: "Wed, 21 Oct 2015 07:28:00 GMT", wantStatus: http.StatusOK, wantBody: "0123456789", wantLength: "10", wantETag: `"sha"`, wantDownloadCount: true},
+		{name: "open ended range", rangeHeader: "bytes=7-", wantStatus: http.StatusPartialContent, wantBody: "789", wantContentRange: "bytes 7-9/10", wantLength: "3"},
+		{name: "suffix range", rangeHeader: "bytes=-3", wantStatus: http.StatusPartialContent, wantBody: "789", wantContentRange: "bytes 7-9/10", wantLength: "3"},
+		{name: "end is clamped", rangeHeader: "bytes=8-99", wantStatus: http.StatusPartialContent, wantBody: "89", wantContentRange: "bytes 8-9/10", wantLength: "2"},
+		{name: "unsatisfiable range", rangeHeader: "bytes=10-", wantStatus: http.StatusRequestedRangeNotSatisfiable, wantContentRange: "bytes */10"},
+		{name: "invalid range", rangeHeader: "bytes=invalid", wantStatus: http.StatusRequestedRangeNotSatisfiable, wantContentRange: "bytes */10"},
+		{name: "unsupported unit", rangeHeader: "items=0-1", wantStatus: http.StatusRequestedRangeNotSatisfiable, wantContentRange: "bytes */10"},
+		{name: "multiple ranges", rangeHeader: "bytes=0-1,4-5", wantStatus: http.StatusOK, wantBody: "0123456789", wantLength: "10", wantDownloadCount: true},
+	}
+
+	for _, test := range rangeTests {
+		t.Run(test.name, func(t *testing.T) {
+			tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+				return rp.SDKDownload
+			})
+
+			tester.WithUser()
+			tester.WithParam("branch", "main")
+			tester.WithParam("file_path", "foo")
+			tester.WithKV("repo_type", types.ModelRepo)
+			tester.WithHeader("Range", test.rangeHeader)
+			if test.ifRangeHeader != "" {
+				tester.WithHeader("If-Range", test.ifRangeHeader)
+			}
+			req := &types.GetFileReq{
+				Namespace:     "u",
+				Name:          "r",
+				Path:          "foo",
+				Ref:           "main",
+				Lfs:           false,
+				SaveAs:        "foo",
+				RepoType:      types.ModelRepo,
+				CountDownload: true,
+			}
+			tester.mocks.repo.EXPECT().IsLfs(tester.Ctx(), req).Return(false, int64(10), nil)
+			if test.ifRangeHeader != "" {
+				tester.mocks.repo.EXPECT().HeadDownloadFile(tester.Ctx(), req, "u").Return(
+					&types.File{SHA: "sha", Size: 10}, &types.Commit{ID: "commit"}, nil,
+				)
+			}
+			downloadReq := *req
+			downloadReq.Limit = test.wantLimit
+			downloadReq.CountDownload = test.wantDownloadCount
+			tester.mocks.repo.EXPECT().SDKDownloadFile(tester.Ctx(), &downloadReq, "u").Return(
+				io.NopCloser(strings.NewReader("0123456789")), int64(10), "", nil,
+			)
+
+			tester.Execute()
+
+			require.Equal(t, test.wantStatus, tester.Response().Code)
+			require.Equal(t, test.wantBody, tester.Response().Body.String())
+			headers := tester.Response().Header()
+			require.Equal(t, "bytes", headers.Get("Accept-Ranges"))
+			require.Equal(t, test.wantContentRange, headers.Get("Content-Range"))
+			require.Equal(t, test.wantLength, headers.Get("Content-Length"))
+			require.Equal(t, test.wantETag, headers.Get("ETag"))
+		})
+	}
+
+	t.Run("download size changed", func(t *testing.T) {
+		tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+			return rp.SDKDownload
+		})
+
+		tester.WithUser()
+		tester.WithParam("branch", "main")
+		tester.WithParam("file_path", "foo")
+		tester.WithKV("repo_type", types.ModelRepo)
+		tester.WithHeader("Range", "bytes=8-9")
+		req := &types.GetFileReq{
+			Namespace:     "u",
+			Name:          "r",
+			Path:          "foo",
+			Ref:           "main",
+			Lfs:           false,
+			SaveAs:        "foo",
+			RepoType:      types.ModelRepo,
+			CountDownload: true,
+		}
+		tester.mocks.repo.EXPECT().IsLfs(tester.Ctx(), req).Return(false, int64(10), nil)
+		downloadReq := *req
+		downloadReq.CountDownload = false
+		tester.mocks.repo.EXPECT().SDKDownloadFile(tester.Ctx(), &downloadReq, "u").Return(
+			io.NopCloser(strings.NewReader("01234567")), int64(8), "", nil,
+		)
+
+		tester.Execute()
+
+		require.Equal(t, http.StatusRequestedRangeNotSatisfiable, tester.Response().Code)
+		require.Equal(t, "bytes */8", tester.Response().Header().Get("Content-Range"))
+	})
+
+	t.Run("empty file range", func(t *testing.T) {
+		tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+			return rp.SDKDownload
+		})
+
+		tester.WithUser()
+		tester.WithParam("branch", "main")
+		tester.WithParam("file_path", "empty")
+		tester.WithKV("repo_type", types.ModelRepo)
+		tester.WithHeader("Range", "bytes=0-0")
+		req := &types.GetFileReq{
+			Namespace:     "u",
+			Name:          "r",
+			Path:          "empty",
+			Ref:           "main",
+			Lfs:           false,
+			SaveAs:        "empty",
+			RepoType:      types.ModelRepo,
+			CountDownload: true,
+		}
+		tester.mocks.repo.EXPECT().IsLfs(tester.Ctx(), req).Return(false, int64(0), nil)
+		downloadReq := *req
+		downloadReq.CountDownload = false
+		tester.mocks.repo.EXPECT().SDKDownloadFile(tester.Ctx(), &downloadReq, "u").Return(
+			io.NopCloser(strings.NewReader("")), int64(0), "", nil,
+		)
+
+		tester.Execute()
+
+		require.Equal(t, http.StatusRequestedRangeNotSatisfiable, tester.Response().Code)
+		require.Equal(t, "bytes", tester.Response().Header().Get("Accept-Ranges"))
+		require.Equal(t, "bytes */0", tester.Response().Header().Get("Content-Range"))
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+			return rp.SDKDownload
+		})
+
+		tester.WithUser()
+		tester.WithParam("branch", "main")
+		tester.WithParam("file_path", "empty")
+		tester.WithKV("repo_type", types.ModelRepo)
+		req := &types.GetFileReq{
+			Namespace:     "u",
+			Name:          "r",
+			Path:          "empty",
+			Ref:           "main",
+			Lfs:           false,
+			SaveAs:        "empty",
+			RepoType:      types.ModelRepo,
+			CountDownload: true,
+		}
+		tester.mocks.repo.EXPECT().IsLfs(tester.Ctx(), req).Return(false, int64(0), nil)
+		downloadReq := *req
+		tester.mocks.repo.EXPECT().SDKDownloadFile(tester.Ctx(), &downloadReq, "u").Return(
+			io.NopCloser(strings.NewReader("")), int64(0), "", nil,
+		)
+
+		tester.Execute()
+
+		require.Equal(t, http.StatusOK, tester.Response().Code)
+		require.Equal(t, "0", tester.Response().Header().Get("Content-Length"))
+		require.Equal(t, "bytes", tester.Response().Header().Get("Accept-Ranges"))
+		require.Empty(t, tester.Response().Body.String())
 	})
 }
 
@@ -1117,7 +1444,113 @@ func TestRepoHandler_HeadSDKDownload(t *testing.T) {
 	headers := tester.Response().Header()
 	require.Equal(t, "100", headers.Get("Content-Length"))
 	require.Equal(t, "abc", headers.Get("X-Repo-Commit"))
-	require.Equal(t, "def", headers.Get("ETag"))
+	require.Equal(t, `"def"`, headers.Get("ETag"))
+	require.Equal(t, "bytes", headers.Get("Accept-Ranges"))
+}
+
+// TestRepoHandler_HeadSDKDownloadLFS verifies LFS metadata advertises byte-range support.
+func TestRepoHandler_HeadSDKDownloadLFS(t *testing.T) {
+	tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+		return rp.HeadSDKDownload
+	})
+
+	tester.WithUser()
+	tester.WithParam("file_path", "model.bin")
+	tester.WithParam("branch", "main")
+	tester.WithKV("repo_type", types.ModelRepo)
+	tester.mocks.repo.EXPECT().HeadDownloadFile(
+		tester.Ctx(), &types.GetFileReq{
+			Namespace: "u",
+			Name:      "r",
+			Path:      "model.bin",
+			Ref:       "main",
+			SaveAs:    "model.bin",
+			RepoType:  types.ModelRepo,
+		}, "u",
+	).Return(&types.File{Lfs: true, Size: 100, SHA: "def"}, &types.Commit{ID: "abc"}, nil)
+
+	tester.Execute()
+
+	require.Equal(t, http.StatusOK, tester.Response().Code)
+	require.Equal(t, "bytes", tester.Response().Header().Get("Accept-Ranges"))
+}
+
+// TestRepoHandler_HeadSDKDownloadNotFound verifies missing repositories receive HTTP 404.
+func TestRepoHandler_HeadSDKDownloadNotFound(t *testing.T) {
+	tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+		return rp.HeadSDKDownload
+	})
+
+	tester.WithUser()
+	tester.WithParam("file_path", "missing")
+	tester.WithParam("branch", "main")
+	tester.WithKV("repo_type", types.ModelRepo)
+	tester.mocks.repo.EXPECT().HeadDownloadFile(
+		tester.Ctx(), &types.GetFileReq{
+			Namespace: "u",
+			Name:      "r",
+			Path:      "missing",
+			Ref:       "main",
+			SaveAs:    "missing",
+			RepoType:  types.ModelRepo,
+		}, "u",
+	).Return(nil, nil, fmt.Errorf("component not-found error: %w", errorx.ErrNotFound))
+
+	tester.Execute()
+
+	require.Equal(t, http.StatusNotFound, tester.Response().Code)
+}
+
+// TestRepoHandler_HeadSDKDownloadForbidden verifies forbidden HEAD requests return HTTP 403.
+func TestRepoHandler_HeadSDKDownloadForbidden(t *testing.T) {
+	tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+		return rp.HeadSDKDownload
+	})
+
+	tester.WithUser()
+	tester.WithParam("file_path", "private")
+	tester.WithParam("branch", "main")
+	tester.WithKV("repo_type", types.ModelRepo)
+	tester.mocks.repo.EXPECT().HeadDownloadFile(
+		tester.Ctx(), &types.GetFileReq{
+			Namespace: "u",
+			Name:      "r",
+			Path:      "private",
+			Ref:       "main",
+			SaveAs:    "private",
+			RepoType:  types.ModelRepo,
+		}, "u",
+	).Return(nil, nil, errorx.ErrForbiddenMsg("access denied"))
+
+	tester.Execute()
+
+	require.Equal(t, http.StatusForbidden, tester.Response().Code)
+}
+
+// TestRepoHandler_HeadSDKDownloadUserNotFound verifies missing users receive HTTP 401.
+func TestRepoHandler_HeadSDKDownloadUserNotFound(t *testing.T) {
+	tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+		return rp.HeadSDKDownload
+	})
+
+	tester.WithUser()
+	tester.WithParam("file_path", "private")
+	tester.WithParam("branch", "main")
+	tester.WithKV("repo_type", types.ModelRepo)
+	tester.mocks.repo.EXPECT().HeadDownloadFile(
+		tester.Ctx(), &types.GetFileReq{
+			Namespace: "u",
+			Name:      "r",
+			Path:      "private",
+			Ref:       "main",
+			SaveAs:    "private",
+			RepoType:  types.ModelRepo,
+		}, "u",
+	).Return(nil, nil, errorx.ErrUserNotFound)
+
+	tester.Execute()
+
+	require.Equal(t, http.StatusUnauthorized, tester.Response().Code)
 }
 
 func TestRepoHandler_CommitWithDiff(t *testing.T) {

--- a/builder/git/gitserver/gitaly/file.go
+++ b/builder/git/gitserver/gitaly/file.go
@@ -127,6 +127,7 @@ func (c *Client) GetRepoFileReader(ctx context.Context, req gitserver.GetRepoInf
 		Repository: repository,
 		Revision:   []byte(req.Ref),
 		Path:       []byte(req.Path),
+		Limit:      req.Limit,
 	}
 
 	treeEntriesStream, err := c.commitClient.TreeEntry(ctx, treeEntriesReq)

--- a/builder/git/gitserver/gitaly/file_test.go
+++ b/builder/git/gitserver/gitaly/file_test.go
@@ -178,6 +178,7 @@ func TestGitalyFile_GetRepoFileReader(t *testing.T) {
 		},
 		Revision: []byte("main"),
 		Path:     []byte("foo"),
+		Limit:    6,
 	}).Return(mockedStream, nil)
 	r, size, err := tester.GetRepoFileReader(ctx, gitserver.GetRepoInfoByPathReq{
 		Namespace: "ns",
@@ -185,6 +186,7 @@ func TestGitalyFile_GetRepoFileReader(t *testing.T) {
 		Ref:       "main",
 		Path:      "foo",
 		RepoType:  types.ModelRepo,
+		Limit:     6,
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(2), size)

--- a/builder/git/gitserver/types.go
+++ b/builder/git/gitserver/types.go
@@ -193,7 +193,9 @@ type GetRepoInfoByPathReq struct {
 	RepoType  types.RepositoryType `json:"repo_type"`
 	File      bool                 `json:"file"`
 	// limit file size, don't return file content if file size is greater than MaxFileSize
-	MaxFileSize                           int64    `json:"max_file_size"`
+	MaxFileSize int64 `json:"max_file_size"`
+	// Limit is the maximum number of bytes read from the beginning of the file; zero means unlimited.
+	Limit                                 int64    `json:"-"`
 	GitObjectDirectoryRelative            string   `json:"git_object_directory_relative"`
 	GitAlternateObjectDirectoriesRelative []string `json:"git_alternate_object_directories_relative"`
 }

--- a/common/types/file.go
+++ b/common/types/file.go
@@ -121,6 +121,10 @@ type GetFileReq struct {
 	CurrentUser string `json:"current_user"`
 	// limit file size, don't return file content if file size is greater than MaxFileSize
 	MaxFileSize int64 `json:"max_file_size"`
+	// Limit is the maximum number of bytes read from the beginning of the file; zero means unlimited.
+	Limit int64 `json:"-"`
+	// CountDownload indicates whether this request should increment repository download statistics.
+	CountDownload bool `json:"-"`
 }
 
 type GetTreeRequest struct {

--- a/component/repo.go
+++ b/component/repo.go
@@ -134,6 +134,7 @@ type RepoComponent interface {
 	SDKListFiles(ctx context.Context, repoType types.RepositoryType, namespace, name, ref, userName string) (*types.SDKFiles, error)
 	IsLfs(ctx context.Context, req *types.GetFileReq) (bool, int64, error)
 	HeadDownloadFile(ctx context.Context, req *types.GetFileReq, userName string) (*types.File, *types.Commit, error)
+	// SDKDownloadFile prepares a download and records it when req.CountDownload is true.
 	SDKDownloadFile(ctx context.Context, req *types.GetFileReq, userName string) (io.ReadCloser, int64, string, error)
 	// UpdateDownloads increase clone download count for repo by given count
 	UpdateDownloads(ctx context.Context, req *types.UpdateDownloadsReq) error
@@ -1635,6 +1636,7 @@ func (c *repoComponentImpl) SDKListFiles(ctx context.Context, repoType types.Rep
 	}, nil
 }
 
+// IsLfs reports whether a repository file is an LFS pointer and returns its downloadable content size.
 func (c *repoComponentImpl) IsLfs(ctx context.Context, req *types.GetFileReq) (bool, int64, error) {
 	getFileRawReq := gitserver.GetRepoInfoByPathReq{
 		Namespace: req.Namespace,
@@ -1645,19 +1647,30 @@ func (c *repoComponentImpl) IsLfs(ctx context.Context, req *types.GetFileReq) (b
 	}
 	content, err := c.git.GetRepoFileRaw(ctx, getFileRawReq)
 	if err != nil {
-		if e, ok := err.(errorx.CustomError); ok && e.Is(errorx.ErrGitFileNotFound) {
+		if isRepositoryContentNotFound(err) {
 			return false, -1, errorx.ErrNotFound
 		}
 		slog.Error("failed to get %s file raw", string(req.RepoType), slog.String("namespace", req.Namespace), slog.String("name", req.Name), slog.String("path", req.Path))
 		return false, -1, err
 	}
 
-	return strings.HasPrefix(content, types.LFSPrefix), int64(len(content)), nil
+	if !strings.HasPrefix(content, types.LFSPrefix) {
+		return false, int64(len(content)), nil
+	}
+	pointer, err := gitaly.ReadPointerFromBuffer([]byte(content))
+	if err != nil {
+		return false, -1, fmt.Errorf("failed to parse LFS pointer: %w", err)
+	}
+	return true, pointer.Size, nil
 }
 
+// HeadDownloadFile returns repository file metadata and its latest commit.
 func (c *repoComponentImpl) HeadDownloadFile(ctx context.Context, req *types.GetFileReq, userName string) (*types.File, *types.Commit, error) {
 	repo, err := c.repoStore.FindByPath(ctx, req.RepoType, req.Namespace, req.Name)
 	if err != nil {
+		if isRepositoryContentNotFound(err) {
+			return nil, nil, errorx.ErrNotFound
+		}
 		return nil, nil, fmt.Errorf("failed to find repo, error: %w", err)
 	}
 	canRead, err := c.AllowReadAccessRepo(ctx, repo, userName)
@@ -1680,7 +1693,7 @@ func (c *repoComponentImpl) HeadDownloadFile(ctx context.Context, req *types.Get
 	file, err := c.git.GetRepoFileContents(ctx, getFileContentReq)
 	if err != nil {
 		slog.Error("err.Error()", slog.Any("err.Error()", err.Error()))
-		if err.Error() == ErrNotFoundMessage || err.Error() == ErrGetContentsOrList {
+		if isRepositoryContentNotFound(err) || err.Error() == ErrNotFoundMessage || err.Error() == ErrGetContentsOrList {
 			return nil, nil, errorx.ErrNotFound
 		}
 		return nil, nil, fmt.Errorf("failed to download git %s repository file, error: %w", req.RepoType, err)
@@ -1704,6 +1717,15 @@ func (c *repoComponentImpl) HeadDownloadFile(ctx context.Context, req *types.Get
 	return file, lastCommit, nil
 }
 
+// isRepositoryContentNotFound identifies lower-layer errors that mean a repository or file does not exist.
+func isRepositoryContentNotFound(err error) bool {
+	return errors.Is(err, errorx.ErrNotFound) ||
+		errors.Is(err, errorx.ErrDatabaseNoRows) ||
+		errors.Is(err, errorx.ErrGitRepoNotFound) ||
+		errors.Is(err, errorx.ErrGitFileNotFound)
+}
+
+// SDKDownloadFile authorizes and prepares a download, recording it when req.CountDownload is true.
 func (c *repoComponentImpl) SDKDownloadFile(ctx context.Context, req *types.GetFileReq, userName string) (io.ReadCloser, int64, string, error) {
 	var downloadUrl string
 	repo, err := c.repoStore.FindByPath(ctx, req.RepoType, req.Namespace, req.Name)
@@ -1719,9 +1741,11 @@ func (c *repoComponentImpl) SDKDownloadFile(ctx context.Context, req *types.GetF
 		return nil, 0, "", errorx.ErrForbiddenMsg("users do not have permission to download file in this repo")
 	}
 
-	err = c.repoStore.UpdateRepoFileDownloads(ctx, repo, time.Now(), 1)
-	if err != nil {
-		return nil, 0, "", fmt.Errorf("failed to update %s file download count, error: %w", fmt.Sprintf("%s/%s/%s", req.RepoType, req.Namespace, req.Name), err)
+	if req.CountDownload {
+		err = c.repoStore.UpdateRepoFileDownloads(ctx, repo, time.Now(), 1)
+		if err != nil {
+			return nil, 0, "", fmt.Errorf("failed to update %s file download count, error: %w", fmt.Sprintf("%s/%s/%s", req.RepoType, req.Namespace, req.Name), err)
+		}
 	}
 
 	if req.Ref == "" {
@@ -1766,6 +1790,7 @@ func (c *repoComponentImpl) SDKDownloadFile(ctx context.Context, req *types.GetF
 			Ref:       req.Ref,
 			Path:      req.Path,
 			RepoType:  req.RepoType,
+			Limit:     req.Limit,
 		}
 		reader, size, err := c.git.GetRepoFileReader(ctx, getFileReaderReq)
 		if err != nil {

--- a/component/repo_test.go
+++ b/component/repo_test.go
@@ -810,28 +810,94 @@ func TestRepoComponent_SDKListFiles(t *testing.T) {
 }
 
 func TestRepoComponent_IsLFS(t *testing.T) {
-	ctx := context.TODO()
-	repo := initializeTestRepoComponent(ctx, t)
+	tests := []struct {
+		name     string
+		content  string
+		wantLFS  bool
+		wantSize int64
+		wantErr  bool
+	}{
+		{name: "regular file", content: "readme", wantSize: 6},
+		{
+			name: "LFS pointer",
+			content: "version https://git-lfs.github.com/spec/v1\n" +
+				"oid sha256:" + strings.Repeat("a", 64) + "\n" +
+				"size 10737418240\n",
+			wantLFS:  true,
+			wantSize: 10737418240,
+		},
+		{name: "invalid LFS pointer", content: types.LFSPrefix, wantSize: -1, wantErr: true},
+	}
 
-	repo.mocks.gitServer.EXPECT().GetRepoFileRaw(ctx, gitserver.GetRepoInfoByPathReq{
-		Namespace: "ns",
-		Name:      "n",
-		Ref:       "main",
-		Path:      "p",
-		RepoType:  types.ModelRepo,
-	}).Return("readme", nil)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.TODO()
+			repo := initializeTestRepoComponent(ctx, t)
+			req := &types.GetFileReq{
+				Namespace: "ns",
+				Name:      "n",
+				Ref:       "main",
+				Path:      "p",
+				RepoType:  types.ModelRepo,
+			}
+			repo.mocks.gitServer.EXPECT().GetRepoFileRaw(ctx, gitserver.GetRepoInfoByPathReq{
+				Namespace: req.Namespace,
+				Name:      req.Name,
+				Ref:       req.Ref,
+				Path:      req.Path,
+				RepoType:  req.RepoType,
+			}).Return(test.content, nil)
 
-	a, b, err := repo.IsLfs(ctx, &types.GetFileReq{
-		Namespace: "ns",
-		Name:      "n",
-		Ref:       "main",
-		Path:      "p",
-		RepoType:  types.ModelRepo,
-	})
-	require.Nil(t, err)
-	require.Equal(t, false, a)
-	require.Equal(t, int64(6), b)
+			lfs, size, err := repo.IsLfs(ctx, req)
 
+			require.Equal(t, test.wantLFS, lfs)
+			require.Equal(t, test.wantSize, size)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestRepoComponent_IsLFSNotFound verifies wrapped lower-layer not-found errors are normalized.
+func TestRepoComponent_IsLFSNotFound(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+	}{
+		{name: "database repository not found", err: errorx.ErrDatabaseNoRows},
+		{name: "git repository not found", err: errorx.ErrGitRepoNotFound},
+		{name: "git file not found", err: errorx.ErrGitFileNotFound},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.TODO()
+			repo := initializeTestRepoComponent(ctx, t)
+			req := &types.GetFileReq{
+				Namespace: "ns",
+				Name:      "n",
+				Ref:       "main",
+				Path:      "p",
+				RepoType:  types.ModelRepo,
+			}
+			repo.mocks.gitServer.EXPECT().GetRepoFileRaw(ctx, gitserver.GetRepoInfoByPathReq{
+				Namespace: req.Namespace,
+				Name:      req.Name,
+				Ref:       req.Ref,
+				Path:      req.Path,
+				RepoType:  req.RepoType,
+			}).Return("", fmt.Errorf("wrapped not-found error: %w", testCase.err))
+
+			lfs, size, err := repo.IsLfs(ctx, req)
+
+			require.False(t, lfs)
+			require.Equal(t, int64(-1), size)
+			require.ErrorIs(t, err, errorx.ErrNotFound)
+		})
+	}
 }
 
 func TestRepoComponent_HeadDownloadFile(t *testing.T) {
@@ -873,17 +939,42 @@ func TestRepoComponent_HeadDownloadFile(t *testing.T) {
 
 }
 
+// TestRepoComponent_HeadDownloadFileNotFound verifies a missing database repository is normalized.
+func TestRepoComponent_HeadDownloadFileNotFound(t *testing.T) {
+	ctx := context.TODO()
+	repo := initializeTestRepoComponent(ctx, t)
+	repo.mocks.stores.RepoMock().EXPECT().FindByPath(
+		ctx, types.ModelRepo, "ns", "n",
+	).Return(nil, fmt.Errorf("wrapped database error: %w", errorx.ErrDatabaseNoRows))
+
+	file, commit, err := repo.HeadDownloadFile(ctx, &types.GetFileReq{
+		Namespace: "ns",
+		Name:      "n",
+		Ref:       "main",
+		Path:      "path",
+		RepoType:  types.ModelRepo,
+	}, "user")
+
+	require.Nil(t, file)
+	require.Nil(t, commit)
+	require.ErrorIs(t, err, errorx.ErrNotFound)
+}
+
+// TestRepoComponent_SDKDownloadFile verifies SDK downloads honor the explicit statistics flag.
 func TestRepoComponent_SDKDownloadFile(t *testing.T) {
 	for _, lfs := range []bool{false, true} {
 		t.Run(fmt.Sprintf("is lfs: %v", lfs), func(t *testing.T) {
 			ctx := context.TODO()
 			repo := initializeTestRepoComponent(ctx, t)
+			var limit int64
+			if !lfs {
+				limit = 6
+			}
 
 			mockedRepo := &database.Repository{}
 			repo.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "ns", "n").Return(
 				mockedRepo, nil,
 			)
-			repo.mocks.stores.RepoMock().EXPECT().UpdateRepoFileDownloads(ctx, mockedRepo, mock.Anything, int64(1)).Return(nil)
 
 			if lfs {
 
@@ -907,6 +998,7 @@ func TestRepoComponent_SDKDownloadFile(t *testing.T) {
 					Ref:       "main",
 					Path:      "path",
 					RepoType:  types.ModelRepo,
+					Limit:     limit,
 				}).Return(nil, 100, nil)
 			}
 
@@ -919,6 +1011,7 @@ func TestRepoComponent_SDKDownloadFile(t *testing.T) {
 				Lfs:         lfs,
 				SaveAs:      "zzz",
 				CurrentUser: "user",
+				Limit:       limit,
 			}, "user")
 			require.Nil(t, err)
 			if lfs {
@@ -933,6 +1026,32 @@ func TestRepoComponent_SDKDownloadFile(t *testing.T) {
 		})
 	}
 
+	t.Run("count download", func(t *testing.T) {
+		ctx := context.TODO()
+		repo := initializeTestRepoComponent(ctx, t)
+		mockedRepo := &database.Repository{}
+		repo.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "ns", "n").Return(mockedRepo, nil)
+		repo.mocks.gitServer.EXPECT().GetRepoFileReader(ctx, gitserver.GetRepoInfoByPathReq{
+			Namespace: "ns",
+			Name:      "n",
+			Ref:       "main",
+			Path:      "path",
+			RepoType:  types.ModelRepo,
+		}).Return(nil, 100, nil)
+		repo.mocks.stores.RepoMock().EXPECT().UpdateRepoFileDownloads(ctx, mockedRepo, mock.Anything, int64(1)).Return(nil)
+
+		_, _, _, err := repo.SDKDownloadFile(ctx, &types.GetFileReq{
+			Namespace:     "ns",
+			Name:          "n",
+			Ref:           "main",
+			Path:          "path",
+			RepoType:      types.ModelRepo,
+			CurrentUser:   "user",
+			CountDownload: true,
+		}, "user")
+
+		require.NoError(t, err)
+	})
 }
 
 func TestRepoComponent_ListRuntimeFrameworkWithType(t *testing.T) {


### PR DESCRIPTION
Summary:
- Main scope: 变更原因：为支持dragonfly下载opencsg，需做一些文件下载的http规范处理，以及range功能的支持。现在获取仓库文件HEAD和文件下载时，LFS通过OSS自动支持相关规范，但普通文件尚未支持.
- Additional context: 主要改动点：.