### PR TITLE
[Manual Sync Required] Check event extra owner type of aigateway event for user inference

### DIFF
--- a/aigateway/component/openai.go
+++ b/aigateway/component/openai.go
@@ -548,17 +548,6 @@ func (m *openaiComponentImpl) isLegacyCSGHubModelID(model types.Model, modelID s
 	return model.LegacyModelID != "" && model.LegacyModelID == modelID
 }
 
-func getSceneFromSvcType(svcType int) int {
-	switch svcType {
-	case commontypes.InferenceType:
-		return int(commontypes.SceneModelInference)
-	case commontypes.ServerlessType:
-		return int(commontypes.SceneModelServerless)
-	default:
-		return int(commontypes.SceneUnknow)
-	}
-}
-
 // llmTypeFromModel returns metadata llm_type used to classify usage metering records.
 func llmTypeFromModel(m *types.Model) (string, error) {
 	if m == nil {
@@ -603,7 +592,7 @@ func (m *openaiComponentImpl) resolveUsageMeteringInfo(c context.Context, nsUUID
 			Scene: commontypes.SceneModelServerless,
 		}
 		if llmType == commontypes.ProviderTypeInference {
-			meteringInfo.Scene = commontypes.SceneModelInference
+			meteringInfo.Scene = commontypes.SceneModelServerless
 			ownerType, err := m.resolveUsageOwnerType(c, nsUUID, model)
 			if err != nil {
 				return usageMeteringInfo{}, err

--- a/aigateway/component/openai_test.go
+++ b/aigateway/component/openai_test.go
@@ -26,37 +26,6 @@ import (
 	commontypes "opencsg.com/csghub-server/common/types"
 )
 
-func TestGetSceneFromSvcType(t *testing.T) {
-	tests := []struct {
-		name     string
-		svcType  int
-		expected int
-	}{
-		{
-			name:     "inference type",
-			svcType:  commontypes.InferenceType,
-			expected: int(commontypes.SceneModelInference),
-		},
-		{
-			name:     "serverless type",
-			svcType:  commontypes.ServerlessType,
-			expected: int(commontypes.SceneModelServerless),
-		},
-		{
-			name:     "unknown type",
-			svcType:  999, // Some arbitrary value not defined in commontypes
-			expected: int(commontypes.SceneUnknow),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := getSceneFromSvcType(tt.svcType)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestFilterAndPaginateModels(t *testing.T) {
 	models := []types.Model{
 		{BaseModel: types.BaseModel{ID: "gpt-4:svc1", Object: "model", OwnedBy: "u1"}},
@@ -824,7 +793,7 @@ func TestOpenAIComponentImpl_RecordUsage(t *testing.T) {
 					require.Equal(t, "csghub://inference/test-model", evt.ResourceID)
 					require.Equal(t, "csghub://inference/test-model", evt.ResourceName)
 					require.Equal(t, "test-service", evt.CustomerID)
-					require.Equal(t, int(commontypes.SceneModelInference), evt.Scene)
+					require.Equal(t, int(commontypes.SceneModelServerless), evt.Scene)
 					require.Equal(t, "test-user-uuid", evt.UserUUID)
 					require.Equal(t, commontypes.TokenNumberType, evt.ValueType)
 					require.Equal(t, int64(150), evt.Value)
@@ -906,7 +875,7 @@ func TestOpenAIComponentImpl_RecordUsage(t *testing.T) {
 					err := json.Unmarshal(data, &evt)
 					require.NoError(t, err)
 					require.Equal(t, "csghub://inference/test-model", evt.ResourceID)
-					require.Equal(t, int(commontypes.SceneModelInference), evt.Scene)
+					require.Equal(t, int(commontypes.SceneModelServerless), evt.Scene)
 
 					var tokenUsageExtra struct {
 						OwnerType commontypes.TokenUsageType `json:"owner_type"`
@@ -968,7 +937,7 @@ func TestOpenAIComponentImpl_RecordUsage(t *testing.T) {
 					require.Equal(t, "csghub://inference/test-model", evt.ResourceID)
 					require.Equal(t, "csghub://inference/test-model", evt.ResourceName)
 					require.Equal(t, "test-service", evt.CustomerID)
-					require.Equal(t, int(commontypes.SceneModelInference), evt.Scene)
+					require.Equal(t, int(commontypes.SceneModelServerless), evt.Scene)
 					require.Equal(t, "test-user-uuid", evt.UserUUID)
 					require.Equal(t, commontypes.TokenNumberType, evt.ValueType)
 					require.Equal(t, int64(150), evt.Value)


### PR DESCRIPTION
Summary:
- Main scope: 修复 AIGateway 用户推理场景下的计费逻辑：当推理请求的 owner_type 为 CSGHub 内部用户（本用户部署、组织成员部署、其他用户部署）时，serverless 计费流程应仅记录消费而不产生实际扣费。.
- Additional context: 用户通过 AIGateway 发起推理请求时，`resolveUsageMeteringInfo` 会根据模型服务类型设置 scene。当 llm_type 为 Inference 时，之前将 scene 设为 `SceneModelInf.

Manual handling required:
- Dev-agent failed to cherry-pick this GitLab MR: Git克隆命令执行失败: Command '['git', '--git-dir', '/root/gitlab-to-github/dev-agent/agent/.cache/mirrors/csghub-server.git', 'fetch', '--prune', 'origin']' returned non-zero exit status 128.
错误输出: fatal: unable to access 'https://github.com/OpenCSGs/csghub-server.git/': Failed to connect to github.com port 443 after 130843 ms: Connection timed out

- Source GitLab MR: !2801
- Source ref: 66b6c2afe190605bb648139fd18ad7ba017c1691
- Files in sync scope: 2
- The GitLab MR patch was applied with git's 3-way apply. Please review before merging.