### PR TITLE
[Manual Sync Required] Support Responses API for hosted CSGHub models and chat adapter tools

### DIFF
--- a/.specs/aigateway-responses-api/csghub-hosted-responses-api.md
+++ b/.specs/aigateway-responses-api/csghub-hosted-responses-api.md
@@ -1,0 +1,53 @@
+# Support Responses API for CSGHub-Hosted Models
+
+## Summary
+
+Extend Responses routing so CSGHub-hosted deployments are not judged only by stored endpoint suffix. Hosted vLLM models using the repo's current `v0.24.0` runtime should route natively to `/v1/responses`; older or uncertain hosted runtimes should fall back to the existing chat adapter when they are OpenAI chat-compatible.
+
+## Key Changes
+
+- Extend `responses.RoutingTarget` to include hosted-model context: whether the model is CSGHub-hosted, runtime framework, image ID, and optional metadata/tags.
+- Extend `responses.RoutingDecision` to carry the resolved backend URL for both native and chat-adapter modes.
+- Keep existing external behavior unchanged:
+  - upstream URL ending `/v1/responses` routes native.
+  - upstream URL ending `/v1/chat/completions` routes chat adapter.
+  - unsupported suffix remains disabled.
+- Add hosted-model routing:
+  - hosted vLLM image/runtime `>= 0.24.0` routes native with backend URL `base + /v1/responses`.
+  - older hosted vLLM variants route chat adapter with backend URL `base + /v1/chat/completions`.
+  - hosted SGLang image/runtime `>= 0.5.0` routes native with backend URL `base + /v1/responses`.
+  - hosted SGLang variants without a detectable SGLang semver, including NGC-style tags, route chat adapter.
+  - unknown hosted runtime remains disabled.
+- Wire `OpenAIHandlerImpl.Responses` to pass hosted-model fields into routing and use `RoutingDecision`'s backend URL when executing native or adapter mode.
+
+## Implementation Notes
+
+- Treat `len(model.SvcName) > 0` as the hosted-model signal.
+- Normalize base deploy target before appending `/v1/responses` or `/v1/chat/completions`, preserving scheme/host and avoiding duplicate slashes.
+- Version detection should parse known image/runtime strings conservatively:
+  - native only for clear `v0.24.0`, `0.24.0`, or higher vLLM versions.
+  - native only for clear `v0.5.0`, `0.5.0`, or higher SGLang versions.
+  - otherwise adapter if the runtime is vLLM- or SGLang-compatible.
+- Do not change `previous_response_id` semantics:
+  - native mode keeps current upstream affinity behavior.
+  - adapter mode still rejects adapter response IDs as before.
+
+## Test Plan
+
+- Add routing tests for:
+  - external `/v1/responses` remains native.
+  - external `/v1/chat/completions` remains chat adapter.
+  - CSGHub hosted vLLM `v0.24.0` routes native to `/v1/responses`.
+  - CSGHub hosted vLLM `v0.9.2`, `v0.8.5`, and CPU `0.4.12-fix1` route chat adapter.
+  - CSGHub hosted SGLang `v0.5.14` routes native to `/v1/responses`.
+  - CSGHub hosted SGLang without detectable SGLang semver routes chat adapter.
+  - unknown hosted runtime remains disabled.
+- Add handler-level tests proving hosted model routing uses the generated backend URL and does not require the original deploy endpoint to end with an OpenAI API suffix.
+- Run focused tests:
+  - `go test ./aigateway/handler/responses ./aigateway/handler`
+
+## Assumptions
+
+- Current default hosted vLLM runtime is `v0.24.0`, so native Responses is acceptable for that runtime.
+- Current default hosted SGLang runtime is `v0.5.14`, so native Responses is acceptable for that runtime.
+- No database migration is needed; routing can derive behavior from existing model fields.

--- a/aigateway/handler/model_target.go
+++ b/aigateway/handler/model_target.go
@@ -16,13 +16,14 @@ import (
 )
 
 type resolvedModelTarget struct {
-	Model          *types.Model
-	Upstream       commonType.UpstreamConfig
-	TargetReq      commonType.EndpointReq
-	Target         string
-	Host           string
-	ModelName      string
-	AttemptTargets []commonType.UpstreamConfig
+	Model           *types.Model
+	Upstream        commonType.UpstreamConfig
+	TargetReq       commonType.EndpointReq
+	Target          string
+	TokenizerTarget string
+	Host            string
+	ModelName       string
+	AttemptTargets  []commonType.UpstreamConfig
 }
 
 const maxSessionKeyLength = 256
@@ -203,6 +204,7 @@ func (h *OpenAIHandlerImpl) resolveModelTargetWithOptions(ctx context.Context, u
 			},
 		)
 	}
+	resolved.TokenizerTarget = resolved.Target
 
 	return resolved, nil
 }

--- a/aigateway/handler/model_target_test.go
+++ b/aigateway/handler/model_target_test.go
@@ -75,7 +75,7 @@ func TestResolveModelTargetWithOptionsRequiredUpstreamID(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, responsespkg.ResponsesModeChatAdapter, decision.Mode)
-	require.Empty(t, decision.NativeURL)
+	require.Equal(t, "https://native.example.com/v1/chat/completions", decision.BackendURL)
 }
 
 func TestResolveModelTargetWithOptionsRequiredUpstreamIDUnavailable(t *testing.T) {

--- a/aigateway/handler/openai_responses.go
+++ b/aigateway/handler/openai_responses.go
@@ -64,8 +64,11 @@ func (h *OpenAIHandlerImpl) Responses(c *gin.Context) {
 	}
 
 	decision, err := responsespkg.ResolveRouting(responsespkg.RoutingTarget{
-		ModelID: modelTarget.Model.ID,
-		Target:  modelTarget.Target,
+		ModelID:          modelTarget.Model.ID,
+		Target:           modelTarget.Target,
+		CSGHubHosted:     isCSGHubHostedModel(modelTarget.Model),
+		RuntimeFramework: modelTarget.Model.RuntimeFramework,
+		ImageID:          modelTarget.Model.ImageID,
 	})
 	if err != nil {
 		writeResponsesError(c, http.StatusBadRequest, "unsupported_feature", "invalid_request_error", err.Error())
@@ -111,12 +114,32 @@ func (h *OpenAIHandlerImpl) Responses(c *gin.Context) {
 
 	switch decision.Mode {
 	case responsespkg.ResponsesModeNative:
-		h.executeNativeResponses(c, req, modelTarget, decision, owner, nsUUID, apikey, publicModelID, publicPreviousResponseID, responsesModeration, responseCapture, generationRecorder)
+		h.executeNativeResponses(c, req, withResponsesBackendURL(modelTarget, decision.BackendURL), decision, owner, nsUUID, apikey, publicModelID, publicPreviousResponseID, responsesModeration, responseCapture, generationRecorder)
 	case responsespkg.ResponsesModeChatAdapter:
-		h.executeAdapterResponses(c, req, modelTarget, nsUUID, apikey, publicModelID, responsesModeration, responseCapture, generationRecorder)
+		h.executeAdapterResponses(c, req, withResponsesBackendURL(modelTarget, decision.BackendURL), nsUUID, apikey, publicModelID, responsesModeration, responseCapture, generationRecorder)
 	default:
 		writeResponsesError(c, http.StatusBadRequest, "unsupported_feature", "invalid_request_error", "unsupported responses execution mode")
 	}
+}
+
+func isCSGHubHostedModel(model *types.Model) bool {
+	return model != nil && model.SvcName != ""
+}
+
+func withResponsesBackendURL(modelTarget *resolvedModelTarget, backendURL string) *resolvedModelTarget {
+	backendURL = strings.TrimSpace(backendURL)
+	if modelTarget == nil || backendURL == "" {
+		return modelTarget
+	}
+	resolved := *modelTarget
+	resolved.Target = backendURL
+	resolved.Upstream.URL = backendURL
+	if modelTarget.Model != nil {
+		modelCopy := *modelTarget.Model
+		modelCopy.Endpoint = backendURL
+		resolved.Model = &modelCopy
+	}
+	return &resolved
 }
 
 func (h *OpenAIHandlerImpl) setupResponsesCapture(c *gin.Context, req *types.ResponsesRequest, modelTarget *resolvedModelTarget, decision responsespkg.RoutingDecision, nsUUID string) *responsespkg.LLMLogRecorder {

--- a/aigateway/handler/openai_responses_adapter.go
+++ b/aigateway/handler/openai_responses_adapter.go
@@ -37,6 +37,13 @@ func (h *OpenAIHandlerImpl) executeAdapterResponses(c *gin.Context, req *types.R
 		slog.WarnContext(c.Request.Context(), "invalid auth header", slog.String("model", modelTarget.ModelName), slog.Any("error", err))
 	}
 	writer := newResponsesAdapterResponseWriter(c.Writer, req.Stream, publicModelID, responsesCounter, moderation, newResponsesModerationSessionID(), logCapture)
+	toolNamespaces, err := responsesNamespaceByFunctionName(req.Tools)
+	if err != nil {
+		finishLLMTraceWithError(generationRecorder, err, types.TraceErrUpstreamError)
+		writeResponsesError(c, http.StatusBadRequest, adapterErrorCode(err), "invalid_request_error", err.Error())
+		return
+	}
+	setResponsesAdapterToolNamespaces(writer, toolNamespaces)
 	primaryWriter, proxyErr := h.executeChatProxyAttempt(c, writer, modelTarget, nsUUID, chatReq)
 	if proxyErr != nil {
 		finishLLMTraceWithError(generationRecorder, proxyErr, types.TraceErrUpstreamUnavailable)

--- a/aigateway/handler/openai_responses_native.go
+++ b/aigateway/handler/openai_responses_native.go
@@ -16,7 +16,8 @@ import (
 )
 
 func (h *OpenAIHandlerImpl) executeNativeResponses(c *gin.Context, req *types.ResponsesRequest, modelTarget *resolvedModelTarget, decision responsespkg.RoutingDecision, owner, nsUUID, apikey, publicModelID, publicPreviousResponseID string, moderation component.Moderation, logCapture *responsespkg.LLMLogRecorder, generationRecorder llmtrace.GenerationRecorder) {
-	if err := h.openaiComponent.CheckUsageLimit(c.Request.Context(), nsUUID, modelTarget.Model, decision.NativeURL); err != nil {
+	backendURL := decision.BackendURL
+	if err := h.openaiComponent.CheckUsageLimit(c.Request.Context(), nsUUID, modelTarget.Model, backendURL); err != nil {
 		finishLLMTraceWithError(generationRecorder, err, types.TraceErrInsufficientBalance)
 		h.handleUsageLimitExceeded(c, req.Stream, nsUUID, publicModelID, err)
 		return
@@ -40,7 +41,7 @@ func (h *OpenAIHandlerImpl) executeNativeResponses(c *gin.Context, req *types.Re
 	if err := applyModelAuthHeaders(c.Request.Header, modelTarget.Model); err != nil {
 		slog.WarnContext(c.Request.Context(), "invalid auth header", slog.String("model", modelTarget.ModelName), slog.Any("error", err))
 	}
-	rp, err := proxy.NewReverseProxy(decision.NativeURL, proxy.WithoutAcceptEncoding())
+	rp, err := proxy.NewReverseProxy(backendURL, proxy.WithoutAcceptEncoding())
 	if err != nil {
 		finishLLMTraceWithError(generationRecorder, err, types.TraceErrUpstreamUnavailable)
 		h.handleProxyError(c, req.Stream, nsUUID, publicModelID, err)
@@ -66,7 +67,7 @@ func (h *OpenAIHandlerImpl) executeNativeResponses(c *gin.Context, req *types.Re
 		slog.String("responses_route_provider", modelTarget.Model.Provider),
 		slog.String("responses_route_model", modelTarget.ModelName),
 	)
-	proxyPath := resolveProxyPathFromModelEndpoint(decision.NativeURL, modelTarget.ModelName)
+	proxyPath := resolveProxyPathFromModelEndpoint(backendURL, modelTarget.ModelName)
 	writer := newResponsesNativeResponseWriter(c.Writer, req.Stream, transformer, moderation, newResponsesModerationSessionID())
 	rp.ServeHTTP(writer, c.Request, proxyPath, modelTarget.Host)
 	if err := writer.Finalize(); err != nil {

--- a/aigateway/handler/openai_responses_test.go
+++ b/aigateway/handler/openai_responses_test.go
@@ -16,6 +16,60 @@ import (
 	commontypes "opencsg.com/csghub-server/common/types"
 )
 
+func TestResponsesCSGHubHostedVLLMUsesNativeResponsesBackendURL(t *testing.T) {
+	tester, c, w := setupTest(t)
+	tester.mocks.openAIComp.ExpectedCalls = nil
+	tester.handler.config.AIGateway.ResponsesIDSecret = "responses-secret"
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses",
+		strings.NewReader(`{"model":"hosted-model","input":"hi"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	var upstreamPath string
+	var upstreamModel string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamPath = r.URL.Path
+		var body struct {
+			Model string `json:"model"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		upstreamModel = body.Model
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_upstream","object":"response","status":"completed"}`))
+	}))
+	defer upstream.Close()
+
+	model := &types.Model{
+		BaseModel: types.BaseModel{
+			ID:       "hosted-model",
+			Metadata: map[string]any{},
+		},
+		InternalModelInfo: types.InternalModelInfo{
+			CSGHubModelID:    "namespace/model",
+			ClusterID:        "cluster-1",
+			SvcName:          "svc-model",
+			RuntimeFramework: "vllm",
+			ImageID:          "opencsghq/vllm:v0.24.0",
+		},
+		Endpoint: upstream.URL,
+	}
+	tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "hosted-model").Return(model, nil).Once()
+	tester.mocks.mockClsComp.EXPECT().GetClusterByID(mock.Anything, "cluster-1").Return(&database.ClusterInfo{
+		ClusterID: "cluster-1",
+	}, nil).Once()
+	tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+	tester.mocks.openAIComp.EXPECT().CheckUsageLimit(mock.Anything, "testuuid", mock.Anything, upstream.URL+"/v1/responses").Return(nil).Once()
+	tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	tester.handler.Responses(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "/v1/responses", upstreamPath)
+	require.Equal(t, "namespace/model", upstreamModel)
+	require.Contains(t, w.Body.String(), `"object":"response"`)
+	require.NotContains(t, w.Body.String(), `"id":"resp_upstream"`)
+}
+
 func TestResolvePreviousResponseRoute(t *testing.T) {
 	tester, c, _ := setupTest(t)
 	tester.handler.config.AIGateway.ResponsesIDSecret = "responses-secret"

--- a/aigateway/handler/openai_responses_usage.go
+++ b/aigateway/handler/openai_responses_usage.go
@@ -18,8 +18,12 @@ func (h *OpenAIHandlerImpl) newResponsesTokenCounter(modelTarget *resolvedModelT
 	if modelTarget == nil || modelTarget.Model == nil {
 		return token.NewResponsesTokenCounter(nil)
 	}
+	tokenizerTarget := modelTarget.TokenizerTarget
+	if tokenizerTarget == "" {
+		tokenizerTarget = modelTarget.Target
+	}
 	tokenizer := token.NewTokenizerImpl(
-		modelTarget.Target,
+		tokenizerTarget,
 		modelTarget.Host,
 		modelTarget.ModelName,
 		modelTarget.Model.ImageID,
@@ -42,15 +46,29 @@ func (h *OpenAIHandlerImpl) recordResponsesUsageWithTrace(c *gin.Context, counte
 				}
 			}
 		}()
-		usageCtx, cancel := context.WithTimeout(baseCtx, 3*time.Second)
-		defer cancel()
-
 		var tokenUsage *token.Usage
 		if counter != nil {
 			var err error
+			usageCtx, cancel := context.WithTimeout(baseCtx, 2*time.Second)
 			tokenUsage, err = counter.Usage(usageCtx)
+			cancel()
 			if err != nil {
-				slog.ErrorContext(usageCtx, "failed to get responses token usage", slog.Any("error", err))
+				slog.ErrorContext(baseCtx, "failed to get responses token usage",
+					slog.String("step", "token_usage"),
+					slog.String("model", modelTarget.ModelName),
+					slog.String("provider", modelTarget.Model.Provider),
+					slog.Any("error", err))
+			}
+			if tokenUsage != nil && tokenUsage.Source != "" {
+				slog.WarnContext(baseCtx, "responses usage fallback",
+					slog.String("step", "token_usage"),
+					slog.String("usage_source", tokenUsage.Source),
+					slog.String("usage_reason", tokenUsage.SourceReason),
+					slog.String("model", modelTarget.ModelName),
+					slog.String("provider", modelTarget.Model.Provider),
+					slog.Int64("prompt_tokens", tokenUsage.PromptTokens),
+					slog.Int64("completion_tokens", tokenUsage.CompletionTokens),
+					slog.Int64("total_tokens", tokenUsage.TotalTokens))
 			}
 		}
 		if traceInput.Recorder != nil {
@@ -64,28 +82,52 @@ func (h *OpenAIHandlerImpl) recordResponsesUsageWithTrace(c *gin.Context, counte
 			traceInput.Recorder.End()
 		}
 		if counter != nil {
-			if err := h.openaiComponent.CommitUsageLimit(usageCtx, nsUUID, modelTarget.Model, counter); err != nil {
-				slog.ErrorContext(usageCtx, "failed to commit responses usage limit", slog.Any("error", err))
+			commitCtx, cancel := context.WithTimeout(baseCtx, time.Second)
+			if err := h.openaiComponent.CommitUsageLimit(commitCtx, nsUUID, modelTarget.Model, counter); err != nil {
+				slog.ErrorContext(baseCtx, "failed to commit responses usage limit",
+					slog.String("step", "commit_usage_limit"),
+					slog.String("model", modelTarget.ModelName),
+					slog.String("provider", modelTarget.Model.Provider),
+					slog.Any("error", err))
 			}
+			cancel()
 		}
 		if tokenUsage != nil {
-			if err := h.openaiComponent.RecordUsageFromTokenUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, tokenUsage, apikey); err != nil {
-				slog.ErrorContext(usageCtx, "failed to record responses usage", slog.Any("error", err))
+			recordCtx, cancel := context.WithTimeout(baseCtx, time.Second)
+			if err := h.openaiComponent.RecordUsageFromTokenUsage(recordCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, tokenUsage, apikey); err != nil {
+				slog.ErrorContext(baseCtx, "failed to record responses usage",
+					slog.String("step", "record_usage"),
+					slog.String("model", modelTarget.ModelName),
+					slog.String("provider", modelTarget.Model.Provider),
+					slog.Any("error", err))
 			}
+			cancel()
 		}
 		if h.config != nil && h.config.AIGateway.EnableLLMLog && recorder != nil && h.llmLogPublisher != nil {
 			record, recordErr := recorder.Record(tokenUsage)
 			if recordErr != nil {
-				slog.ErrorContext(usageCtx, "failed to build responses llmlog training record", slog.Any("error", recordErr))
+				slog.ErrorContext(baseCtx, "failed to build responses llmlog training record",
+					slog.String("step", "build_llmlog_record"),
+					slog.String("model", modelTarget.ModelName),
+					slog.String("provider", modelTarget.Model.Provider),
+					slog.Any("error", recordErr))
 				return
 			}
 			payload, marshalErr := json.Marshal(record)
 			if marshalErr != nil {
-				slog.ErrorContext(usageCtx, "failed to marshal responses llmlog training record", slog.Any("error", marshalErr))
+				slog.ErrorContext(baseCtx, "failed to marshal responses llmlog training record",
+					slog.String("step", "marshal_llmlog_record"),
+					slog.String("model", modelTarget.ModelName),
+					slog.String("provider", modelTarget.Model.Provider),
+					slog.Any("error", marshalErr))
 				return
 			}
 			if publishErr := h.llmLogPublisher.PublishTrainingLog(payload); publishErr != nil {
-				slog.ErrorContext(usageCtx, "failed to publish responses llmlog training record", slog.Any("error", publishErr))
+				slog.ErrorContext(baseCtx, "failed to publish responses llmlog training record",
+					slog.String("step", "publish_llmlog_record"),
+					slog.String("model", modelTarget.ModelName),
+					slog.String("provider", modelTarget.Model.Provider),
+					slog.Any("error", publishErr))
 			}
 		}
 	}()

--- a/aigateway/handler/openai_responses_usage_test.go
+++ b/aigateway/handler/openai_responses_usage_test.go
@@ -55,6 +55,42 @@ func TestNewResponsesTokenCounterBuildsTokenizer(t *testing.T) {
 	require.NotNil(t, usage)
 }
 
+func TestNewResponsesTokenCounterUsesTokenizerTarget(t *testing.T) {
+	tester, _, _ := setupTest(t)
+	var tokenizePaths []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenizePaths = append(tokenizePaths, r.URL.Path)
+		require.Equal(t, "/tokenize", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":3}`))
+	}))
+	defer upstream.Close()
+
+	model := &types.Model{
+		BaseModel: types.BaseModel{ID: "m"},
+		InternalModelInfo: types.InternalModelInfo{
+			ImageID: "vllm-local:latest",
+		},
+	}
+	modelTarget := &resolvedModelTarget{
+		Model:           model,
+		Target:          upstream.URL + "/v1/responses",
+		TokenizerTarget: upstream.URL,
+		ModelName:       "upstream-model",
+	}
+
+	counter := tester.handler.newResponsesTokenCounter(modelTarget)
+	counter.Request(&types.ResponsesRequest{Model: "m", Input: json.RawMessage(`"hi"`)})
+	counter.Response(&types.ResponsesResponse{OutputText: "ok"})
+
+	usage, err := counter.Usage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(3), usage.PromptTokens)
+	require.Equal(t, int64(3), usage.CompletionTokens)
+	require.Equal(t, int64(6), usage.TotalTokens)
+	require.Equal(t, []string{"/tokenize", "/tokenize"}, tokenizePaths)
+}
+
 func TestRecordResponsesUsageHappyPathCallsComponent(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		tester, c, _ := setupTest(t)

--- a/aigateway/handler/responses/responses_adapter_stream_events.go
+++ b/aigateway/handler/responses/responses_adapter_stream_events.go
@@ -116,6 +116,7 @@ type StreamFunctionCallItem struct {
 	Type      string `json:"type"`
 	CallID    string `json:"call_id"`
 	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
 	Arguments string `json:"arguments"`
 	Status    string `json:"status"`
 }

--- a/aigateway/handler/responses/responses_id_mapper.go
+++ b/aigateway/handler/responses/responses_id_mapper.go
@@ -27,7 +27,8 @@ var (
 )
 
 type IDClaims struct {
-	NamespaceUUID      string `json:"namespace_uuid"`
+	NamespaceUUID string `json:"namespace_uuid"`
+	// UpstreamID is zero for CSGHub-hosted models that do not have an upstream row.
 	UpstreamID         int64  `json:"upstream_id"`
 	UpstreamResponseID string `json:"upstream_response_id"`
 }
@@ -69,9 +70,6 @@ func (m *IDMapper) Wrap(claims IDClaims) (string, error) {
 	}
 	if claims.NamespaceUUID == "" {
 		return "", fmt.Errorf("namespace uuid is empty")
-	}
-	if claims.UpstreamID == 0 {
-		return "", fmt.Errorf("upstream id is empty")
 	}
 	payload, err := json.Marshal(claims)
 	if err != nil {

--- a/aigateway/handler/responses/responses_id_mapper_test.go
+++ b/aigateway/handler/responses/responses_id_mapper_test.go
@@ -36,13 +36,16 @@ func TestResponsesIDMapperRejectsOtherOwner(t *testing.T) {
 	require.ErrorIs(t, err, ErrResponseIDOwner)
 }
 
-func TestResponsesIDMapperRequiresUpstreamID(t *testing.T) {
+func TestResponsesIDMapperAllowsEmptyUpstreamID(t *testing.T) {
 	mapper, err := NewIDMapper("test-secret")
 	require.NoError(t, err)
 
-	_, err = mapper.Wrap(IDClaims{UpstreamResponseID: "resp_1", NamespaceUUID: "namespace-1"})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "upstream id is empty")
+	id, err := mapper.Wrap(IDClaims{UpstreamResponseID: "resp_1", NamespaceUUID: "namespace-1"})
+	require.NoError(t, err)
+	claims, err := mapper.Unwrap(id, "namespace-1")
+	require.NoError(t, err)
+	require.Equal(t, "resp_1", claims.UpstreamResponseID)
+	require.Zero(t, claims.UpstreamID)
 }
 
 func TestResponsesIDMapperFromConfigUsesResponsesSecret(t *testing.T) {

--- a/aigateway/handler/responses/responses_llmlog.go
+++ b/aigateway/handler/responses/responses_llmlog.go
@@ -254,6 +254,15 @@ func (r *LLMLogRecorder) Record(usage *token.Usage) (*commontypes.LLMLogRecord, 
 		}
 		metadata["response_id"] = r.responseID
 	}
+	if usage != nil && usage.Source != "" {
+		if metadata == nil {
+			metadata = map[string]any{}
+		}
+		metadata["usage_source"] = usage.Source
+		if usage.SourceReason != "" {
+			metadata["usage_reason"] = usage.SourceReason
+		}
+	}
 	return &commontypes.LLMLogRecord{
 		RequestID:  r.requestID,
 		EventTime:  time.Now().Format(time.RFC3339Nano),

--- a/aigateway/handler/responses/responses_llmlog_test.go
+++ b/aigateway/handler/responses/responses_llmlog_test.go
@@ -63,6 +63,26 @@ func TestResponsesLLMLogRecorderRecordNormalizesInputAndOutput(t *testing.T) {
 	require.Empty(t, traceInfo.FinishReasons)
 }
 
+func TestResponsesLLMLogRecorderRecordIncludesUsageSourceMetadata(t *testing.T) {
+	recorder, err := NewLLMLogRecorder("req-1", "backend-model", "user-1", &types.ResponsesRequest{
+		Model: "public-model",
+		Input: json.RawMessage(`"hello"`),
+	}, nil)
+	require.NoError(t, err)
+
+	record, err := recorder.Record(&token.Usage{
+		PromptTokens:     1,
+		CompletionTokens: 2,
+		TotalTokens:      3,
+		Source:           "approx_chars_div_4",
+		SourceReason:     "unsupported_tokenizer",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "approx_chars_div_4", record.Metadata["usage_source"])
+	require.Equal(t, "unsupported_tokenizer", record.Metadata["usage_reason"])
+}
+
 func TestResponsesLLMLogRecorderCapturesStreamPayloads(t *testing.T) {
 	recorder, err := NewLLMLogRecorder("req-1", "backend-model", "user-1", &types.ResponsesRequest{
 		Model: "public-model",

--- a/aigateway/handler/responses/responses_routing.go
+++ b/aigateway/handler/responses/responses_routing.go
@@ -3,7 +3,11 @@ package responses
 import (
 	"fmt"
 	"net/url"
+	"regexp"
+	"strconv"
 	"strings"
+
+	commonutils "opencsg.com/csghub-server/common/utils/common"
 )
 
 type ResponsesExecutionMode string
@@ -15,14 +19,17 @@ const (
 )
 
 type RoutingDecision struct {
-	Mode      ResponsesExecutionMode
-	NativeURL string
-	Reason    string
+	Mode       ResponsesExecutionMode
+	BackendURL string
+	Reason     string
 }
 
 type RoutingTarget struct {
-	ModelID string
-	Target  string
+	ModelID          string
+	Target           string
+	CSGHubHosted     bool
+	RuntimeFramework string
+	ImageID          string
 }
 
 func ResolveRouting(modelTarget RoutingTarget) (RoutingDecision, error) {
@@ -30,20 +37,48 @@ func ResolveRouting(modelTarget RoutingTarget) (RoutingDecision, error) {
 		return RoutingDecision{}, fmt.Errorf("model target is nil")
 	}
 	target := strings.TrimSpace(modelTarget.Target)
-	parsed, err := url.Parse(target)
-	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return RoutingDecision{}, fmt.Errorf("cannot resolve responses mode from upstream url %q", target)
+	parsed, err := parseResponsesRoutingTarget(target, modelTarget.CSGHubHosted)
+	if err != nil {
+		return RoutingDecision{}, fmt.Errorf("cannot resolve responses mode from upstream url %q: %w", target, err)
 	}
 
 	path := strings.TrimRight(parsed.Path, "/")
 	switch {
 	case PathEndsWithSegments(path, "responses"):
-		return RoutingDecision{Mode: ResponsesModeNative, NativeURL: target, Reason: "upstream_url_responses"}, nil
+		return RoutingDecision{Mode: ResponsesModeNative, BackendURL: target, Reason: "upstream_url_responses"}, nil
 	case PathEndsWithSegments(path, "chat", "completions"):
-		return RoutingDecision{Mode: ResponsesModeChatAdapter, Reason: "upstream_url_chat_completions"}, nil
-	default:
-		return RoutingDecision{Mode: ResponsesModeDisabled, Reason: "unsupported_upstream_url"}, nil
+		return RoutingDecision{Mode: ResponsesModeChatAdapter, BackendURL: target, Reason: "upstream_url_chat_completions"}, nil
 	}
+
+	if modelTarget.CSGHubHosted {
+		return resolveHostedRouting(modelTarget, parsed)
+	}
+
+	return RoutingDecision{Mode: ResponsesModeDisabled, Reason: "unsupported_upstream_url"}, nil
+}
+
+func parseResponsesRoutingTarget(target string, allowSchemeLessHost bool) (*url.URL, error) {
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return nil, err
+	}
+	if parsed.Scheme != "" && parsed.Host != "" {
+		return parsed, nil
+	}
+	if !allowSchemeLessHost {
+		return nil, fmt.Errorf("upstream url must include scheme and host")
+	}
+	if !strings.Contains(target, "://") && strings.Contains(target, "/") && strings.Contains(target, ":") {
+		return nil, fmt.Errorf("target %q looks like host:port with path, please prepend \"http://\"", target)
+	}
+	if !strings.Contains(target, "://") && !strings.Contains(target, "/") {
+		parsed, err := url.Parse("http://" + target)
+		if err != nil || parsed.Host == "" {
+			return nil, fmt.Errorf("upstream url must include host")
+		}
+		return parsed, nil
+	}
+	return nil, fmt.Errorf("upstream url must include host")
 }
 
 func PathEndsWithSegments(path string, segments ...string) bool {
@@ -58,4 +93,136 @@ func PathEndsWithSegments(path string, segments ...string) bool {
 		}
 	}
 	return true
+}
+
+func resolveHostedRouting(modelTarget RoutingTarget, parsed *url.URL) (RoutingDecision, error) {
+	runtime := strings.ToLower(strings.TrimSpace(modelTarget.RuntimeFramework))
+	image := strings.ToLower(strings.TrimSpace(modelTarget.ImageID))
+	switch {
+	case isHostedVLLM(runtime, image) && isVLLMNativeResponsesCapable(runtime, image):
+		backendURL := appendEndpointPath(parsed, "v1", "responses")
+		return RoutingDecision{Mode: ResponsesModeNative, BackendURL: backendURL, Reason: "csghub_hosted_vllm_native"}, nil
+	case isHostedVLLM(runtime, image):
+		return RoutingDecision{Mode: ResponsesModeChatAdapter, BackendURL: appendEndpointPath(parsed, "v1", "chat", "completions"), Reason: "csghub_hosted_vllm_chat_adapter"}, nil
+	case isHostedSGLang(runtime, image) && isSGLangNativeResponsesCapable(runtime, image):
+		backendURL := appendEndpointPath(parsed, "v1", "responses")
+		return RoutingDecision{Mode: ResponsesModeNative, BackendURL: backendURL, Reason: "csghub_hosted_sglang_native"}, nil
+	case strings.Contains(runtime, "sglang") || strings.Contains(image, "sglang"):
+		return RoutingDecision{Mode: ResponsesModeChatAdapter, BackendURL: appendEndpointPath(parsed, "v1", "chat", "completions"), Reason: "csghub_hosted_sglang_chat_adapter"}, nil
+	default:
+		return RoutingDecision{Mode: ResponsesModeDisabled, Reason: "unsupported_csghub_hosted_runtime"}, nil
+	}
+}
+
+func isHostedVLLM(runtime, image string) bool {
+	return strings.Contains(runtime, "vllm") || strings.Contains(image, "vllm")
+}
+
+func isHostedSGLang(runtime, image string) bool {
+	return strings.Contains(runtime, "sglang") || strings.Contains(image, "sglang")
+}
+
+func isVLLMNativeResponsesCapable(runtime, image string) bool {
+	for _, value := range []string{runtime, image} {
+		if vllmVersionAtLeast(value, 0, 24, 0) {
+			return true
+		}
+	}
+	return false
+}
+
+var vllmVersionPattern = regexp.MustCompile(`(?i)(?:^|[/_:])vllm[:_]?(v?)([0-9]+)\.([0-9]+)(?:\.([0-9]+))?`)
+
+func vllmVersionAtLeast(value string, major, minor, patch int) bool {
+	matches := vllmVersionPattern.FindAllStringSubmatch(value, -1)
+	capable := false
+	for _, match := range matches {
+		if len(match) != 5 {
+			continue
+		}
+		explicitVersionPrefix := strings.EqualFold(match[1], "v")
+		gotMajor, errMajor := strconv.Atoi(match[2])
+		gotMinor, errMinor := strconv.Atoi(match[3])
+		gotPatch := 0
+		var errPatch error
+		if match[4] != "" {
+			gotPatch, errPatch = strconv.Atoi(match[4])
+		}
+		if errMajor != nil || errMinor != nil || errPatch != nil {
+			continue
+		}
+		// Hosted image tags such as opencsghq/vllm:2.5 are packaging versions,
+		// not upstream vLLM semver. Treat major > 0 as an upstream vLLM version
+		// only when the tag explicitly uses a v-prefixed semver token.
+		if gotMajor > major && !explicitVersionPrefix {
+			continue
+		}
+		if gotMajor != major {
+			capable = capable || gotMajor > major
+			continue
+		}
+		if gotMinor != minor {
+			capable = capable || gotMinor > minor
+			continue
+		}
+		if gotPatch != patch {
+			capable = capable || gotPatch >= patch
+			continue
+		}
+		capable = true
+	}
+	return capable
+}
+
+func isSGLangNativeResponsesCapable(runtime, image string) bool {
+	for _, value := range []string{runtime, image} {
+		if versionAtLeast(sglangVersionPattern, value, 0, 5, 0) {
+			return true
+		}
+	}
+	return false
+}
+
+var sglangVersionPattern = regexp.MustCompile(`(?i)(?:^|[/_:])sglang[:_]?v?([0-9]+)\.([0-9]+)(?:\.([0-9]+))?`)
+
+func versionAtLeast(pattern *regexp.Regexp, value string, major, minor, patch int) bool {
+	matches := pattern.FindAllStringSubmatch(value, -1)
+	capable := false
+	for _, match := range matches {
+		if len(match) != 4 {
+			continue
+		}
+		gotMajor, errMajor := strconv.Atoi(match[1])
+		gotMinor, errMinor := strconv.Atoi(match[2])
+		gotPatch := 0
+		var errPatch error
+		if match[3] != "" {
+			gotPatch, errPatch = strconv.Atoi(match[3])
+		}
+		if errMajor != nil || errMinor != nil || errPatch != nil {
+			continue
+		}
+		if gotMajor != major {
+			capable = capable || gotMajor > major
+			continue
+		}
+		if gotMinor != minor {
+			capable = capable || gotMinor > minor
+			continue
+		}
+		if gotPatch != patch {
+			capable = capable || gotPatch >= patch
+			continue
+		}
+		capable = true
+	}
+	return capable
+}
+
+func appendEndpointPath(base *url.URL, segments ...string) string {
+	u := *base
+	u.Path = commonutils.JoinURLPath(u.Path, segments...)
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
 }

--- a/aigateway/handler/responses/responses_routing_test.go
+++ b/aigateway/handler/responses/responses_routing_test.go
@@ -14,7 +14,7 @@ func TestResolveResponsesRoutingNativeResponsesURL(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, ResponsesModeNative, decision.Mode)
-	require.Equal(t, target, decision.NativeURL)
+	require.Equal(t, target, decision.BackendURL)
 	require.Equal(t, "upstream_url_responses", decision.Reason)
 }
 
@@ -25,7 +25,7 @@ func TestResolveResponsesRoutingChatCompletionsURL(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, ResponsesModeChatAdapter, decision.Mode)
-	require.Empty(t, decision.NativeURL)
+	require.Equal(t, "https://cloud.infini-ai.com/maas/v1/chat/completions", decision.BackendURL)
 	require.Equal(t, "upstream_url_chat_completions", decision.Reason)
 }
 
@@ -46,6 +46,175 @@ func TestResolveResponsesRoutingUnsupportedURL(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ResponsesModeDisabled, decision.Mode)
 	require.Equal(t, "unsupported_upstream_url", decision.Reason)
+}
+
+func TestResolveResponsesRoutingCSGHubHostedVLLMNative(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		runtimeFramework string
+		imageID          string
+	}{
+		{name: "default vllm image", runtimeFramework: "vllm", imageID: "opencsghq/vllm:v0.24.0"},
+		{name: "amd vllm image", runtimeFramework: "amd-vllm", imageID: "opencsghq/amd-vllm:rocm7.2.1_vllm_0.24.0"},
+		{name: "future vllm image", runtimeFramework: "vllm", imageID: "opencsghq/vllm:v0.25.1"},
+		{name: "future upstream major vllm image", runtimeFramework: "vllm", imageID: "opencsghq/vllm:v1.0.0"},
+		{name: "multiple version tokens", runtimeFramework: "vllm", imageID: "opencsghq/vllm:v0.8.5_vllm_0.24.0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decision, err := ResolveRouting(RoutingTarget{
+				ModelID:          "hosted-vllm",
+				Target:           "https://model.internal",
+				CSGHubHosted:     true,
+				RuntimeFramework: tc.runtimeFramework,
+				ImageID:          tc.imageID,
+			})
+			require.NoError(t, err)
+			require.Equal(t, ResponsesModeNative, decision.Mode)
+			require.Equal(t, "https://model.internal/v1/responses", decision.BackendURL)
+			require.Equal(t, "csghub_hosted_vllm_native", decision.Reason)
+		})
+	}
+}
+
+func TestResolveResponsesRoutingCSGHubHostedVLLMChatAdapter(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		imageID string
+	}{
+		{name: "legacy cu118 image", imageID: "opencsghq/vllm:v0.9.2-cu118"},
+		{name: "legacy dcu image", imageID: "opencsghq/vllm:v0.8.5-dtk25.04"},
+		{name: "cpu image", imageID: "opencsghq/vllm-cpu:2.4"},
+		{name: "nvidia image without vllm semver", imageID: "opencsghq/nvidia-vllm:25.11-py3"},
+		{name: "packaging major is not upstream vllm semver", imageID: "opencsghq/vllm:2.5"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decision, err := ResolveRouting(RoutingTarget{
+				ModelID:          "hosted-vllm",
+				Target:           "https://model.internal/",
+				CSGHubHosted:     true,
+				RuntimeFramework: "vllm",
+				ImageID:          tc.imageID,
+			})
+			require.NoError(t, err)
+			require.Equal(t, ResponsesModeChatAdapter, decision.Mode)
+			require.Equal(t, "https://model.internal/v1/chat/completions", decision.BackendURL)
+			require.Equal(t, "csghub_hosted_vllm_chat_adapter", decision.Reason)
+		})
+	}
+}
+
+func TestResolveResponsesRoutingCSGHubHostedSchemeLessTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		target  string
+		wantURL string
+	}{
+		{name: "host", target: "remote.app.internal", wantURL: "http://remote.app.internal/v1/responses"},
+		{name: "host port", target: "remote.app.internal:8000", wantURL: "http://remote.app.internal:8000/v1/responses"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decision, err := ResolveRouting(RoutingTarget{
+				ModelID:          "hosted-vllm",
+				Target:           tc.target,
+				CSGHubHosted:     true,
+				RuntimeFramework: "vllm",
+				ImageID:          "opencsghq/vllm:v0.24.0",
+			})
+			require.NoError(t, err)
+			require.Equal(t, ResponsesModeNative, decision.Mode)
+			require.Equal(t, tc.wantURL, decision.BackendURL)
+			require.Equal(t, "csghub_hosted_vllm_native", decision.Reason)
+		})
+	}
+}
+
+func TestResolveResponsesRoutingCSGHubHostedSchemeLessTargetWithPath(t *testing.T) {
+	_, err := ResolveRouting(RoutingTarget{
+		ModelID:          "hosted-vllm",
+		Target:           "cluster.local:8000/v1",
+		CSGHubHosted:     true,
+		RuntimeFramework: "vllm",
+		ImageID:          "opencsghq/vllm:v0.24.0",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `looks like host:port with path`)
+	require.Contains(t, err.Error(), `please prepend "http://"`)
+}
+
+func TestResolveResponsesRoutingCSGHubHostedSGLangChatAdapter(t *testing.T) {
+	decision, err := ResolveRouting(RoutingTarget{
+		ModelID:          "hosted-sglang",
+		Target:           "https://model.internal/base",
+		CSGHubHosted:     true,
+		RuntimeFramework: "nvidia-sglang",
+		ImageID:          "opencsghq/nvidia-sglang:latest",
+	})
+	require.NoError(t, err)
+	require.Equal(t, ResponsesModeChatAdapter, decision.Mode)
+	require.Equal(t, "https://model.internal/base/v1/chat/completions", decision.BackendURL)
+	require.Equal(t, "csghub_hosted_sglang_chat_adapter", decision.Reason)
+}
+
+func TestResolveResponsesRoutingCSGHubHostedSGLangNative(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		runtimeFramework string
+		imageID          string
+	}{
+		{name: "default sglang image", runtimeFramework: "sglang", imageID: "opencsghq/sglang:v0.5.14-cu130"},
+		{name: "guard stream sglang image", runtimeFramework: "sglang-qwen3-guard-stream", imageID: "opencsghq/sglang:0.5.3rc0-qwen3-guard-stream"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decision, err := ResolveRouting(RoutingTarget{
+				ModelID:          "hosted-sglang",
+				Target:           "https://model.internal",
+				CSGHubHosted:     true,
+				RuntimeFramework: tc.runtimeFramework,
+				ImageID:          tc.imageID,
+			})
+			require.NoError(t, err)
+			require.Equal(t, ResponsesModeNative, decision.Mode)
+			require.Equal(t, "https://model.internal/v1/responses", decision.BackendURL)
+			require.Equal(t, "csghub_hosted_sglang_native", decision.Reason)
+		})
+	}
+}
+
+func TestResolveResponsesRoutingCSGHubHostedSGLangNonNative(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		imageID string
+	}{
+		{name: "nvidia image without sglang semver", imageID: "opencsghq/nvidia-sglang:25.10-py3"},
+		{name: "old sglang image", imageID: "opencsghq/sglang:v0.4.9-cu121"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decision, err := ResolveRouting(RoutingTarget{
+				ModelID:          "hosted-sglang",
+				Target:           "https://model.internal",
+				CSGHubHosted:     true,
+				RuntimeFramework: "sglang",
+				ImageID:          tc.imageID,
+			})
+			require.NoError(t, err)
+			require.Equal(t, ResponsesModeChatAdapter, decision.Mode)
+			require.Equal(t, "https://model.internal/v1/chat/completions", decision.BackendURL)
+			require.Equal(t, "csghub_hosted_sglang_chat_adapter", decision.Reason)
+		})
+	}
+}
+
+func TestResolveResponsesRoutingCSGHubHostedUnknownRuntime(t *testing.T) {
+	decision, err := ResolveRouting(RoutingTarget{
+		ModelID:          "hosted-unknown",
+		Target:           "https://model.internal",
+		CSGHubHosted:     true,
+		RuntimeFramework: "mindie",
+		ImageID:          "opencsghq/mindie:latest",
+	})
+	require.NoError(t, err)
+	require.Equal(t, ResponsesModeDisabled, decision.Mode)
+	require.Equal(t, "unsupported_csghub_hosted_runtime", decision.Reason)
 }
 
 func TestResolveResponsesRoutingRejectsPartialPathSegmentMatches(t *testing.T) {

--- a/aigateway/handler/responses_adapter.go
+++ b/aigateway/handler/responses_adapter.go
@@ -300,6 +300,7 @@ func responsesToolsToChatTools(ctx context.Context, raw json.RawMessage, modelNa
 	}
 	chatTools := make([]map[string]json.RawMessage, 0, len(tools))
 	functionTools := map[string]struct{}{}
+	namespaceByFunctionName := map[string]string{}
 	for _, tool := range tools {
 		var obj map[string]json.RawMessage
 		if err := json.Unmarshal(tool, &obj); err != nil {
@@ -307,6 +308,32 @@ func responsesToolsToChatTools(ctx context.Context, raw json.RawMessage, modelNa
 		}
 		var toolType string
 		_ = json.Unmarshal(obj["type"], &toolType)
+		if toolType == "namespace" {
+			namespaceTools, namespaceFunctionTools, err := responsesNamespaceToolToChatTools(ctx, obj, modelName)
+			if err != nil {
+				return nil, nil, err
+			}
+			namespaceName := responsesNamespaceName(obj)
+			for name := range namespaceFunctionTools {
+				if err := responsesRecordToolNamespace(namespaceByFunctionName, name, namespaceName); err != nil {
+					return nil, nil, err
+				}
+			}
+			for _, chatTool := range namespaceTools {
+				chatTools = append(chatTools, chatTool)
+			}
+			for name := range namespaceFunctionTools {
+				functionTools[name] = struct{}{}
+			}
+			if len(namespaceTools) == 0 {
+				slog.InfoContext(ctx, "drop empty responses namespace tool for chat adapter",
+					slog.String("api", "/v1/responses"),
+					slog.String("adapter", "chat_completions"),
+					slog.String("model", modelName),
+					slog.String("dropped_tool_type", toolType))
+			}
+			continue
+		}
 		if toolType != "" && toolType != "function" {
 			// Chat completions APIs only support function tools.
 			// Drop unsupported tool types to avoid upstream errors.
@@ -317,30 +344,12 @@ func responsesToolsToChatTools(ctx context.Context, raw json.RawMessage, modelNa
 				slog.String("dropped_tool_type", toolType))
 			continue
 		}
-		function := map[string]json.RawMessage{}
-		if rawFunction, ok := obj["function"]; ok {
-			if err := json.Unmarshal(rawFunction, &function); err != nil || function == nil {
-				return nil, nil, fmt.Errorf("convert responses function tool: function must be an object")
-			}
-		} else {
-			for _, key := range []string{"name", "description", "parameters", "strict"} {
-				if value, ok := obj[key]; ok {
-					function[key] = value
-				}
-			}
-		}
-		functionRaw, err := json.Marshal(function)
+		chatTool, functionName, err := responsesFunctionToolToChatTool(obj)
 		if err != nil {
-			return nil, nil, fmt.Errorf("convert responses function tool: %w", err)
+			return nil, nil, err
 		}
-		var functionName string
-		_ = json.Unmarshal(function["name"], &functionName)
 		if functionName != "" {
 			functionTools[functionName] = struct{}{}
-		}
-		chatTool := map[string]json.RawMessage{
-			"type":     json.RawMessage(`"function"`),
-			"function": functionRaw,
 		}
 		chatTools = append(chatTools, chatTool)
 	}
@@ -352,6 +361,183 @@ func responsesToolsToChatTools(ctx context.Context, raw json.RawMessage, modelNa
 		return nil, nil, fmt.Errorf("convert responses tools to chat tools: %w", err)
 	}
 	return data, functionTools, nil
+}
+
+func responsesNamespaceToolToChatTools(ctx context.Context, obj map[string]json.RawMessage, modelName string) ([]map[string]json.RawMessage, map[string]struct{}, error) {
+	rawChildren := responsesNamespaceToolChildren(obj)
+	chatTools := make([]map[string]json.RawMessage, 0, len(rawChildren)+1)
+	functionTools := map[string]struct{}{}
+	if len(rawChildren) == 0 && responsesLooksLikeFunctionTool(obj) {
+		chatTool, functionName, err := responsesFunctionToolToChatTool(obj)
+		if err != nil {
+			return nil, nil, err
+		}
+		if functionName != "" {
+			functionTools[functionName] = struct{}{}
+		}
+		chatTools = append(chatTools, chatTool)
+	}
+	for _, rawChild := range rawChildren {
+		var child map[string]json.RawMessage
+		if err := json.Unmarshal(rawChild, &child); err != nil {
+			return nil, nil, fmt.Errorf("convert responses namespace tool: %w", err)
+		}
+		var childType string
+		_ = json.Unmarshal(child["type"], &childType)
+		if childType != "" && childType != "function" {
+			slog.InfoContext(ctx, "drop unsupported responses namespace child tool for chat adapter",
+				slog.String("api", "/v1/responses"),
+				slog.String("adapter", "chat_completions"),
+				slog.String("model", modelName),
+				slog.String("dropped_tool_type", childType))
+			continue
+		}
+		chatTool, functionName, err := responsesFunctionToolToChatTool(child)
+		if err != nil {
+			return nil, nil, err
+		}
+		if functionName != "" {
+			functionTools[functionName] = struct{}{}
+		}
+		chatTools = append(chatTools, chatTool)
+	}
+	return chatTools, functionTools, nil
+}
+
+func responsesNamespaceByFunctionName(raw json.RawMessage) (map[string]string, error) {
+	result := map[string]string{}
+	for _, tool := range splitRawJSONArray(raw) {
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(tool, &obj); err != nil {
+			continue
+		}
+		var toolType string
+		_ = json.Unmarshal(obj["type"], &toolType)
+		if toolType != "namespace" {
+			continue
+		}
+		namespaceName := responsesNamespaceName(obj)
+		if namespaceName == "" {
+			continue
+		}
+		children := responsesNamespaceToolChildren(obj)
+		if len(children) == 0 && responsesLooksLikeFunctionTool(obj) {
+			if err := responsesRecordToolNamespace(result, responsesFunctionToolName(obj), namespaceName); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		for _, rawChild := range children {
+			var child map[string]json.RawMessage
+			if err := json.Unmarshal(rawChild, &child); err != nil {
+				continue
+			}
+			var childType string
+			_ = json.Unmarshal(child["type"], &childType)
+			if childType != "" && childType != "function" {
+				continue
+			}
+			functionName := responsesFunctionToolName(child)
+			if err := responsesRecordToolNamespace(result, functionName, namespaceName); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
+}
+
+func responsesRecordToolNamespace(result map[string]string, functionName, namespaceName string) error {
+	if functionName == "" || namespaceName == "" {
+		return nil
+	}
+	if existing, ok := result[functionName]; ok && existing != namespaceName {
+		return fmt.Errorf("duplicated tool name across namespaces: %s", functionName)
+	}
+	result[functionName] = namespaceName
+	return nil
+}
+
+func responsesNamespaceName(obj map[string]json.RawMessage) string {
+	var name string
+	_ = json.Unmarshal(obj["name"], &name)
+	if name != "" {
+		return name
+	}
+	var namespace map[string]json.RawMessage
+	if err := json.Unmarshal(obj["namespace"], &namespace); err != nil {
+		return ""
+	}
+	_ = json.Unmarshal(namespace["name"], &name)
+	return name
+}
+
+func responsesNamespaceToolChildren(obj map[string]json.RawMessage) []json.RawMessage {
+	var children []json.RawMessage
+	for _, key := range []string{"tools", "functions"} {
+		children = append(children, splitRawJSONArray(obj[key])...)
+	}
+	var namespace map[string]json.RawMessage
+	if err := json.Unmarshal(obj["namespace"], &namespace); err == nil {
+		for _, key := range []string{"tools", "functions"} {
+			children = append(children, splitRawJSONArray(namespace[key])...)
+		}
+	}
+	return children
+}
+
+func responsesLooksLikeFunctionTool(obj map[string]json.RawMessage) bool {
+	if _, ok := obj["function"]; ok {
+		return true
+	}
+	if _, ok := obj["name"]; !ok {
+		return false
+	}
+	for _, key := range []string{"parameters", "description", "strict"} {
+		if _, ok := obj[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func responsesFunctionToolName(obj map[string]json.RawMessage) string {
+	function := map[string]json.RawMessage{}
+	if rawFunction, ok := obj["function"]; ok {
+		_ = json.Unmarshal(rawFunction, &function)
+	} else {
+		function = obj
+	}
+	var functionName string
+	_ = json.Unmarshal(function["name"], &functionName)
+	return functionName
+}
+
+func responsesFunctionToolToChatTool(obj map[string]json.RawMessage) (map[string]json.RawMessage, string, error) {
+	function := map[string]json.RawMessage{}
+	if rawFunction, ok := obj["function"]; ok {
+		if err := json.Unmarshal(rawFunction, &function); err != nil || function == nil {
+			return nil, "", fmt.Errorf("convert responses function tool: function must be an object")
+		}
+	} else {
+		for _, key := range []string{"name", "description", "parameters", "strict"} {
+			if value, ok := obj[key]; ok {
+				function[key] = value
+			}
+		}
+	}
+	functionRaw, err := json.Marshal(function)
+	if err != nil {
+		return nil, "", fmt.Errorf("convert responses function tool: %w", err)
+	}
+	functionName := responsesFunctionToolName(obj)
+	chatTool := map[string]json.RawMessage{
+		"type":     json.RawMessage(`"function"`),
+		"function": functionRaw,
+	}
+	return chatTool, functionName, nil
 }
 
 func responsesToolChoiceToChatToolChoice(ctx context.Context, raw json.RawMessage, functionTools map[string]struct{}, modelName string) json.RawMessage {
@@ -451,10 +637,14 @@ func responsesInputToChatMessages(ctx context.Context, req *types.ResponsesReque
 			messages = append(messages, message)
 			lastAssistantIdx = len(messages) - 1
 		case "function_call_output":
+			content, err := normalizeResponsesContent(item["output"])
+			if err != nil {
+				return nil, err
+			}
 			messages = append(messages, map[string]any{
 				"role":         "tool",
 				"tool_call_id": item["call_id"],
-				"content":      item["output"],
+				"content":      content,
 			})
 		case "reasoning":
 			if reasoning := responsesReasoningItemText(item); reasoning != "" {
@@ -541,10 +731,7 @@ func normalizeResponsesContent(content any) (any, error) {
 		case "input_text", "output_text", "text":
 			chatParts = append(chatParts, map[string]any{"type": "text", "text": obj["text"]})
 		case "input_image", "image_url":
-			imageURL := obj["image_url"]
-			if s, ok := imageURL.(string); ok {
-				imageURL = map[string]any{"url": s}
-			}
+			imageURL := normalizeResponsesImageURL(obj)
 			chatParts = append(chatParts, map[string]any{"type": "image_url", "image_url": imageURL})
 		case "input_audio":
 			inputAudio := obj["input_audio"]
@@ -566,7 +753,34 @@ func normalizeResponsesContent(content any) (any, error) {
 	return chatParts, nil
 }
 
+func normalizeResponsesImageURL(obj map[string]any) any {
+	imageURL := obj["image_url"]
+	detail, hasDetail := obj["detail"]
+	if s, ok := imageURL.(string); ok {
+		normalized := map[string]any{"url": s}
+		if hasDetail {
+			normalized["detail"] = detail
+		}
+		return normalized
+	}
+	if imageURLObj, ok := imageURL.(map[string]any); ok && hasDetail {
+		if _, exists := imageURLObj["detail"]; !exists {
+			normalized := make(map[string]any, len(imageURLObj)+1)
+			for key, value := range imageURLObj {
+				normalized[key] = value
+			}
+			normalized["detail"] = detail
+			return normalized
+		}
+	}
+	return imageURL
+}
+
 func chatResponseToResponses(data []byte, publicModel string) (*types.ResponsesResponse, error) {
+	return chatResponseToResponsesWithToolNamespaces(data, publicModel, nil)
+}
+
+func chatResponseToResponsesWithToolNamespaces(data []byte, publicModel string, toolNamespaces map[string]string) (*types.ResponsesResponse, error) {
 	var chat types.ChatCompletion
 	if err := json.Unmarshal(data, &chat); err != nil {
 		return nil, err
@@ -595,14 +809,18 @@ func chatResponseToResponses(data []byte, publicModel string) (*types.ResponsesR
 	msg := chat.Choices[0].Message
 	if len(msg.ToolCalls) > 0 {
 		for _, call := range msg.ToolCalls {
-			resp.Output = append(resp.Output, types.ResponsesOutputItem{
+			item := types.ResponsesOutputItem{
 				ID:        call.ID,
 				Type:      "function_call",
 				Status:    "completed",
 				CallID:    call.ID,
 				Name:      call.Function.Name,
 				Arguments: call.Function.Arguments,
-			})
+			}
+			if namespace := toolNamespaces[call.Function.Name]; namespace != "" {
+				item.Extra = map[string]any{"namespace": namespace}
+			}
+			resp.Output = append(resp.Output, item)
 		}
 		appendResponsesReasoning(resp, reasoning)
 		return resp, nil

--- a/aigateway/handler/responses_adapter.go
+++ b/aigateway/handler/responses_adapter.go
@@ -319,9 +319,7 @@ func responsesToolsToChatTools(ctx context.Context, raw json.RawMessage, modelNa
 					return nil, nil, err
 				}
 			}
-			for _, chatTool := range namespaceTools {
-				chatTools = append(chatTools, chatTool)
-			}
+			chatTools = append(chatTools, namespaceTools...)
 			for name := range namespaceFunctionTools {
 				functionTools[name] = struct{}{}
 			}

--- a/aigateway/handler/responses_adapter_non_stream_writer.go
+++ b/aigateway/handler/responses_adapter_non_stream_writer.go
@@ -21,6 +21,7 @@ type responsesAdapterNonStreamWriter struct {
 	moderation       component.Moderation
 	sessionID        string
 	logCapture       *responsespkg.LLMLogRecorder
+	toolNamespaces   map[string]string
 }
 
 func newResponsesAdapterNonStreamWriter(w gin.ResponseWriter, model string, responsesCounter token.ResponsesTokenCounter, moderation component.Moderation, sessionID string, logCapture ...*responsespkg.LLMLogRecorder) *responsesAdapterNonStreamWriter {
@@ -57,7 +58,7 @@ func (w *responsesAdapterNonStreamWriter) Finalize(statusCode int) error {
 	if sensitive {
 		return nil
 	}
-	resp, err := chatResponseToResponses(chatBody, w.model)
+	resp, err := chatResponseToResponsesWithToolNamespaces(chatBody, w.model, w.toolNamespaces)
 	if err != nil {
 		return err
 	}

--- a/aigateway/handler/responses_adapter_stream_writer.go
+++ b/aigateway/handler/responses_adapter_stream_writer.go
@@ -52,14 +52,18 @@ type responsesAdapterStreamWriter struct {
 	moderation         component.Moderation
 	sessionID          string
 	logCapture         *responsespkg.LLMLogRecorder
+	toolNamespaces     map[string]string
 }
 
 type responsesToolCallStreamState struct {
-	OutputIndex int
-	CallID      string
-	Name        string
-	Arguments   strings.Builder
-	Done        bool
+	OutputIndex           int
+	CallID                string
+	Name                  string
+	Namespace             string
+	Arguments             strings.Builder
+	pendingArgumentDeltas []string
+	Added                 bool
+	Done                  bool
 }
 
 func newResponsesAdapterStreamWriter(w gin.ResponseWriter, model string, responsesCounter token.ResponsesTokenCounter, moderation component.Moderation, sessionID string, logCapture ...*responsespkg.LLMLogRecorder) *responsesAdapterStreamWriter {
@@ -272,17 +276,7 @@ func (w *responsesAdapterStreamWriter) writeToolCallDeltas(chunk types.ChatCompl
 				w.logCapture.CaptureToolCallStart(state.CallID, state.Name, "")
 			}
 			if args := call.Function.Arguments; args != "" {
-				state.Arguments.WriteString(args)
-				if w.logCapture != nil {
-					w.logCapture.CaptureToolCallArgumentsDelta(state.CallID, args)
-				}
-				w.writeResponsesEvent("response.function_call_arguments.delta", responsespkg.StreamFunctionCallArgumentsDeltaEvent{
-					Type:        "response.function_call_arguments.delta",
-					ResponseID:  w.respID,
-					ItemID:      state.CallID,
-					OutputIndex: state.OutputIndex,
-					Delta:       args,
-				})
+				w.captureToolCallArguments(state, args)
 			}
 		}
 	}
@@ -295,6 +289,9 @@ func (w *responsesAdapterStreamWriter) ensureToolCallItem(index int, callID, nam
 		}
 		if state.Name == "" && name != "" {
 			state.Name = name
+			state.Namespace = w.toolNamespaces[name]
+			w.ensureToolCallItemAdded(state)
+			w.flushPendingToolCallArguments(state)
 		}
 		return state
 	}
@@ -306,26 +303,71 @@ func (w *responsesAdapterStreamWriter) ensureToolCallItem(index int, callID, nam
 		OutputIndex: w.nextOutputIndex(),
 		CallID:      itemID,
 		Name:        name,
+		Namespace:   w.toolNamespaces[name],
 	}
 	w.toolCallItems[index] = state
 	if w.logCapture != nil {
 		w.logCapture.CaptureResponseID(w.respID)
 		w.logCapture.CaptureToolCallStart(itemID, name, "")
 	}
+	if name == "" {
+		return state
+	}
+	w.ensureToolCallItemAdded(state)
+	return state
+}
+
+func (w *responsesAdapterStreamWriter) ensureToolCallItemAdded(state *responsesToolCallStreamState) {
+	if state == nil || state.Added || state.Name == "" {
+		return
+	}
+	state.Added = true
 	w.writeResponsesEvent("response.output_item.added", responsespkg.StreamOutputItemEvent{
 		Type:        "response.output_item.added",
 		ResponseID:  w.respID,
 		OutputIndex: state.OutputIndex,
 		Item: responsespkg.StreamFunctionCallItem{
-			ID:        itemID,
+			ID:        state.CallID,
 			Type:      "function_call",
-			CallID:    itemID,
-			Name:      name,
+			CallID:    state.CallID,
+			Name:      state.Name,
+			Namespace: state.Namespace,
 			Arguments: "",
 			Status:    "in_progress",
 		},
 	})
-	return state
+}
+
+func (w *responsesAdapterStreamWriter) captureToolCallArguments(state *responsesToolCallStreamState, args string) {
+	state.Arguments.WriteString(args)
+	if state.Name == "" {
+		state.pendingArgumentDeltas = append(state.pendingArgumentDeltas, args)
+		return
+	}
+	w.writeToolCallArgumentsDelta(state, args)
+}
+
+func (w *responsesAdapterStreamWriter) flushPendingToolCallArguments(state *responsesToolCallStreamState) {
+	if state == nil || state.Name == "" {
+		return
+	}
+	for _, args := range state.pendingArgumentDeltas {
+		w.writeToolCallArgumentsDelta(state, args)
+	}
+	state.pendingArgumentDeltas = nil
+}
+
+func (w *responsesAdapterStreamWriter) writeToolCallArgumentsDelta(state *responsesToolCallStreamState, args string) {
+	if w.logCapture != nil {
+		w.logCapture.CaptureToolCallArgumentsDelta(state.CallID, args)
+	}
+	w.writeResponsesEvent("response.function_call_arguments.delta", responsespkg.StreamFunctionCallArgumentsDeltaEvent{
+		Type:        "response.function_call_arguments.delta",
+		ResponseID:  w.respID,
+		ItemID:      state.CallID,
+		OutputIndex: state.OutputIndex,
+		Delta:       args,
+	})
 }
 
 func (w *responsesAdapterStreamWriter) ensureStarted() {
@@ -540,10 +582,12 @@ func (w *responsesAdapterStreamWriter) finishRefusalItem() {
 
 func (w *responsesAdapterStreamWriter) finishToolCallItems() {
 	for _, state := range w.orderedToolCallStates() {
-		if state == nil || state.Done {
+		if state == nil || state.Done || state.Name == "" {
 			continue
 		}
 		state.Done = true
+		w.ensureToolCallItemAdded(state)
+		w.flushPendingToolCallArguments(state)
 		if w.logCapture != nil {
 			w.logCapture.CaptureResponseID(w.respID)
 			w.logCapture.CaptureToolCallStart(state.CallID, state.Name, state.Arguments.String())
@@ -563,6 +607,7 @@ func (w *responsesAdapterStreamWriter) finishToolCallItems() {
 				Type:      "function_call",
 				CallID:    state.CallID,
 				Name:      state.Name,
+				Namespace: state.Namespace,
 				Arguments: state.Arguments.String(),
 				Status:    "completed",
 			},
@@ -630,7 +675,7 @@ func (w *responsesAdapterStreamWriter) completedResponse() responsespkg.StreamRe
 		}{index: w.reasoningOutputIdx, item: w.reasoningOutput("completed")})
 	}
 	for _, state := range w.orderedToolCallStates() {
-		if state == nil {
+		if state == nil || state.Name == "" {
 			continue
 		}
 		outputItems = append(outputItems, struct {
@@ -641,6 +686,7 @@ func (w *responsesAdapterStreamWriter) completedResponse() responsespkg.StreamRe
 			Type:      "function_call",
 			CallID:    state.CallID,
 			Name:      state.Name,
+			Namespace: state.Namespace,
 			Arguments: state.Arguments.String(),
 			Status:    "completed",
 		}})

--- a/aigateway/handler/responses_adapter_test.go
+++ b/aigateway/handler/responses_adapter_test.go
@@ -355,6 +355,66 @@ func TestResponsesToChatRequestMapsInputImageStringURL(t *testing.T) {
 	}`, string(body))
 }
 
+func TestResponsesToChatRequestMapsFunctionCallOutputInputImage(t *testing.T) {
+	req := &types.ResponsesRequest{
+		Model: "public",
+		Input: json.RawMessage(`[
+			{
+				"type": "function_call",
+				"call_id": "call_view_image_1",
+				"name": "view_image",
+				"arguments": "{\"path\":\"/tmp/image.png\"}"
+			},
+			{
+				"type": "function_call_output",
+				"call_id": "call_view_image_1",
+				"output": [
+					{"type": "input_image", "image_url": "data:image/jpeg;base64,abc", "detail": "high"}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "input_text", "text": "describe it"}
+				]
+			}
+		]`),
+	}
+	chatReq, err := responsesToChatRequest(context.Background(), req, "upstream-model", nil)
+	require.NoError(t, err)
+
+	body, err := marshalChatRequestBody(chatReq, "upstream-model")
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"model": "upstream-model",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": "",
+				"tool_calls": [{
+					"id": "call_view_image_1",
+					"type": "function",
+					"function": {"name": "view_image", "arguments": "{\"path\":\"/tmp/image.png\"}"}
+				}]
+			},
+			{
+				"role": "tool",
+				"tool_call_id": "call_view_image_1",
+				"content": [
+					{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,abc", "detail": "high"}}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "text", "text": "describe it"}
+				]
+			}
+		],
+		"parallel_tool_calls": true
+	}`, string(body))
+}
+
 func TestResponsesToChatRequestAttachesReasoningInputToAssistantMessage(t *testing.T) {
 	req := &types.ResponsesRequest{
 		Model: "public",
@@ -882,6 +942,54 @@ func TestResponsesAdapterNonStreamWriterFinalizesResponse(t *testing.T) {
 	require.Equal(t, int64(5), usage.TotalTokens)
 }
 
+func extractResponsesOutputItem(t *testing.T, data []byte, index int) []byte {
+	t.Helper()
+	var body struct {
+		Output []json.RawMessage `json:"output"`
+	}
+	require.NoError(t, json.Unmarshal(data, &body))
+	require.Greater(t, len(body.Output), index)
+	return body.Output[index]
+}
+
+func TestResponsesAdapterNonStreamWriterRestoresNamespaceToolCall(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	writer := newResponsesAdapterNonStreamWriter(ctx.Writer, "public-model", nil, nil, "")
+	writer.toolNamespaces = map[string]string{"get_top_download_models": "mcp__csghub_production"}
+	writer.WriteHeader(http.StatusOK)
+	_, err := writer.Write([]byte(`{
+		"id":"chatcmpl_1",
+		"created":123,
+		"model":"upstream-model",
+		"choices":[{
+			"message":{
+				"role":"assistant",
+				"tool_calls":[{
+					"id":"call_1",
+					"type":"function",
+					"function":{"name":"get_top_download_models","arguments":"{\"num\":20}"}
+				}]
+			},
+			"finish_reason":"tool_calls"
+		}]
+	}`))
+	require.NoError(t, err)
+
+	require.NoError(t, writer.Finalize(http.StatusOK))
+	require.Equal(t, http.StatusOK, w.Code)
+	require.JSONEq(t, `{
+		"id": "call_1",
+		"type": "function_call",
+		"status": "completed",
+		"call_id": "call_1",
+		"name": "get_top_download_models",
+		"namespace": "mcp__csghub_production",
+		"arguments": "{\"num\":20}"
+	}`, string(extractResponsesOutputItem(t, w.Body.Bytes(), 0)))
+}
+
 func TestResponsesAdapterNonStreamWriterForwardsUpstreamError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
@@ -1147,6 +1255,90 @@ func TestResponsesAdapterStreamWriterToolOnlyStreamDoesNotEmitTextItem(t *testin
 	require.Contains(t, body, "event: response.completed")
 }
 
+func TestResponsesAdapterStreamWriterRestoresNamespaceToolCall(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	writer := newResponsesAdapterStreamWriter(ctx.Writer, "public-model", nil, nil, "")
+	writer.toolNamespaces = map[string]string{"get_top_download_models": "mcp__csghub_production"}
+	writer.WriteHeader(200)
+
+	_, err := writer.Write([]byte(`data: {"id":"chatcmpl_1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_top_download_models","arguments":"{\"num\":20}"}}]}}]}` + "\n\n"))
+	require.NoError(t, err)
+	_, err = writer.Write([]byte(`data: {"id":"chatcmpl_1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n"))
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("data: [DONE]\n\n"))
+	require.NoError(t, err)
+
+	body := w.Body.String()
+	require.Contains(t, body, `"type":"function_call"`)
+	require.Contains(t, body, `"name":"get_top_download_models"`)
+	require.Contains(t, body, `"namespace":"mcp__csghub_production"`)
+	require.Contains(t, body, `"call_id":"call_1"`)
+	require.Contains(t, body, "event: response.output_item.added")
+	require.Contains(t, body, "event: response.output_item.done")
+	require.Contains(t, body, "event: response.completed")
+}
+
+func TestResponsesAdapterStreamWriterRestoresNamespaceWhenToolNameArrivesLate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	writer := newResponsesAdapterStreamWriter(ctx.Writer, "public-model", nil, nil, "")
+	writer.toolNamespaces = map[string]string{"get_top_download_models": "mcp__csghub_production"}
+	writer.WriteHeader(200)
+
+	_, err := writer.Write([]byte(`data: {"id":"chatcmpl_1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{}}]}}]}` + "\n\n"))
+	require.NoError(t, err)
+	require.NotContains(t, w.Body.String(), "event: response.output_item.added")
+	_, err = writer.Write([]byte(`data: {"id":"chatcmpl_1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"get_top_download_models"}}]}}]}` + "\n\n"))
+	require.NoError(t, err)
+	_, err = writer.Write([]byte(`data: {"id":"chatcmpl_1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"arguments":"{\"num\":20}"}}]}}]}` + "\n\n"))
+	require.NoError(t, err)
+	_, err = writer.Write([]byte(`data: {"id":"chatcmpl_1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n"))
+	require.NoError(t, err)
+
+	body := w.Body.String()
+	added := strings.Index(body, "event: response.output_item.added")
+	delta := strings.Index(body, "event: response.function_call_arguments.delta")
+	require.NotEqual(t, -1, added)
+	require.NotEqual(t, -1, delta)
+	require.Less(t, added, delta)
+	addedEnd := strings.Index(body[added:], "\n\n")
+	require.NotEqual(t, -1, addedEnd)
+	require.Contains(t, body[added:added+addedEnd], `"name":"get_top_download_models"`)
+	require.Contains(t, body[added:added+addedEnd], `"namespace":"mcp__csghub_production"`)
+}
+
+func TestResponsesAdapterStreamWriterBuffersArgumentsUntilToolNameArrives(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	writer := newResponsesAdapterStreamWriter(ctx.Writer, "public-model", nil, nil, "")
+	writer.toolNamespaces = map[string]string{"get_top_download_models": "mcp__csghub_production"}
+	writer.WriteHeader(200)
+
+	_, err := writer.Write([]byte(`data: {"id":"chatcmpl_1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"arguments":"{\"num\":"}}]}}]}` + "\n\n"))
+	require.NoError(t, err)
+	require.NotContains(t, w.Body.String(), "event: response.output_item.added")
+	require.NotContains(t, w.Body.String(), "event: response.function_call_arguments.delta")
+
+	_, err = writer.Write([]byte(`data: {"id":"chatcmpl_1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"get_top_download_models"}}]}}]}` + "\n\n"))
+	require.NoError(t, err)
+
+	body := w.Body.String()
+	added := strings.Index(body, "event: response.output_item.added")
+	delta := strings.Index(body, "event: response.function_call_arguments.delta")
+	require.NotEqual(t, -1, added)
+	require.NotEqual(t, -1, delta)
+	require.Less(t, added, delta)
+	addedEnd := strings.Index(body[added:], "\n\n")
+	require.NotEqual(t, -1, addedEnd)
+	require.Contains(t, body[added:added+addedEnd], `"name":"get_top_download_models"`)
+	require.Contains(t, body[added:added+addedEnd], `"namespace":"mcp__csghub_production"`)
+	require.Contains(t, body, `"delta":"{\"num\":"`)
+}
+
 func TestResponsesAdapterStreamWriterEmitsRefusalEvents(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
@@ -1318,6 +1510,203 @@ func TestResponsesToChatRequestDropsNonFunctionTools(t *testing.T) {
 	var parsed map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(body, &parsed))
 	require.NotContains(t, parsed, "tools")
+}
+
+func TestResponsesToChatRequestFlattensNamespaceFunctionTools(t *testing.T) {
+	req := &types.ResponsesRequest{
+		Model: "public",
+		Input: json.RawMessage(`"hello"`),
+		Tools: json.RawMessage(`[
+			{
+				"type": "namespace",
+				"name": "mcp",
+				"description": "CSGHub production MCP server",
+				"tools": [
+					{
+						"type": "function",
+						"name": "view_image",
+						"description": "View an image",
+						"parameters": {
+							"type": "object",
+							"properties": {"path": {"type": "string"}},
+							"required": ["path"]
+						}
+					},
+					{"type": "web_search"}
+				]
+			},
+			{"type": "web_search"}
+		]`),
+	}
+	chatReq, err := responsesToChatRequest(context.Background(), req, "upstream-model", nil)
+	require.NoError(t, err)
+
+	require.Len(t, chatReq.Tools, 1)
+	data, err := json.Marshal(chatReq.Tools)
+	require.NoError(t, err)
+	require.JSONEq(t, `[
+		{
+			"type": "function",
+			"function": {
+				"name": "view_image",
+				"description": "View an image",
+				"parameters": {
+					"type": "object",
+					"properties": {"path": {"type": "string"}},
+					"required": ["path"]
+				}
+			}
+		}
+	]`, string(data))
+	toolNamespaces, err := responsesNamespaceByFunctionName(req.Tools)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"view_image": "mcp"}, toolNamespaces)
+}
+
+func TestResponsesToChatRequestConvertsCallableNamespaceTool(t *testing.T) {
+	req := &types.ResponsesRequest{
+		Model: "public",
+		Input: json.RawMessage(`"hello"`),
+		Tools: json.RawMessage(`[
+			{
+				"type": "namespace",
+				"name": "exec_command",
+				"description": "Run a command",
+				"parameters": {
+					"type": "object",
+					"properties": {"cmd": {"type": "string"}},
+					"required": ["cmd"]
+				}
+			}
+		]`),
+	}
+	chatReq, err := responsesToChatRequest(context.Background(), req, "upstream-model", nil)
+	require.NoError(t, err)
+
+	require.Len(t, chatReq.Tools, 1)
+	data, err := json.Marshal(chatReq.Tools)
+	require.NoError(t, err)
+	require.JSONEq(t, `[
+		{
+			"type": "function",
+			"function": {
+				"name": "exec_command",
+				"description": "Run a command",
+				"parameters": {
+					"type": "object",
+					"properties": {"cmd": {"type": "string"}},
+					"required": ["cmd"]
+				}
+			}
+		}
+	]`, string(data))
+	toolNamespaces, err := responsesNamespaceByFunctionName(req.Tools)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"exec_command": "exec_command"}, toolNamespaces)
+
+	resp, err := chatResponseToResponsesWithToolNamespaces([]byte(`{
+		"id":"chatcmpl_1",
+		"created":123,
+		"model":"upstream-model",
+		"choices":[{
+			"message":{
+				"role":"assistant",
+				"tool_calls":[{
+					"id":"call_1",
+					"type":"function",
+					"function":{"name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"}
+				}]
+			},
+			"finish_reason":"tool_calls"
+		}]
+	}`), "public-model", toolNamespaces)
+	require.NoError(t, err)
+	require.Len(t, resp.Output, 1)
+	data, err = json.Marshal(resp.Output[0])
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"id": "call_1",
+		"type": "function_call",
+		"status": "completed",
+		"call_id": "call_1",
+		"name": "exec_command",
+		"namespace": "exec_command",
+		"arguments": "{\"cmd\":\"pwd\"}"
+	}`, string(data))
+}
+
+func TestResponsesToChatRequestRejectsDuplicateNamespaceToolNames(t *testing.T) {
+	req := &types.ResponsesRequest{
+		Model: "public",
+		Input: json.RawMessage(`"hello"`),
+		Tools: json.RawMessage(`[
+			{
+				"type": "namespace",
+				"name": "mcp_filesystem",
+				"tools": [
+					{"type": "function", "name": "filesystem.read", "parameters": {"type": "object"}}
+				]
+			},
+			{
+				"type": "namespace",
+				"name": "codex_filesystem",
+				"tools": [
+					{"type": "function", "name": "filesystem.read", "parameters": {"type": "object"}}
+				]
+			}
+		]`),
+	}
+
+	_, err := responsesToChatRequest(context.Background(), req, "upstream-model", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicated tool name across namespaces: filesystem.read")
+
+	_, err = responsesNamespaceByFunctionName(req.Tools)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicated tool name across namespaces: filesystem.read")
+}
+
+func TestResponsesToChatRequestFlattensNestedNamespaceFunctionTools(t *testing.T) {
+	req := &types.ResponsesRequest{
+		Model:      "public",
+		Input:      json.RawMessage(`"hello"`),
+		ToolChoice: json.RawMessage(`{"type":"function","function":{"name":"exec_command"}}`),
+		Tools: json.RawMessage(`[
+			{
+				"type": "namespace",
+				"namespace": {
+					"name": "local",
+					"functions": [
+						{
+							"function": {
+								"name": "exec_command",
+								"description": "Run a command",
+								"parameters": {"type": "object"}
+							}
+						}
+					]
+				}
+			}
+		]`),
+	}
+	chatReq, err := responsesToChatRequest(context.Background(), req, "upstream-model", nil)
+	require.NoError(t, err)
+
+	body, err := marshalChatRequestBody(chatReq, "upstream-model")
+	require.NoError(t, err)
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	require.JSONEq(t, `{"type":"function","function":{"name":"exec_command"}}`, string(parsed["tool_choice"]))
+	require.JSONEq(t, `[
+		{
+			"type": "function",
+			"function": {
+				"name": "exec_command",
+				"description": "Run a command",
+				"parameters": {"type": "object"}
+			}
+		}
+	]`, string(parsed["tools"]))
 }
 
 func TestResponsesToChatRequestDropsRequiredToolChoiceWhenNoFunctionToolsRemain(t *testing.T) {

--- a/aigateway/handler/responses_writer.go
+++ b/aigateway/handler/responses_writer.go
@@ -51,6 +51,18 @@ type responsesAdapterResponseWriter interface {
 	Finalize(statusCode int) error
 }
 
+func setResponsesAdapterToolNamespaces(w responsesAdapterResponseWriter, toolNamespaces map[string]string) {
+	if len(toolNamespaces) == 0 {
+		return
+	}
+	switch writer := w.(type) {
+	case *responsesAdapterStreamWriter:
+		writer.toolNamespaces = toolNamespaces
+	case *responsesAdapterNonStreamWriter:
+		writer.toolNamespaces = toolNamespaces
+	}
+}
+
 func newResponsesAdapterResponseWriter(w gin.ResponseWriter, stream bool, model string, responsesCounter token.ResponsesTokenCounter, moderation component.Moderation, sessionID string, logCapture ...*responsespkg.LLMLogRecorder) responsesAdapterResponseWriter {
 	var recorder *responsespkg.LLMLogRecorder
 	if len(logCapture) > 0 {

--- a/aigateway/token/responses_token_counter.go
+++ b/aigateway/token/responses_token_counter.go
@@ -29,6 +29,7 @@ type responsesTokenCounterImpl struct {
 	toolCallText   strings.Builder
 	tokenizer      Tokenizer
 	promptFallback strings.Builder
+	computedUsage  *Usage
 }
 
 func NewResponsesTokenCounter(tokenizer Tokenizer) ResponsesTokenCounter {
@@ -41,6 +42,7 @@ func (c *responsesTokenCounterImpl) Request(req *types.ResponsesRequest) {
 	}
 	cp := *req
 	c.request = &cp
+	c.computedUsage = nil
 	c.promptFallback.Reset()
 	c.promptFallback.WriteString(types.ResponsesPromptText(req))
 }
@@ -50,6 +52,7 @@ func (c *responsesTokenCounterImpl) Response(resp *types.ResponsesResponse) {
 		return
 	}
 	cp := *resp
+	c.computedUsage = nil
 	c.response = &cp
 	if resp.Usage != nil {
 		c.usage = resp.Usage
@@ -64,6 +67,7 @@ func (c *responsesTokenCounterImpl) Response(resp *types.ResponsesResponse) {
 }
 
 func (c *responsesTokenCounterImpl) AppendEvent(event types.ResponsesStreamEvent) {
+	c.computedUsage = nil
 	if event.Response != nil {
 		cp := *event.Response
 		c.response = &cp
@@ -98,7 +102,11 @@ func (c *responsesTokenCounterImpl) AppendEvent(event types.ResponsesStreamEvent
 }
 
 func (c *responsesTokenCounterImpl) Usage(ctx context.Context) (*Usage, error) {
+	if c.computedUsage != nil {
+		return c.computedUsage, nil
+	}
 	if usage := responsesUsageToTokenUsage(c.usage); usage != nil {
+		c.computedUsage = usage
 		return usage, nil
 	}
 
@@ -109,34 +117,81 @@ func (c *responsesTokenCounterImpl) Usage(ctx context.Context) (*Usage, error) {
 	}
 
 	if c.tokenizer == nil {
-		promptTokens := approxTokensByText(promptText)
-		completionTokens := approxTokensByText(outputText)
-		totalTokens := promptTokens + completionTokens
-		slog.WarnContext(ctx, "responses tokenizer unavailable, using approximate token usage",
-			slog.Int64("prompt_tokens", promptTokens),
-			slog.Int64("completion_tokens", completionTokens),
-			slog.Int64("total_tokens", totalTokens))
-		return &Usage{
-			PromptTokens:     promptTokens,
-			CompletionTokens: completionTokens,
-			TotalTokens:      totalTokens,
-		}, nil
+		c.computedUsage = approximateResponsesUsage(ctx, "responses tokenizer unavailable, using approximate token usage", "tokenizer_unavailable", promptText, outputText)
+		return c.computedUsage, nil
 	}
 
-	promptTokens, err := c.tokenizer.Encode(types.Message{Role: string(types.RoleUser), Content: promptText})
+	promptTokens, err := encodeResponsesTokens(ctx, c.tokenizer, types.Message{Role: string(types.RoleUser), Content: promptText})
 	if err != nil {
-		return nil, err
+		c.computedUsage = approximateResponsesUsage(ctx, "responses tokenizer failed, using approximate token usage", responsesTokenizerFallbackReason(err), promptText, outputText)
+		return c.computedUsage, nil
 	}
-	completionTokens, err := c.tokenizer.Encode(types.Message{Content: outputText})
+	completionTokens, err := encodeResponsesTokens(ctx, c.tokenizer, types.Message{Content: outputText})
 	if err != nil {
-		return nil, err
+		c.computedUsage = approximateResponsesUsage(ctx, "responses tokenizer failed, using approximate token usage", responsesTokenizerFallbackReason(err), promptText, outputText)
+		return c.computedUsage, nil
 	}
 	totalTokens := promptTokens + completionTokens
+	c.computedUsage = &Usage{
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      totalTokens,
+	}
+	return c.computedUsage, nil
+}
+
+type responsesEncodeResult struct {
+	tokens int64
+	err    error
+}
+
+func encodeResponsesTokens(ctx context.Context, tokenizer Tokenizer, message types.Message) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	resultCh := make(chan responsesEncodeResult, 1)
+	go func() {
+		tokens, err := tokenizer.Encode(message)
+		resultCh <- responsesEncodeResult{tokens: tokens, err: err}
+	}()
+	select {
+	case result := <-resultCh:
+		return result.tokens, result.err
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+}
+
+func responsesTokenizerFallbackReason(err error) string {
+	switch {
+	case errors.Is(err, errUnsupportedTokenizer):
+		return "unsupported_tokenizer"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "tokenizer_timeout"
+	case errors.Is(err, context.Canceled):
+		return "tokenizer_canceled"
+	default:
+		return "tokenizer_error"
+	}
+}
+
+func approximateResponsesUsage(ctx context.Context, message, reason, promptText, outputText string) *Usage {
+	promptTokens := approxTokensByText(promptText)
+	completionTokens := approxTokensByText(outputText)
+	totalTokens := promptTokens + completionTokens
+	slog.WarnContext(ctx, message,
+		slog.String("usage_source", "approx_chars_div_4"),
+		slog.String("usage_reason", reason),
+		slog.Int64("prompt_tokens", promptTokens),
+		slog.Int64("completion_tokens", completionTokens),
+		slog.Int64("total_tokens", totalTokens))
 	return &Usage{
 		PromptTokens:     promptTokens,
 		CompletionTokens: completionTokens,
 		TotalTokens:      totalTokens,
-	}, nil
+		Source:           "approx_chars_div_4",
+		SourceReason:     reason,
+	}
 }
 
 func (c *responsesTokenCounterImpl) captureOutputItem(item types.ResponsesOutputItem) {

--- a/aigateway/token/responses_token_counter_test.go
+++ b/aigateway/token/responses_token_counter_test.go
@@ -3,6 +3,7 @@ package token
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -70,6 +71,48 @@ func TestResponsesTokenCounterEstimatesNonStreamResponse(t *testing.T) {
 	require.Equal(t, usage.PromptTokens+usage.CompletionTokens, usage.TotalTokens)
 }
 
+func TestResponsesTokenCounterApproximatesUnsupportedTokenizer(t *testing.T) {
+	counter := NewResponsesTokenCounter(NewTokenizerImpl("http://example.com", "", "m", "sglang", ""))
+	counter.Request(&types.ResponsesRequest{
+		Model:        "m",
+		Instructions: json.RawMessage(`"sys"`),
+		Input:        json.RawMessage(`"hello"`),
+	})
+	counter.Response(&types.ResponsesResponse{OutputText: "world"})
+
+	usage, err := counter.Usage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, approxTokensByText("sys\nhello"), usage.PromptTokens)
+	require.Equal(t, approxTokensByText("world"), usage.CompletionTokens)
+	require.Equal(t, usage.PromptTokens+usage.CompletionTokens, usage.TotalTokens)
+	require.Equal(t, "approx_chars_div_4", usage.Source)
+	require.Equal(t, "unsupported_tokenizer", usage.SourceReason)
+}
+
+func TestResponsesTokenCounterApproximatesTokenizerError(t *testing.T) {
+	counter := NewResponsesTokenCounter(responsesFailingTokenizer{err: errors.New("tokenize failed")})
+	counter.Request(&types.ResponsesRequest{Model: "m", Input: json.RawMessage(`"hello"`)})
+	counter.Response(&types.ResponsesResponse{OutputText: "world"})
+
+	usage, err := counter.Usage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "approx_chars_div_4", usage.Source)
+	require.Equal(t, "tokenizer_error", usage.SourceReason)
+}
+
+func TestResponsesTokenCounterApproximatesCanceledTokenizer(t *testing.T) {
+	counter := NewResponsesTokenCounter(responsesBlockingTokenizer{})
+	counter.Request(&types.ResponsesRequest{Model: "m", Input: json.RawMessage(`"hello"`)})
+	counter.Response(&types.ResponsesResponse{OutputText: "world"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	usage, err := counter.Usage(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "approx_chars_div_4", usage.Source)
+	require.Equal(t, "tokenizer_canceled", usage.SourceReason)
+}
+
 func TestResponsesTokenCounterEstimatesStreamEventsWithoutDoubleCountingDonePayloads(t *testing.T) {
 	counter := NewResponsesTokenCounter(&DumyTokenizer{})
 	counter.Request(&types.ResponsesRequest{Model: "m", Input: json.RawMessage(`"hi"`)})
@@ -131,4 +174,26 @@ func TestResponsesTokenCounterEstimatesReasoningStreamEventsWithoutDoubleCountin
 	require.Equal(t, int64(2), usage.PromptTokens)
 	require.Equal(t, int64(5), usage.CompletionTokens)
 	require.Equal(t, int64(7), usage.TotalTokens)
+}
+
+type responsesFailingTokenizer struct {
+	err error
+}
+
+func (t responsesFailingTokenizer) Encode(types.Message) (int64, error) {
+	return 0, t.err
+}
+
+func (t responsesFailingTokenizer) EmbeddingEncode(string) (int64, error) {
+	return 0, t.err
+}
+
+type responsesBlockingTokenizer struct{}
+
+func (responsesBlockingTokenizer) Encode(types.Message) (int64, error) {
+	select {}
+}
+
+func (responsesBlockingTokenizer) EmbeddingEncode(string) (int64, error) {
+	select {}
 }

--- a/aigateway/token/token_counter.go
+++ b/aigateway/token/token_counter.go
@@ -49,4 +49,8 @@ type Usage struct {
 	// Completion resource count for multi-modal
 	CompletionRC   int64
 	CompletionDesc string
+	// Usage source metadata. Empty means usage came from the upstream response
+	// or the normal tokenizer path.
+	Source       string
+	SourceReason string
 }


### PR DESCRIPTION
Summary:
- Main scope: 变更原因：.
- Additional context: CSGHub 自部署模型的 `/v1/responses` 路由不能只依赖已配置的 upstream URL 后缀；新版 vLLM/SGLang 已支持原生 Responses API，旧版或不确定版本仍需要走 chat adapter。.

Manual handling required:
- Dev-agent failed to cherry-pick this GitLab MR: Git克隆命令执行失败: Command '['git', '--git-dir', '/root/gitlab-to-github/dev-agent/agent/.cache/mirrors/csghub-server.git', 'fetch', '--prune', 'origin']' returned non-zero exit status 128.
错误输出: fatal: unable to access 'https://github.com/OpenCSGs/csghub-server.git/': Failed to connect to github.com port 443 after 130364 ms: Connection timed out

- Source GitLab MR: !2774
- Source ref: d47c7f9bef96b27c54324d6acd132a033f515c22
- Files in sync scope: 24
- The GitLab MR patch was applied with git's 3-way apply. Please review before merging.