### PR TITLE
Add vLLM audio duration response header

### DIFF
--- a/aigateway/component/adapter/audio/adapter_test.go
+++ b/aigateway/component/adapter/audio/adapter_test.go
@@ -101,11 +101,29 @@ func TestFunASRAdapterDurationFromHeader(t *testing.T) {
 	}
 }
 
-func TestOpenAICompatibleAdapterIgnoresDurationHeader(t *testing.T) {
-	header := http.Header{}
-	header.Set(audioDurationHeader, "9.2")
+func TestOpenAICompatibleAdapterDurationFromHeader(t *testing.T) {
+	adapter := NewOpenAICompatibleAdapter()
 
-	got, ok := NewOpenAICompatibleAdapter().DurationFromHeader(header)
-	require.False(t, ok)
-	require.Zero(t, got)
+	tests := []struct {
+		name string
+		val  string
+		want float64
+		ok   bool
+	}{
+		{name: "valid", val: "9.2", want: 9.2, ok: true},
+		{name: "invalid", val: "nope"},
+		{name: "missing"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := http.Header{}
+			if tt.val != "" {
+				header.Set(audioDurationHeader, tt.val)
+			}
+
+			got, ok := adapter.DurationFromHeader(header)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/aigateway/component/adapter/audio/openai_compatible.go
+++ b/aigateway/component/adapter/audio/openai_compatible.go
@@ -21,5 +21,5 @@ func (a *OpenAICompatibleAdapter) CanHandle(model *types.Model) bool {
 }
 
 func (a *OpenAICompatibleAdapter) DurationFromHeader(header http.Header) (float64, bool) {
-	return 0, false
+	return parseDurationHeader(header)
 }

--- a/docker/inference/Dockerfile.vllm
+++ b/docker/inference/Dockerfile.vllm
@@ -11,6 +11,8 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://mirrors.aliyun.com/ubuntu|
 RUN mkdir -p /var/log/supervisord
 COPY ./supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY ./vllm/ /etc/csghub/
+# Add Audio-Duration-Seconds to successful /v1/audio/transcriptions responses.
+RUN python3 /etc/csghub/patch_audio_duration_header.py
 RUN chmod +x /etc/csghub/*.sh
 RUN chmod +x /vllm-workspace/examples/ray_serving/*.sh
 

--- a/docker/inference/Dockerfile.vllm-amd
+++ b/docker/inference/Dockerfile.vllm-amd
@@ -10,6 +10,8 @@ RUN pip install --no-cache-dir "vllm[audio]==0.24.0" vllm-omni==0.24.0
 RUN mkdir -p /var/log/supervisord
 COPY ./supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY ./vllm/ /etc/csghub/
+# Add Audio-Duration-Seconds to successful /v1/audio/transcriptions responses.
+RUN python3 /etc/csghub/patch_audio_duration_header.py
 RUN chmod +x /etc/csghub/*.sh
 RUN chmod +x /app/vllm/examples/ray_serving/*.sh
 

--- a/docker/inference/vllm/patch_audio_duration_header.py
+++ b/docker/inference/vllm/patch_audio_duration_header.py
@@ -1,0 +1,76 @@
+"""Patch vLLM v0.24.0 to expose the decoded input audio duration.
+
+The patch is intentionally version-locked. It must fail during the image build
+when vLLM changes, rather than silently producing an image without the header.
+"""
+
+from pathlib import Path
+
+import vllm
+
+
+def replace_once(path: Path, old: str, new: str) -> None:
+    content = path.read_text()
+    if content.count(old) != 1:
+        raise RuntimeError(f"unexpected vLLM v0.24.0 source in {path}")
+    path.write_text(content.replace(old, new))
+
+
+vllmRoot = Path(vllm.__file__).resolve().parent
+servingPath = vllmRoot / "entrypoints/speech_to_text/base/serving.py"
+routerPath = vllmRoot / "entrypoints/speech_to_text/transcription/api_router.py"
+
+replace_once(
+    servingPath,
+    """        engine_inputs, duration_s = await self._preprocess_speech_to_text(
+            request=request,
+            audio_data=audio_data,
+            request_id=request_id,
+        )
+""",
+    """        engine_inputs, duration_s = await self._preprocess_speech_to_text(
+            request=request,
+            audio_data=audio_data,
+            request_id=request_id,
+        )
+        raw_request.state.audio_duration_s = duration_s
+""",
+)
+
+replace_once(
+    routerPath,
+    """    generator = await handler.create_transcription(audio_data, request, raw_request)
+
+    if isinstance(generator, ErrorResponse):
+        return JSONResponse(
+            content=generator.model_dump(), status_code=generator.error.code
+        )
+
+    elif isinstance(generator, TranscriptionResponseVariant):
+        return JSONResponse(content=generator.model_dump())
+
+    return StreamingResponse(content=generator, media_type="text/event-stream")
+""",
+    """    generator = await handler.create_transcription(audio_data, request, raw_request)
+    durationS = getattr(raw_request.state, "audio_duration_s", None)
+    headers = (
+        {"Audio-Duration-Seconds": f"{durationS:.3f}"}
+        if durationS is not None
+        else None
+    )
+
+    if isinstance(generator, ErrorResponse):
+        return JSONResponse(
+            content=generator.model_dump(), status_code=generator.error.code
+        )
+
+    elif isinstance(generator, TranscriptionResponseVariant):
+        return JSONResponse(content=generator.model_dump(), headers=headers)
+
+    return StreamingResponse(
+        content=generator,
+        media_type="text/event-stream",
+        headers=headers,
+    )
+""",
+)


### PR DESCRIPTION
Summary:
- Main scope: 变更原因：vLLM 音频转写接口在流式响应中不会返回音频时长，AIGateway 无法从上游响应记录时长用量，只能走额外的音频探测兜底。.
- Additional context: 主要改动点：.