### PR TITLE
[Manual Sync Required] Don't set MSPath HFPath GithubPath for user created repo

### DIFF
--- a/common/types/mirror.go
+++ b/common/types/mirror.go
@@ -21,6 +21,9 @@ type CreateMirrorReq struct {
 	SyncLfs         bool           `json:"sync_lfs"`
 	// Urgent routes the next synchronization through the urgent mirror queues.
 	Urgent bool `json:"urgent,omitempty"`
+	// SkipSourcePath skips setting HFPath/MSPath/GithubPath on the repository.
+	// Used for user-created code/skill repos where auto-generated descriptions are not desired.
+	SkipSourcePath bool `json:"-"`
 }
 
 // MirrorFromSaasReq identifies an existing repository and the user requesting a SaaS mirror sync.
@@ -272,6 +275,9 @@ type CreateMirrorRepoReq struct {
 	Priority MirrorPriority `json:"priority,omitempty"`
 	// Urgent routes the initial synchronization through the urgent mirror queues.
 	Urgent bool `json:"urgent,omitempty"`
+	// SkipSourcePath skips setting HFPath/MSPath/GithubPath on the repository.
+	// Used for user-imported code/skill repos where auto-generated descriptions are not desired.
+	SkipSourcePath bool `json:"-"`
 }
 
 type ResolveNamespaceReq struct {

--- a/component/code.go
+++ b/component/code.go
@@ -778,14 +778,15 @@ func (c *codeComponentImpl) createMirrorIfNeeded(ctx context.Context, req *types
 	}
 
 	mirrorReq := types.CreateMirrorReq{
-		Namespace:   req.Namespace,
-		Name:        req.Name,
-		SourceUrl:   req.GitURL,
-		Username:    req.GitUsername,
-		AccessToken: req.GitPassword,
-		CurrentUser: req.Username,
-		RepoType:    types.CodeRepo,
-		SyncLfs:     true,
+		Namespace:      req.Namespace,
+		Name:           req.Name,
+		SourceUrl:      req.GitURL,
+		Username:       req.GitUsername,
+		AccessToken:    req.GitPassword,
+		CurrentUser:    req.Username,
+		RepoType:       types.CodeRepo,
+		SyncLfs:        true,
+		SkipSourcePath: true, // user-created code repos should not set source paths
 	}
 
 	_, err := c.mirrorComponent.CreateMirror(ctx, mirrorReq)

--- a/component/mirror.go
+++ b/component/mirror.go
@@ -344,16 +344,16 @@ func NewMirrorComponent(config *config.Config) (MirrorComponent, error) {
 	return c, nil
 }
 
-// mapNamespaceAndName resolves a remote namespace to a lowercase local namespace.
+// mapNamespaceAndName resolves a remote namespace while preserving the mapped target casing.
 func (m *mirrorComponentImpl) mapNamespaceAndName(sourceNamespace string) string {
 	n, err := m.mirrorNamespaceMappingStore.FindBySourceNamespace(context.Background(), sourceNamespace)
 	if err != nil {
-		return "aiwizards"
+		return "Aiwizards"
 	}
 	if n.TargetNamespace == "" {
-		return "aiwizards"
+		return "Aiwizards"
 	}
-	return strings.ToLower(strings.TrimSpace(n.TargetNamespace))
+	return strings.TrimSpace(n.TargetNamespace)
 }
 
 // CreateMirror creates a mirror configuration for an existing repository.
@@ -429,8 +429,10 @@ func (m *mirrorComponentImpl) CreateMirror(ctx context.Context, req types.Create
 
 	mirror.Priority = types.LowMirrorPriority
 
-	sourceType, sourcePath, _ := common.GetSourceTypeAndPathFromURL(req.SourceUrl)
-	applyMirrorRepositorySourcePath(repo, sourceType, sourcePath)
+	if !req.SkipSourcePath {
+		sourceType, sourcePath, _ := common.GetSourceTypeAndPathFromURL(req.SourceUrl)
+		applyMirrorRepositorySourcePath(repo, sourceType, sourcePath)
+	}
 	reqMirror, err := m.mirrorRepoStore.CreateMirrorRepoRecords(ctx, database.CreateMirrorRepoRecordsInput{
 		Repository:       repo,
 		CreateRepository: false,

--- a/component/mirror_repo.go
+++ b/component/mirror_repo.go
@@ -124,7 +124,8 @@ func (m *mirrorComponentImpl) CreateMirrorRepo(ctx context.Context, req types.Cr
 			)
 		}
 
-		return m.createMirrorRepoRecords(ctx, req, repo, namespace, name, false)
+		repoNamespace, _ := repo.NamespaceAndName()
+		return m.createMirrorRepoRecords(ctx, req, repo, repoNamespace, repo.Name, false)
 	}
 	if req.CreateTargetRepo != nil && !*req.CreateTargetRepo {
 		return nil, errorx.RepoNotFound(
@@ -155,13 +156,17 @@ func (m *mirrorComponentImpl) CreateMirrorRepo(ctx context.Context, req types.Cr
 		StarCount:     req.MCPServerAttributes.StarCount,
 	}
 
-	sourceType, sourcePath, _ := common.GetSourceTypeAndPathFromURL(req.SourceGitCloneUrl)
+	sourceType, sourcePath := "", ""
+	if !req.SkipSourcePath {
+		sourceType, sourcePath, _ = common.GetSourceTypeAndPathFromURL(req.SourceGitCloneUrl)
+	}
 	dbRepo, err := m.prepareMirrorRepository(ctx, createRepoReq, sourceType, sourcePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare mirror repository, error: %w", err)
 	}
 
-	return m.createMirrorRepoRecords(ctx, req, dbRepo, namespace, name, true)
+	repoNamespace, _ := dbRepo.NamespaceAndName()
+	return m.createMirrorRepoRecords(ctx, req, dbRepo, repoNamespace, dbRepo.Name, true)
 }
 
 // normalizeMirrorPriority defaults an omitted priority and rejects values unsupported by workhub.
@@ -235,7 +240,7 @@ func normalizeMirrorSource(sourceURL, username, accessToken string) (string, str
 	return parsedURL.String(), username, accessToken, nil
 }
 
-// resolveMirrorRepoTarget chooses and lowercases the local mirror target path from fork fields or namespace mapping.
+// resolveMirrorRepoTarget chooses and trims the local mirror target path from fork fields or namespace mapping.
 func (m *mirrorComponentImpl) resolveMirrorRepoTarget(req types.CreateMirrorRepoReq) (string, string) {
 	namespace := req.ForkNamespace
 	if namespace == "" {
@@ -245,13 +250,13 @@ func (m *mirrorComponentImpl) resolveMirrorRepoTarget(req types.CreateMirrorRepo
 	if name == "" {
 		name = req.SourceName
 	}
-	return strings.ToLower(strings.TrimSpace(namespace)), strings.ToLower(strings.TrimSpace(name))
+	return strings.TrimSpace(namespace), strings.TrimSpace(name)
 }
 
 // createMirrorRepoRecords creates mirror rows transactionally, and optionally the target repo rows too.
 func (m *mirrorComponentImpl) createMirrorRepoRecords(ctx context.Context, req types.CreateMirrorRepoReq, repo *database.Repository, namespace, name string, createRepository bool) (*database.Mirror, error) {
 	mirror := buildMirrorRepoRecord(req, repo, namespace, name)
-	if !createRepository {
+	if !createRepository && !req.SkipSourcePath {
 		sourceType, sourcePath, _ := common.GetSourceTypeAndPathFromURL(req.SourceGitCloneUrl)
 		applyMirrorRepositorySourcePath(repo, sourceType, sourcePath)
 	}
@@ -282,7 +287,8 @@ func (m *mirrorComponentImpl) prepareMirrorRepository(ctx context.Context, req t
 		return nil, errorx.ErrRepoNameInvalid
 	}
 
-	if _, err := m.namespaceStore.FindByPath(ctx, req.Namespace); err != nil {
+	namespace, err := m.namespaceStore.FindByPath(ctx, req.Namespace)
+	if err != nil {
 		slog.ErrorContext(ctx, "namespace does not exist", slog.Any("error", err))
 		return nil, errorx.ErrNamespaceNotFound
 	}
@@ -301,7 +307,7 @@ func (m *mirrorComponentImpl) prepareMirrorRepository(ctx context.Context, req t
 		req.DefaultBranch = types.MainBranch
 	}
 
-	repoPath := path.Join(req.Namespace, req.Name)
+	repoPath := path.Join(namespace.Path, req.Name)
 	repo := &database.Repository{
 		UserID:         user.ID,
 		Path:           repoPath,

--- a/component/mirror_repo_test.go
+++ b/component/mirror_repo_test.go
@@ -524,6 +524,103 @@ func TestMirrorComponent_CreateMirror(t *testing.T) {
 	}, fakeStore.inputs[0].Mirror)
 }
 
+// TestMirrorComponent_CreateMirrorRequeuesSameSource verifies repeated creation starts a fresh sync for the existing source.
+func TestMirrorComponent_CreateMirrorRequeuesSameSource(t *testing.T) {
+	ctx := context.TODO()
+	mc := initializeTestMirrorComponent(ctx, t)
+	fakeStore := &fakeMirrorRepoStore{}
+	mc.mirrorRepoStore = fakeStore
+
+	repo := &database.Repository{ID: 123, Path: "ns/n", RepositoryType: types.ModelRepo}
+	mirror := &database.Mirror{
+		ID: 456, RepositoryID: repo.ID, SourceUrl: "https://github.com/upstream/repo.git",
+	}
+	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "user", "ns", membership.RoleAdmin).Return(true, nil)
+	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "ns", "n").Return(repo, nil)
+	mc.mocks.stores.MirrorMock().EXPECT().FindByRepoID(ctx, repo.ID).Return(mirror, nil)
+	username, accessToken := "source-user", "source-token"
+	expectMirrorRepoRequeue(ctx, t, mc, repo, mirror, &username, &accessToken, types.LowMirrorPriority, true)
+
+	got, err := mc.CreateMirror(ctx, types.CreateMirrorReq{
+		SourceUrl:   "https://source-user:source-token@github.com/upstream/repo",
+		CurrentUser: "user",
+		Namespace:   "ns",
+		Name:        "n",
+		RepoType:    types.ModelRepo,
+		Urgent:      true,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, mirror.ID, got.ID)
+	require.Equal(t, username, got.Username)
+	require.Equal(t, accessToken, got.AccessToken)
+	require.Empty(t, fakeStore.inputs)
+}
+
+// TestMirrorComponent_CreateMirrorSkipsSourcePathForCodeAndSkill verifies that CreateMirror
+// does not set source path fields for code and skill repos, since these are user-imported types.
+func TestMirrorComponent_CreateMirrorSkipsSourcePathForCodeAndSkill(t *testing.T) {
+	for _, repoType := range []types.RepositoryType{types.CodeRepo, types.SkillRepo} {
+		t.Run(string(repoType), func(t *testing.T) {
+			ctx := context.TODO()
+			mc := initializeTestMirrorComponent(ctx, t)
+			fakeStore := &fakeMirrorRepoStore{}
+			mc.mirrorRepoStore = fakeStore
+
+			repo := &database.Repository{
+				ID:             123,
+				Path:           "ns/n",
+				HTTPCloneURL:   "https://opencsg.com/repos/ns/n.git",
+				RepositoryType: repoType,
+			}
+
+			mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "user", "ns", membership.RoleAdmin).Return(true, nil)
+			mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, repoType, "ns", "n").Return(repo, nil)
+			mc.mocks.stores.MirrorMock().EXPECT().FindByRepoID(ctx, repo.ID).Return(nil, sql.ErrNoRows)
+
+			got, err := mc.CreateMirror(ctx, types.CreateMirrorReq{
+				SourceUrl:      "https://github.com/upstream/repo",
+				CurrentUser:    "user",
+				Namespace:      "ns",
+				Name:           "n",
+				RepoType:       repoType,
+				SkipSourcePath: true,
+			})
+			require.NoError(t, err)
+			require.Equal(t, repo.ID, got.RepositoryID)
+			require.Len(t, fakeStore.inputs, 1)
+			require.Empty(t, fakeStore.inputs[0].Repository.GithubPath)
+			require.Empty(t, fakeStore.inputs[0].Repository.HFPath)
+			require.Empty(t, fakeStore.inputs[0].Repository.MSPath)
+		})
+	}
+}
+
+// TestMirrorComponent_CreateMirrorRejectsDifferentSource verifies creation cannot replace an existing mirror source.
+func TestMirrorComponent_CreateMirrorRejectsDifferentSource(t *testing.T) {
+	ctx := context.TODO()
+	mc := initializeTestMirrorComponent(ctx, t)
+
+	repo := &database.Repository{ID: 123, Path: "ns/n", RepositoryType: types.ModelRepo}
+	mirror := &database.Mirror{
+		ID: 456, RepositoryID: repo.ID, SourceUrl: "https://github.com/existing/repo.git",
+	}
+	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "user", "ns", membership.RoleAdmin).Return(true, nil)
+	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.ModelRepo, "ns", "n").Return(repo, nil)
+	mc.mocks.stores.MirrorMock().EXPECT().FindByRepoID(ctx, repo.ID).Return(mirror, nil)
+
+	got, err := mc.CreateMirror(ctx, types.CreateMirrorReq{
+		SourceUrl:   "https://github.com/new/repo",
+		CurrentUser: "user",
+		Namespace:   "ns",
+		Name:        "n",
+		RepoType:    types.ModelRepo,
+	})
+
+	require.ErrorIs(t, err, errorx.ErrMirrorSourceConflict)
+	require.Equal(t, repo.ID, got.RepositoryID)
+}
+
 // TestMirrorComponent_CreateMirrorRepoRejectsEmptyCurrentUser verifies mirror creation requires an explicit current user.
 func TestMirrorComponent_CreateMirrorRepoRejectsEmptyCurrentUser(t *testing.T) {
 	ctx := context.TODO()
@@ -541,8 +638,8 @@ func TestMirrorComponent_CreateMirrorRepoRejectsEmptyCurrentUser(t *testing.T) {
 	require.Nil(t, got)
 }
 
-// TestMirrorComponent_CreateMirrorRepoNormalizesForkTarget verifies local mirror target identifiers are trimmed and lowercased.
-func TestMirrorComponent_CreateMirrorRepoNormalizesForkTarget(t *testing.T) {
+// TestMirrorComponent_CreateMirrorRepoPreservesForkTargetCase verifies local mirror target identifiers are trimmed without changing case.
+func TestMirrorComponent_CreateMirrorRepoPreservesForkTargetCase(t *testing.T) {
 	ctx := context.TODO()
 	mc := initializeTestMirrorComponent(ctx, t)
 	fakeStore := &fakeMirrorRepoStore{}
@@ -554,14 +651,14 @@ func TestMirrorComponent_CreateMirrorRepoNormalizesForkTarget(t *testing.T) {
 		RepoType:          types.ModelRepo,
 		CurrentUser:       "admin",
 		SourceGitCloneUrl: "https://github.com/upstream/repo.git",
-		ForkNamespace:     "  Alice-Team ",
+		ForkNamespace:     "  ALICE-TEAM ",
 		ForkName:          " Qwen-Model  ",
 	}
 
-	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "admin", "alice-team", membership.RoleWrite).Return(true, nil)
-	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, req.RepoType, "alice-team", "qwen-model").Return(nil, sql.ErrNoRows)
-	mc.mocks.stores.NamespaceMock().EXPECT().FindByPath(ctx, "alice-team").Return(database.Namespace{
-		Path: "alice-team",
+	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "admin", "ALICE-TEAM", membership.RoleWrite).Return(true, nil)
+	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, req.RepoType, "ALICE-TEAM", "Qwen-Model").Return(nil, sql.ErrNoRows)
+	mc.mocks.stores.NamespaceMock().EXPECT().FindByPath(ctx, "ALICE-TEAM").Return(database.Namespace{
+		Path: "Alice-Team",
 	}, nil)
 	mc.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "admin").Return(database.User{
 		ID:       1,
@@ -574,10 +671,10 @@ func TestMirrorComponent_CreateMirrorRepoNormalizesForkTarget(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Len(t, fakeStore.inputs, 1)
-	require.Equal(t, "alice-team/qwen-model", fakeStore.inputs[0].Repository.Path)
-	require.Equal(t, "qwen-model", fakeStore.inputs[0].Repository.Name)
-	require.Equal(t, "models_alice-team/qwen-model", fakeStore.inputs[0].Repository.GitPath)
-	require.Equal(t, "github_model_alice-team_qwen-model", fakeStore.inputs[0].Mirror.LocalRepoPath)
+	require.Equal(t, "Alice-Team/Qwen-Model", fakeStore.inputs[0].Repository.Path)
+	require.Equal(t, "Qwen-Model", fakeStore.inputs[0].Repository.Name)
+	require.Equal(t, "models_Alice-Team/Qwen-Model", fakeStore.inputs[0].Repository.GitPath)
+	require.Equal(t, "github_model_Alice-Team_Qwen-Model", fakeStore.inputs[0].Mirror.LocalRepoPath)
 }
 
 // TestMirrorComponent_CreateMirrorRepoRejectsCaseVariantExistingTarget verifies repository identity remains case-insensitive.
@@ -922,15 +1019,15 @@ func TestMirrorComponent_CreateMirrorRepoAddsSourceToExistingTargetWithoutMirror
 		RepoType:          types.DatasetRepo,
 		CurrentUser:       "admin",
 		SourceGitCloneUrl: "https://github.com/upstream/repo.git",
-		ForkNamespace:     "alice",
-		ForkName:          "forked",
+		ForkNamespace:     "ALICE",
+		ForkName:          "FORKED",
 		CreateTargetRepo:  &createTargetRepo,
 	}
-	repo := &database.Repository{ID: 11, Path: "alice/forked", RepositoryType: types.DatasetRepo}
+	repo := &database.Repository{ID: 11, Path: "alice/Forked", Name: "Forked", RepositoryType: types.DatasetRepo}
 
-	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, req.RepoType, "alice", "forked").Return(repo, nil)
+	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, req.RepoType, "ALICE", "FORKED").Return(repo, nil)
 	mc.mocks.stores.MirrorMock().EXPECT().FindByRepoID(ctx, repo.ID).Return(nil, sql.ErrNoRows)
-	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "admin", "alice", membership.RoleWrite).Return(true, nil)
+	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "admin", "ALICE", membership.RoleWrite).Return(true, nil)
 
 	got, err := mc.CreateMirrorRepo(ctx, req)
 	require.NoError(t, err)
@@ -939,7 +1036,7 @@ func TestMirrorComponent_CreateMirrorRepoAddsSourceToExistingTargetWithoutMirror
 	require.Equal(t, repo, fakeStore.inputs[0].Repository)
 	require.Equal(t, "upstream/repo", fakeStore.inputs[0].Repository.GithubPath)
 	require.Empty(t, fakeStore.inputs[0].Mirror.Username)
-	require.Equal(t, "github_dataset_alice_forked", fakeStore.inputs[0].Mirror.LocalRepoPath)
+	require.Equal(t, "github_dataset_alice_Forked", fakeStore.inputs[0].Mirror.LocalRepoPath)
 }
 
 // TestMirrorComponent_CreateMirrorRepoRejectsExistingTargetWhenRequested verifies callers can keep import-style no-overwrite semantics.
@@ -1124,4 +1221,44 @@ func TestMirrorComponent_CreateMirrorRepoCreatesAllMirrorRepoTypes(t *testing.T)
 			}
 		})
 	}
+}
+
+// TestMirrorComponent_CreateMirrorRepoSkipSourcePath verifies that when SkipSourcePath is true,
+// the source path fields (HFPath/MSPath/GithubPath) are not set on the repository.
+func TestMirrorComponent_CreateMirrorRepoSkipSourcePath(t *testing.T) {
+	ctx := context.TODO()
+	mc := initializeTestMirrorComponent(ctx, t)
+	fakeStore := &fakeMirrorRepoStore{}
+	mc.mirrorRepoStore = fakeStore
+
+	req := types.CreateMirrorRepoReq{
+		SourceNamespace:   "upstream",
+		SourceName:        "repo",
+		RepoType:          types.CodeRepo,
+		CurrentUser:       "admin",
+		SourceGitCloneUrl: "https://github.com/upstream/repo.git",
+		ForkNamespace:     "alice",
+		ForkName:          "forked",
+		SkipSourcePath:    true,
+	}
+
+	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "admin", "alice", membership.RoleWrite).Return(true, nil)
+	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, req.RepoType, "alice", "forked").Return(nil, sql.ErrNoRows)
+	mc.mocks.stores.NamespaceMock().EXPECT().FindByPath(ctx, "alice").Return(database.Namespace{
+		Path: "alice",
+	}, nil)
+	mc.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "admin").Return(database.User{
+		ID:       1,
+		Username: "admin",
+		Email:    "admin@example.com",
+		RoleMask: "admin",
+	}, nil)
+
+	got, err := mc.CreateMirrorRepo(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, fakeStore.inputs, 1)
+	require.Empty(t, fakeStore.inputs[0].Repository.GithubPath)
+	require.Empty(t, fakeStore.inputs[0].Repository.HFPath)
+	require.Empty(t, fakeStore.inputs[0].Repository.MSPath)
 }

--- a/component/skill.go
+++ b/component/skill.go
@@ -395,14 +395,15 @@ func (c *skillComponentImpl) createMirrorIfNeeded(ctx context.Context, req *type
 	}
 
 	mirrorReq := types.CreateMirrorReq{
-		Namespace:   req.Namespace,
-		Name:        req.Name,
-		SourceUrl:   req.GitURL,
-		Username:    req.GitUsername,
-		AccessToken: req.GitPassword,
-		CurrentUser: req.Username,
-		RepoType:    types.SkillRepo,
-		SyncLfs:     true,
+		Namespace:      req.Namespace,
+		Name:           req.Name,
+		SourceUrl:      req.GitURL,
+		Username:       req.GitUsername,
+		AccessToken:    req.GitPassword,
+		CurrentUser:    req.Username,
+		RepoType:       types.SkillRepo,
+		SyncLfs:        true,
+		SkipSourcePath: true, // user-created skill repos should not set source paths
 	}
 
 	_, err := c.mirrorComponent.CreateMirror(ctx, mirrorReq)


### PR DESCRIPTION
Summary:
- Main scope: 变更原因：.
- Additional context: 1. readme 内容为空时仍然调用 LLM 生成 description.

Manual handling required:
- Dev-agent failed to cherry-pick this GitLab MR: Git克隆命令执行失败: Command '['git', '--git-dir', '/root/gitlab-to-github/dev-agent/agent/.cache/mirrors/csghub-server.git', 'fetch', '--prune', 'origin']' returned non-zero exit status 128.
错误输出: error: RPC failed; curl 56 GnuTLS recv error (-54): Error in the pull function.
error: 52 bytes of body are still expected
fatal: expected flush after ref listing

- Source GitLab MR: !2795
- Source ref: 9ad77ce1b11f06086abe6755a1119b8cd8c31fcc
- Files in sync scope: 6
- The patch could not be applied cleanly, so this branch uses the GitLab MR final file snapshot for the affected files. Please reconcile any overwritten GitHub-side edits before merging.