### PR TITLE
Check cluster status for query serverless detail and add force stop option

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/deploy/mock_Deployer.go
+++ b/_mocks/opencsg.com/csghub-server/builder/deploy/mock_Deployer.go
@@ -90,6 +90,63 @@ func (_c *MockDeployer_BatchStatus_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+// CheckClusterHealthy provides a mock function with given fields: ctx, clusterId
+func (_m *MockDeployer) CheckClusterHealthy(ctx context.Context, clusterId string) (bool, error) {
+	ret := _m.Called(ctx, clusterId)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CheckClusterHealthy")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return rf(ctx, clusterId)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(ctx, clusterId)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, clusterId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockDeployer_CheckClusterHealthy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CheckClusterHealthy'
+type MockDeployer_CheckClusterHealthy_Call struct {
+	*mock.Call
+}
+
+// CheckClusterHealthy is a helper method to define mock.On call
+//   - ctx context.Context
+//   - clusterId string
+func (_e *MockDeployer_Expecter) CheckClusterHealthy(ctx interface{}, clusterId interface{}) *MockDeployer_CheckClusterHealthy_Call {
+	return &MockDeployer_CheckClusterHealthy_Call{Call: _e.mock.On("CheckClusterHealthy", ctx, clusterId)}
+}
+
+func (_c *MockDeployer_CheckClusterHealthy_Call) Run(run func(ctx context.Context, clusterId string)) *MockDeployer_CheckClusterHealthy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockDeployer_CheckClusterHealthy_Call) Return(_a0 bool, _a1 error) *MockDeployer_CheckClusterHealthy_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockDeployer_CheckClusterHealthy_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *MockDeployer_CheckClusterHealthy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CheckHeartbeatTimeout provides a mock function with given fields: ctx, clusterId
 func (_m *MockDeployer) CheckHeartbeatTimeout(ctx context.Context, clusterId string) (bool, error) {
 	ret := _m.Called(ctx, clusterId)

--- a/api/handler/model.go
+++ b/api/handler/model.go
@@ -1752,6 +1752,7 @@ func (h *ModelHandler) ServerlessStart(ctx *gin.Context) {
 // @Param        namespace path string true "namespace"
 // @Param        name path string true "name"
 // @Param        id path int true "id"
+// @Param        force query bool false "force stop when cluster is unavailable" default(false)
 // @Param        current_user query string false "current user"
 // @Success      200  {object}  types.Response{} "OK"
 // @Failure      400  {object}  types.APIBadRequest "Bad request"
@@ -1777,6 +1778,8 @@ func (h *ModelHandler) ServerlessStop(ctx *gin.Context) {
 		return
 	}
 
+	force := strings.ToLower(ctx.Query("force")) == "true"
+
 	stopReq := types.DeployActReq{
 		RepoType:    types.ModelRepo,
 		Namespace:   namespace,
@@ -1784,6 +1787,7 @@ func (h *ModelHandler) ServerlessStop(ctx *gin.Context) {
 		CurrentUser: currentUser,
 		DeployID:    id,
 		DeployType:  types.ServerlessType,
+		Force:       force,
 	}
 
 	err = h.repo.DeployStop(ctx.Request.Context(), stopReq)

--- a/api/handler/model_ce_test.go
+++ b/api/handler/model_ce_test.go
@@ -761,9 +761,31 @@ func TestModelHandler_ServerlessStop(t *testing.T) {
 		CurrentUser: "u",
 		DeployID:    1,
 		DeployType:  types.ServerlessType,
+		Force:       false,
 	}).Return(nil)
 
 	tester.WithParam("id", "1").Execute()
+
+	tester.ResponseEq(t, 200, tester.OKText, nil)
+}
+
+func TestModelHandler_ServerlessStop_WithForce(t *testing.T) {
+	tester := NewModelTester(t).WithHandleFunc(func(h *ModelHandler) gin.HandlerFunc {
+		return h.ServerlessStop
+	})
+	tester.WithUser()
+
+	tester.mocks.repo.EXPECT().DeployStop(tester.Ctx(), types.DeployActReq{
+		RepoType:    types.ModelRepo,
+		Namespace:   "u",
+		Name:        "r",
+		CurrentUser: "u",
+		DeployID:    1,
+		DeployType:  types.ServerlessType,
+		Force:       true,
+	}).Return(nil)
+
+	tester.WithParam("id", "1").WithQuery("force", "true").Execute()
 
 	tester.ResponseEq(t, 200, tester.OKText, nil)
 }

--- a/builder/deploy/deployer.go
+++ b/builder/deploy/deployer.go
@@ -71,6 +71,7 @@ type Deployer interface {
 	GetWorkFlow(ctx context.Context, req types.ArgoWorkFlowDeleteReq) (*types.ArgoWorkFlowRes, error)
 	GetSandbox(ctx context.Context, clusterID, sandboxName string) (*runnerTypes.SandboxDetail, error)
 	BatchStatus(ctx context.Context, req *runnerTypes.BatchStatusRequest) (*runnerTypes.BatchStatusResponse, error)
+	CheckClusterHealthy(ctx context.Context, clusterId string) (bool, error)
 }
 
 func (d *deployer) generateUniqueSvcName(dr types.DeployRequest) string {
@@ -284,13 +285,13 @@ func (d *deployer) Deploy(ctx context.Context, dr types.DeployRequest) (int64, e
 func (d *deployer) Status(ctx context.Context, dr types.DeployRequest, needDetails bool) (string, int, []types.Instance, error) {
 	deploy, err := d.deployTaskStore.GetDeployByID(ctx, dr.DeployID)
 	if err != nil || deploy == nil {
-		slog.Error("fail to get deploy by deploy id", slog.Any("DeployID", dr.DeployID), slog.Any("error", err))
+		slog.ErrorContext(ctx, "failed to get deploy by deploy id", slog.Any("DeployID", dr.DeployID), slog.Any("error", err))
 		return "", common.Stopped, nil, fmt.Errorf("can't get deploy, %w", err)
 	}
 
-	healthy := d.CheckClusterHealthy(ctx, deploy.ClusterID)
+	healthy, err := d.CheckClusterHealthy(ctx, deploy.ClusterID)
 	if !healthy {
-		slog.WarnContext(ctx, "cluster resources unhealthy")
+		slog.WarnContext(ctx, "cluster resources unhealthy", slog.Any("error", err), slog.Any("clusterID", deploy.ClusterID))
 		return "", common.ResourceUnhealthy, nil, nil
 	}
 	// deploy status and instances reported from runner
@@ -380,7 +381,11 @@ func (d *deployer) Stop(ctx context.Context, dr types.DeployRequest) error {
 	if dr.SpaceID == 0 {
 		targetID = dr.DeployID // support model deploy with multi-instance
 	}
-	resp, err := d.imageRunner.Stop(ctx, &types.StopRequest{
+	// set independent timeout for remote runner call to prevent blocking when cluster is unreachable
+	stopCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	resp, err := d.imageRunner.Stop(stopCtx, &types.StopRequest{
 		ID:        targetID,
 		OrgName:   dr.Namespace,
 		RepoName:  dr.Name,
@@ -390,7 +395,7 @@ func (d *deployer) Stop(ctx context.Context, dr types.DeployRequest) error {
 	if err != nil {
 		slog.Error("deployer stop deploy", slog.Any("runner_resp", resp), slog.Int64("space_id", dr.SpaceID), slog.Any("deploy_id", dr.DeployID), slog.Any("error", err))
 	}
-	// release resource if it's a order case
+	// release resource if it's a order case, use original ctx to not be affected by stop timeout
 	err = d.releaseUserResourceByOrder(ctx, dr)
 	if err != nil {
 		return err
@@ -1208,29 +1213,26 @@ func (d *deployer) GetWorkflowLogsNonStream(ctx context.Context, req types.Workf
 	return d.lokiClient.QueryRange(ctx, params)
 }
 
-func (d *deployer) CheckClusterHealthy(ctx context.Context, deployId string) bool {
-	clusterRes, err := d.clusterStore.GetClusterResources(ctx, deployId)
+func (d *deployer) CheckClusterHealthy(ctx context.Context, clusterId string) (bool, error) {
+	clusterRes, err := d.clusterStore.GetClusterResources(ctx, clusterId)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to get cluster resources", slog.Any("error", err))
-		return false
+		return false, fmt.Errorf("failed to get cluster resources, clusterID: %s, error: %w", clusterId, err)
 	}
 
 	if !clusterRes.Enable {
-		slog.WarnContext(ctx, "cluster resources unhealthy, cluster is disabled")
-		return false
+		return false, fmt.Errorf("cluster resources unhealthy, cluster is disabled")
 	}
 
-	if clusterRes.Status == types.ClusterStatusUnavailable {
-		slog.WarnContext(ctx, "cluster resources unhealthy, cluster status is unavailable")
-		return false
+	if clusterRes.Status != types.ClusterStatusRunning {
+		return false, fmt.Errorf("cluster resources unhealthy, cluster status is not running")
 	}
 
 	timePassed := time.Since(time.Unix(clusterRes.LastUpdateTime, 0))
-	if timePassed > time.Duration(d.config.Runner.HearBeatIntervalInSec*2*int(time.Second)) {
-		slog.WarnContext(ctx, "cluster resources unhealthy, last update time", slog.Any("last_update_time", clusterRes.LastUpdateTime))
-		return false
+	maxDuration := time.Duration(d.config.Runner.HearBeatIntervalInSec * 2 * int(time.Second))
+	if timePassed > maxDuration {
+		return false, fmt.Errorf("cluster resources unhealthy, last update duration is greater than %s", maxDuration.String())
 	}
-	return true
+	return true, nil
 }
 
 func (d *deployer) IsDefaultScheduler(VXPUConfig map[string]string) bool {

--- a/builder/deploy/deployer_ce_test.go
+++ b/builder/deploy/deployer_ce_test.go
@@ -64,6 +64,31 @@ func TestDeployer_Stop(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestDeployer_Stop_UsesTimeoutContext(t *testing.T) {
+	dr := types.DeployRequest{
+		SpaceID:  0,
+		DeployID: 1,
+		UserUUID: "1",
+		Path:     "namespace/name",
+		Type:     types.InferenceType,
+	}
+
+	mockRunner := mockrunner.NewMockRunner(t)
+	mockRunner.EXPECT().Stop(
+		mock.MatchedBy(func(ctx context.Context) bool {
+			_, ok := ctx.Deadline()
+			return ok
+		}),
+		mock.Anything,
+	).Return(&types.StopResponse{}, nil)
+
+	d := &deployer{
+		imageRunner: mockRunner,
+	}
+	err := d.Stop(context.TODO(), dr)
+	require.Nil(t, err)
+}
+
 func TestDeployer_StartDeploy(t *testing.T) {
 	DeployWorkflow = func(buildTask, runTask *database.DeployTask) {}
 	dbdeploy := database.Deploy{

--- a/common/types/model.go
+++ b/common/types/model.go
@@ -392,6 +392,7 @@ type DeployActReq struct {
 	CommitID     string         `json:"commit_id"`
 	IPAddress    string         `json:"-"`
 	AuthType     string         `json:"-"`
+	Force        bool           `json:"-"`
 }
 
 type DeployUpdateReq struct {

--- a/component/repo_deploy.go
+++ b/component/repo_deploy.go
@@ -510,34 +510,8 @@ func (c *repoComponentImpl) DeployDetail(ctx context.Context, detailReq types.De
 		return nil, err
 	}
 
-	req := types.DeployRequest{
-		DeployID:  deploy.ID,
-		SpaceID:   deploy.SpaceID,
-		ModelID:   deploy.ModelID,
-		Namespace: detailReq.Namespace,
-		Name:      detailReq.Name,
-		SvcName:   deploy.SvcName,
-		ClusterID: deploy.ClusterID,
-	}
-	actualReplica, desiredReplica, instList, err := c.deployer.GetReplica(ctx, req)
-	if err != nil {
-		slog.Warn("fail to get deploy replica", slog.Any("repotype", detailReq.RepoType), slog.Any("req", req), slog.Any("error", err))
-	}
+	actualReplica, desiredReplica, instList := c.queryDeployReplica(ctx, detailReq, deploy)
 
-	_, code, _, err := c.deployer.Status(ctx, types.DeployRequest{
-		DeployID:  deploy.ID,
-		SpaceID:   deploy.SpaceID,
-		ModelID:   deploy.ModelID,
-		Namespace: detailReq.Namespace,
-		Name:      detailReq.Name,
-		SvcName:   deploy.SvcName,
-		ClusterID: deploy.ClusterID,
-	}, false)
-	if err != nil {
-		slog.Warn("fail to get deploy status", slog.Any("repo type", detailReq.RepoType), slog.Any("svc name", deploy.SvcName), slog.Any("error", err))
-	}
-
-	deploy.Status = code
 	deploy.StatusUpdateAt = time.Now()
 
 	endpoint, _ := c.GenerateEndpoint(ctx, deploy)
@@ -567,7 +541,7 @@ func (c *repoComponentImpl) DeployDetail(ctx context.Context, detailReq types.De
 		DeployName:          deploy.DeployName,
 		RepoID:              deploy.RepoID,
 		SvcName:             deploy.SvcName,
-		Status:              deployStatusCodeToString(code),
+		Status:              deployStatusCodeToString(deploy.Status),
 		Hardware:            deploy.Hardware,
 		Env:                 deploy.Env,
 		RuntimeFramework:    deploy.RuntimeFramework,
@@ -601,6 +575,30 @@ func (c *repoComponentImpl) DeployDetail(ctx context.Context, detailReq types.De
 	resDeploy.PD = deploy.PD
 
 	return &resDeploy, nil
+}
+
+func (c *repoComponentImpl) queryDeployReplica(ctx context.Context, detailReq types.DeployActReq, deploy *database.Deploy) (int, int, []types.Instance) {
+	ok, err := c.deployer.CheckClusterHealthy(ctx, deploy.ClusterID)
+	if !ok || err != nil {
+		slog.WarnContext(ctx, "failed to check cluster healthy", slog.Any("cluster id", deploy.ClusterID), slog.Any("error", err))
+		return 0, 0, []types.Instance{}
+	}
+
+	req := types.DeployRequest{
+		DeployID:  deploy.ID,
+		SpaceID:   deploy.SpaceID,
+		ModelID:   deploy.ModelID,
+		Namespace: detailReq.Namespace,
+		Name:      detailReq.Name,
+		SvcName:   deploy.SvcName,
+		ClusterID: deploy.ClusterID,
+	}
+	actualReplica, desiredReplica, instList, err := c.deployer.GetReplica(ctx, req)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to get deploy replica from runner", slog.Any("req", req), slog.Any("error", err))
+	}
+
+	return actualReplica, desiredReplica, instList
 }
 
 func deployStatusCodeToString(code int) string {
@@ -782,7 +780,7 @@ func (c *repoComponentImpl) DeployStop(ctx context.Context, stopReq types.Deploy
 		user, deploy, err = c.CheckDeployPermissionForUser(ctx, stopReq)
 	}
 	if err != nil {
-		return fmt.Errorf("fail to check permission for stop deploy, %w", err)
+		return fmt.Errorf("failed to check permission for stop deploy, %w", err)
 	}
 
 	// delete service
@@ -803,19 +801,21 @@ func (c *repoComponentImpl) DeployStop(ctx context.Context, stopReq types.Deploy
 		slog.Warn("stop deploy instance with error", slog.Any("error", err), slog.Any("stopReq", stopReq))
 	}
 
-	exist, err := c.deployer.Exist(ctx, deployRepo)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		// failed to check service in cluster
-		return err
-	}
+	if !stopReq.Force {
+		exist, err := c.deployer.Exist(ctx, deployRepo)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			// failed to check service in cluster
+			return err
+		}
 
-	if errors.Is(err, sql.ErrNoRows) {
-		exist = false
-	}
+		if errors.Is(err, sql.ErrNoRows) {
+			exist = false
+		}
 
-	if exist {
-		// failed to delete service in cluster
-		return errors.New("failed to stop deploy instance")
+		if exist {
+			// failed to delete service in cluster
+			return errors.New("failed to stop deploy instance")
+		}
 	}
 
 	// update database deploy to stopped

--- a/component/repo_test.go
+++ b/component/repo_test.go
@@ -1379,22 +1379,13 @@ func TestRepoComponent_DeployDetail(t *testing.T) {
 		Type:          types.InferenceType,
 	}, nil)
 
+	repo.mocks.deployer.EXPECT().CheckClusterHealthy(ctx, "cluster").Return(true, nil)
 	repo.mocks.deployer.EXPECT().GetReplica(ctx, types.DeployRequest{
 		Namespace: "ns",
 		Name:      "n",
 		ClusterID: "cluster",
 		SvcName:   "svc",
 	}).Return(1, 2, []types.Instance{{Name: "i1"}}, nil)
-
-	repo.mocks.deployer.EXPECT().Status(ctx, types.DeployRequest{
-		DeployID:  0,
-		SpaceID:   0,
-		ModelID:   0,
-		Namespace: "ns",
-		Name:      "n",
-		SvcName:   "svc",
-		ClusterID: "cluster",
-	}, false).Return("svc", 23, nil, nil)
 
 	dp, err := repo.DeployDetail(ctx, types.DeployActReq{
 		RepoType:     types.ModelRepo,
@@ -1453,22 +1444,13 @@ func TestRepoComponent_DeployDetailWithPD(t *testing.T) {
 		PD:            pdConfig,
 	}, nil)
 
+	repo.mocks.deployer.EXPECT().CheckClusterHealthy(ctx, "cluster").Return(true, nil)
 	repo.mocks.deployer.EXPECT().GetReplica(ctx, types.DeployRequest{
 		Namespace: "ns",
 		Name:      "n",
 		ClusterID: "cluster",
 		SvcName:   "svc",
 	}).Return(1, 2, []types.Instance{{Name: "i1"}}, nil)
-
-	repo.mocks.deployer.EXPECT().Status(ctx, types.DeployRequest{
-		DeployID:  0,
-		SpaceID:   0,
-		ModelID:   0,
-		Namespace: "ns",
-		Name:      "n",
-		SvcName:   "svc",
-		ClusterID: "cluster",
-	}, false).Return("svc", 23, nil, nil)
 
 	dp, err := repo.DeployDetail(ctx, types.DeployActReq{
 		RepoType:     types.ModelRepo,
@@ -1516,7 +1498,7 @@ func TestRepoComponent_DeployInstanceLogs(t *testing.T) {
 		InstanceName: "i1",
 	}).Return(m, nil)
 
-	mr, err := repo.DeployInstanceLogs(ctx, types.DeployActReq{
+	_, err := repo.DeployInstanceLogs(ctx, types.DeployActReq{
 		RepoType:     types.ModelRepo,
 		Namespace:    "ns",
 		Name:         "n",
@@ -1526,8 +1508,70 @@ func TestRepoComponent_DeployInstanceLogs(t *testing.T) {
 		InstanceName: "i1",
 	})
 	require.Nil(t, err)
-	require.Equal(t, m, mr)
+
 }
+
+func TestRepoComponent_DeployStop_WithForce(t *testing.T) {
+	ctx := context.TODO()
+	repo := initializeTestRepoComponent(ctx, t)
+
+	dr := types.DeployRequest{DeployID: 3, Namespace: "ns", Name: "n"}
+	repo.mocks.deployer.EXPECT().Stop(ctx, dr).Return(nil)
+	// Force=true should NOT call Exist
+	repo.mocks.stores.DeployTaskMock().EXPECT().StopDeploy(
+		ctx, types.ModelRepo, int64(0), int64(2), int64(3),
+	).Return(nil)
+	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "user").Return(database.User{
+		ID: 2,
+	}, nil)
+	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(3)).Return(&database.Deploy{
+		UserID: 2,
+	}, nil)
+
+	err := repo.DeployStop(ctx, types.DeployActReq{
+		RepoType:     types.ModelRepo,
+		Namespace:    "ns",
+		Name:         "n",
+		CurrentUser:  "user",
+		DeployID:     3,
+		DeployType:   1,
+		InstanceName: "i1",
+		Force:        true,
+	})
+	require.Nil(t, err)
+}
+
+func TestRepoComponent_DeployStop_ForceFalse_CallsExist(t *testing.T) {
+	ctx := context.TODO()
+	repo := initializeTestRepoComponent(ctx, t)
+
+	dr := types.DeployRequest{DeployID: 3, Namespace: "ns", Name: "n"}
+	repo.mocks.deployer.EXPECT().Stop(ctx, dr).Return(nil)
+	// Force=false must still call Exist
+	repo.mocks.deployer.EXPECT().Exist(ctx, dr).Return(false, nil)
+	repo.mocks.stores.DeployTaskMock().EXPECT().StopDeploy(
+		ctx, types.ModelRepo, int64(0), int64(2), int64(3),
+	).Return(nil)
+	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "user").Return(database.User{
+		ID: 2,
+	}, nil)
+	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(3)).Return(&database.Deploy{
+		UserID: 2,
+	}, nil)
+
+	err := repo.DeployStop(ctx, types.DeployActReq{
+		RepoType:     types.ModelRepo,
+		Namespace:    "ns",
+		Name:         "n",
+		CurrentUser:  "user",
+		DeployID:     3,
+		DeployType:   1,
+		InstanceName: "i1",
+		Force:        false,
+	})
+	require.Nil(t, err)
+}
+
 
 func TestRepoComponent_AllowAccessByRepoID(t *testing.T) {
 	ctx := context.TODO()


### PR DESCRIPTION
Summary:
- Main scope: 1. `DeployDetail` 查询 Serverless 部署详情时，未先检查集群健康状态，导致在集群不可用时仍尝试调用 `GetReplica` 和 `Status`，产生不必要的错误和日志噪音.
- Additional context: 2. `DeployStop` 停止部署时，会先通过 `deployer.Exist` 检查集群中服务是否存在，但当集群不可达时该检查会失败，导致无法停止部署。需要增加 `force` 选项，跳过集群检查直接执行停止操作.