### PR TITLE
Enhance: Add token usage info in the evaluation summary

### DIFF
--- a/common/types/claw_eval_summary.go
+++ b/common/types/claw_eval_summary.go
@@ -16,6 +16,8 @@ const (
 // ClawEvalSummary mirrors claw-eval batch_summary.json.
 // PassHatK and PassAtK serialize as pass_hat_{trials_per_task} and pass_at_{trials_per_task}
 // to stay compatible with the upstream evaluator output format.
+// InputTokens/OutputTokens/TotalTokens serialize as input_tokens/output_tokens/total_tokens
+// in the API response.
 type ClawEvalSummary struct {
 	Tasks         int     `json:"tasks"`
 	TrialsPerTask int     `json:"trials_per_task"`
@@ -23,6 +25,9 @@ type ClawEvalSummary struct {
 	AvgScore      float64 `json:"avg_score"`
 	PassHatK      int     `json:"-"`
 	PassAtK       int     `json:"-"`
+	InputTokens   int     `json:"input_tokens"`
+	OutputTokens  int     `json:"output_tokens"`
+	TotalTokens   int     `json:"total_tokens"`
 }
 
 func (s ClawEvalSummary) MarshalJSON() ([]byte, error) {
@@ -31,6 +36,9 @@ func (s ClawEvalSummary) MarshalJSON() ([]byte, error) {
 		"trials_per_task": s.TrialsPerTask,
 		"errored":         s.Errored,
 		"avg_score":       s.AvgScore,
+		"input_tokens":    s.InputTokens,
+		"output_tokens":   s.OutputTokens,
+		"total_tokens":    s.TotalTokens,
 	}
 	k := s.TrialsPerTask
 	if k <= 0 {
@@ -71,6 +79,16 @@ func ParseClawEvalSummary(raw []byte) (*ClawEvalSummary, error) {
 	if err := decodeIntField(payload, fmt.Sprintf("pass_at_%d", k), &summary.PassAtK); err != nil {
 		return nil, err
 	}
+	if err := decodeIntField(payload, "total_input_tokens", &summary.InputTokens); err != nil {
+		return nil, err
+	}
+	if err := decodeIntField(payload, "total_output_tokens", &summary.OutputTokens); err != nil {
+		return nil, err
+	}
+	if err := decodeIntField(payload, "total_tokens", &summary.TotalTokens); err != nil {
+		return nil, err
+	}
+
 	return summary, nil
 }
 

--- a/common/types/claw_eval_summary_test.go
+++ b/common/types/claw_eval_summary_test.go
@@ -14,7 +14,10 @@ func TestParseClawEvalSummary(t *testing.T) {
 		"errored": 3,
 		"avg_score": 0.72,
 		"pass_hat_3": 40,
-		"pass_at_3": 55
+		"pass_at_3": 55,
+		"total_input_tokens": 12000,
+		"total_output_tokens": 3400,
+		"total_tokens": 15400
 	}`)
 
 	summary, err := ParseClawEvalSummary(raw)
@@ -25,8 +28,21 @@ func TestParseClawEvalSummary(t *testing.T) {
 	require.InDelta(t, 0.72, summary.AvgScore, 0.0001)
 	require.Equal(t, 40, summary.PassHatK)
 	require.Equal(t, 55, summary.PassAtK)
+	require.Equal(t, 12000, summary.InputTokens)
+	require.Equal(t, 3400, summary.OutputTokens)
+	require.Equal(t, 15400, summary.TotalTokens)
 
 	encoded, err := json.Marshal(summary)
 	require.NoError(t, err)
-	require.JSONEq(t, string(raw), string(encoded))
+	require.JSONEq(t, `{
+		"tasks": 129,
+		"trials_per_task": 3,
+		"errored": 3,
+		"avg_score": 0.72,
+		"pass_hat_3": 40,
+		"pass_at_3": 55,
+		"input_tokens": 12000,
+		"output_tokens": 3400,
+		"total_tokens": 15400
+	}`, string(encoded))
 }

--- a/component/evaluation_claw_test.go
+++ b/component/evaluation_claw_test.go
@@ -393,7 +393,10 @@ func TestEvaluationComponent_GetClawEvaluationSummary(t *testing.T) {
 			"errored": 3,
 			"avg_score": 0.72,
 			"pass_hat_3": 40,
-			"pass_at_3": 55
+			"pass_at_3": 55,
+			"total_input_tokens": 12000,
+			"total_output_tokens": 3400,
+			"total_tokens": 15400
 		}`))
 	}))
 	defer summaryServer.Close()
@@ -421,6 +424,9 @@ func TestEvaluationComponent_GetClawEvaluationSummary(t *testing.T) {
 	require.InDelta(t, 0.72, res.Summary.AvgScore, 0.0001)
 	require.Equal(t, 40, res.Summary.PassHatK)
 	require.Equal(t, 55, res.Summary.PassAtK)
+	require.Equal(t, 12000, res.Summary.InputTokens)
+	require.Equal(t, 3400, res.Summary.OutputTokens)
+	require.Equal(t, 15400, res.Summary.TotalTokens)
 }
 
 func TestEvaluationComponent_DeleteClawEvaluation(t *testing.T) {


### PR DESCRIPTION
Summary:
- Add token usage info in the evaluation summary API. Update code to parse token usage info from the output `batch_summary.json` of claw-eval.