### PR TITLE
Add OpenAI-compatible /v1/audio/translations api to AIGateway

### DIFF
--- a/aigateway/handler/openai.go
+++ b/aigateway/handler/openai.go
@@ -72,6 +72,8 @@ type OpenAIHandler interface {
 	GetVideoContentDeprecated(c *gin.Context)
 	// Transcribe audio to text
 	Transcription(c *gin.Context)
+	// Translate audio to English text
+	Translation(c *gin.Context)
 	// Extract text from an image with OCR
 	OCR(c *gin.Context)
 	// Generate speech audio from text

--- a/aigateway/handler/openai_audio.go
+++ b/aigateway/handler/openai_audio.go
@@ -20,6 +20,15 @@ import (
 	"opencsg.com/csghub-server/common/utils/trace"
 )
 
+const (
+	audioSTTKindTranscription = "transcription"
+	audioSTTKindTranslation   = "translation"
+
+	audioTranscriptionsPathSuffix = "/audio/transcriptions"
+	audioTranslationsPathSuffix   = "/audio/translations"
+	audioTranslationsDefaultPath  = "/v1/audio/translations"
+)
+
 // Transcription godoc
 // @Security     ApiKey
 // @Summary      Transcribe audio to text
@@ -35,6 +44,28 @@ import (
 // @Failure      500  {object}  error "Internal server error"
 // @Router       /v1/audio/transcriptions [post]
 func (h *OpenAIHandlerImpl) Transcription(c *gin.Context) {
+	h.handleAudioSTT(c, audioSTTKindTranscription)
+}
+
+// Translation godoc
+// @Security     ApiKey
+// @Summary      Translate audio to English text
+// @Description  Sends an OpenAI-compatible multipart audio translation request to the backend model. Translates speech in any language into English.
+// @Tags         AIGateway
+// @Accept       multipart/form-data
+// @Produce      json
+// @Param        model formData string true "Model ID"
+// @Param        file formData file true "Audio file"
+// @Success      200  {object}  types.Response{} "OK"
+// @Failure      400  {object}  error "Bad request"
+// @Failure      404  {object}  error "Model not found"
+// @Failure      500  {object}  error "Internal server error"
+// @Router       /v1/audio/translations [post]
+func (h *OpenAIHandlerImpl) Translation(c *gin.Context) {
+	h.handleAudioSTT(c, audioSTTKindTranslation)
+}
+
+func (h *OpenAIHandlerImpl) handleAudioSTT(c *gin.Context, kind string) {
 	username := httpbase.GetCurrentUser(c)
 	nsUUID := httpbase.GetCurrentNamespaceUUID(c)
 	apikey := httpbase.GetAccessToken(c)
@@ -92,11 +123,21 @@ func (h *OpenAIHandlerImpl) Transcription(c *gin.Context) {
 	modelTarget, err := h.resolveModelTarget(ctx, username, modelID, c.Request.Header)
 	if err != nil {
 		preflight.RecordError(err, "model_resolve")
-		handleModelTargetError(c, ctx, modelID, "failed to get transcription target address", err)
+		handleModelTargetError(c, ctx, modelID, fmt.Sprintf("failed to get %s target address", kind), err)
 		return
 	}
 	preflight.SetTargetModel(modelID, modelTarget)
 	preflight.End()
+
+	traceMetadata := map[string]any{
+		"aigateway.audio.response_format": firstMultipartValue(form, "response_format"),
+		"aigateway.audio.kind":            kind,
+	}
+	if kind == audioSTTKindTranscription {
+		traceMetadata["aigateway.audio.language"] = firstMultipartValue(form, "language")
+	} else {
+		traceMetadata["aigateway.audio.language"] = "english"
+	}
 
 	traceCtx, generationRecorder := h.startModalGenerationTrace(ctx, modalTraceStartInput{
 		API:           c.FullPath(),
@@ -106,10 +147,7 @@ func (h *OpenAIHandlerImpl) Transcription(c *gin.Context) {
 		NSUUID:        nsUUID,
 		ModelID:       modelID,
 		ModelTarget:   modelTarget,
-		Metadata: map[string]any{
-			"aigateway.audio.response_format": firstMultipartValue(form, "response_format"),
-			"aigateway.audio.language":        firstMultipartValue(form, "language"),
-		},
+		Metadata:      traceMetadata,
 	})
 	ctx = traceCtx
 	c.Request = c.Request.WithContext(traceCtx)
@@ -149,17 +187,18 @@ func (h *OpenAIHandlerImpl) Transcription(c *gin.Context) {
 		return
 	}
 
-	proxyToApi := ""
-	if modelTarget.Model.Endpoint != "" {
-		uri, err := url.ParseRequestURI(modelTarget.Model.Endpoint)
-		if err != nil {
-			slog.WarnContext(ctx, "endpoint has wrong struct", slog.String("model", modelTarget.ModelName))
-		} else {
-			proxyToApi = uri.Path
-		}
+	proxyToApi, pathErr := audioSTTProxyPath(kind, modelTarget.Model.Endpoint)
+	if pathErr != nil {
+		slog.WarnContext(ctx, "endpoint has wrong struct", slog.String("model", modelTarget.ModelName), slog.Any("error", pathErr))
 	}
-
-	slog.InfoContext(ctx, "proxy audio transcription request to model endpoint", slog.Any("target", modelTarget.Target), slog.Any("host", modelTarget.Host), slog.Any("user", username), slog.Any("model_id", modelID), slog.Any("model_name", modelTarget.ModelName))
+	slog.InfoContext(ctx, fmt.Sprintf("proxy audio %s request to model endpoint", kind),
+		slog.Any("target", modelTarget.Target),
+		slog.Any("host", modelTarget.Host),
+		slog.Any("user", username),
+		slog.Any("model_id", modelID),
+		slog.Any("model_name", modelTarget.ModelName),
+		slog.String("proxy_path", proxyToApi),
+	)
 
 	audioCounter := token.NewAudioUsageCounter(token.NewTokenizerImpl(modelTarget.Target, modelTarget.Host, modelTarget.ModelName, modelTarget.Model.ImageID, modelTarget.Model.Provider))
 	w := NewResponseWriterWrapperAudio(c.Writer, audioCounter, isStream, adapter)
@@ -174,7 +213,7 @@ func (h *OpenAIHandlerImpl) Transcription(c *gin.Context) {
 			var usageErr error
 			usage, usageErr = audioCounter.Usage(usageCtx)
 			if usageErr != nil {
-				slog.ErrorContext(usageCtx, "failed to get audio transcription token usage", slog.Any("error", usageErr))
+				slog.ErrorContext(usageCtx, fmt.Sprintf("failed to get audio %s token usage", kind), slog.Any("error", usageErr))
 			}
 		}
 		if generationRecorder != nil {
@@ -195,10 +234,53 @@ func (h *OpenAIHandlerImpl) Transcription(c *gin.Context) {
 
 		if w.StatusCode() < http.StatusBadRequest && usage != nil {
 			if err := h.openaiComponent.RecordUsageFromTokenUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, usage, apikey); err != nil {
-				slog.ErrorContext(usageCtx, "failed to record audio transcription usage", slog.Any("error", err))
+				slog.ErrorContext(usageCtx, fmt.Sprintf("failed to record audio %s usage", kind), slog.Any("error", err))
 			}
 		}
 	}()
+}
+
+func audioSTTProxyPath(kind, endpoint string) (string, error) {
+	if kind == audioSTTKindTranslation {
+		return audioTranslationProxyPath(endpoint)
+	}
+	return audioTranscriptionProxyPath(endpoint)
+}
+
+func audioTranscriptionProxyPath(endpoint string) (string, error) {
+	if endpoint == "" {
+		return "", nil
+	}
+	uri, err := url.ParseRequestURI(endpoint)
+	if err != nil {
+		return "", err
+	}
+	return uri.Path, nil
+}
+
+// audioTranslationProxyPath rewrites a model endpoint that points at
+// /audio/transcriptions to /audio/translations so the same Whisper-style
+// deployment can serve OpenAI-compatible translations without a separate
+// endpoint configuration.
+func audioTranslationProxyPath(endpoint string) (string, error) {
+	if endpoint == "" {
+		return audioTranslationsDefaultPath, nil
+	}
+	uri, err := url.ParseRequestURI(endpoint)
+	if err != nil {
+		return audioTranslationsDefaultPath, err
+	}
+	path := uri.Path
+	if path == "" || path == "/" {
+		return audioTranslationsDefaultPath, nil
+	}
+	if strings.HasSuffix(path, audioTranslationsPathSuffix) {
+		return path, nil
+	}
+	if strings.HasSuffix(path, audioTranscriptionsPathSuffix) {
+		return strings.TrimSuffix(path, audioTranscriptionsPathSuffix) + audioTranslationsPathSuffix, nil
+	}
+	return path, nil
 }
 
 func (h *OpenAIHandlerImpl) audioAdapter(model *types.Model) audioadapter.Adapter {

--- a/aigateway/handler/openai_test.go
+++ b/aigateway/handler/openai_test.go
@@ -1794,7 +1794,143 @@ func TestOpenAIHandler_Transcription(t *testing.T) {
 	})
 }
 
+func TestOpenAIHandler_Translation(t *testing.T) {
+	t.Run("rewrites transcriptions endpoint to translations and records usage", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+
+		var downstreamModel string
+		var downstreamPrompt string
+		var downstreamFile string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/v1/audio/translations", r.URL.Path)
+			require.NoError(t, r.ParseMultipartForm(32<<20))
+			downstreamModel = r.FormValue("model")
+			downstreamPrompt = r.FormValue("prompt")
+			file, _, err := r.FormFile("file")
+			require.NoError(t, err)
+			defer file.Close()
+			data, err := io.ReadAll(file)
+			require.NoError(t, err)
+			downstreamFile = string(data)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"text":"hello world","usage":{"prompt_tokens":100,"completion_tokens":20,"total_tokens":120,"seconds":3.5}}`))
+		}))
+		defer server.Close()
+
+		c.Request = newMultipartAudioSTTRequest(t, "/v1/audio/translations", "model1", "audio-bytes", map[string]string{
+			"prompt": "meeting",
+		})
+		c.Set(trace.HeaderRequestID, "req-audio-translate-ok")
+		recorder := &testGenerationRecorderWithMutex{}
+		tracer := &testLLMTracerWithMutex{recorder: recorder}
+		tester.handler.llmTracer = tracer
+		// Endpoint still points at transcriptions (common Whisper deploy); gateway must rewrite.
+		model := &types.Model{
+			BaseModel: types.BaseModel{
+				ID:       "backend-model",
+				Object:   "model",
+				Metadata: map[string]any{},
+				Task:     "audio-transcription",
+			},
+			Endpoint: server.URL + "/v1/audio/transcriptions",
+			Upstreams: []commontypes.UpstreamConfig{
+				{URL: server.URL + "/v1/audio/transcriptions", Enabled: true, ModelName: "backend-model"},
+			},
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").Return(model, nil).Once()
+		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+		tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, mock.Anything, mock.MatchedBy(func(usage *token.Usage) bool {
+			return usage != nil &&
+				usage.TotalTokens == 120 &&
+				usage.PromptTokens == 100 &&
+				usage.CompletionTokens == 20 &&
+				usage.Duration == 3.5
+		}), "").RunAndReturn(
+			func(ctx context.Context, userUUID string, model *types.Model, targetModelName string, usage *token.Usage, apikey string) error {
+				wg.Done()
+				return nil
+			}).Once()
+
+		tester.handler.Translation(c)
+		wg.Wait()
+
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		require.JSONEq(t, `{"text":"hello world","usage":{"prompt_tokens":100,"completion_tokens":20,"total_tokens":120,"seconds":3.5}}`, w.Body.String())
+		require.Equal(t, "backend-model", downstreamModel)
+		require.Equal(t, "meeting", downstreamPrompt)
+		require.Equal(t, "audio-bytes", downstreamFile)
+		starts := tracer.Starts()
+		require.Len(t, starts, 1)
+		require.Equal(t, "translation", starts[0].Metadata["aigateway.audio.kind"])
+		require.Equal(t, "english", starts[0].Metadata["aigateway.audio.language"])
+		usage, response, errorCode, ended, events := generationTraceSnapshot(recorder)
+		require.True(t, ended)
+		require.NotNil(t, response)
+		require.Equal(t, "backend-model", response.Model)
+		require.Equal(t, 3.5, response.Metadata[llmtrace.TraceMetadataKeyAudioDurationSeconds])
+		require.NotNil(t, usage)
+		require.Equal(t, int64(120), usage.TotalTokens)
+		require.Empty(t, errorCode)
+		require.Equal(t, []string{"response", "usage", "end"}, events)
+	})
+
+	t.Run("missing model", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = newMultipartAudioSTTRequest(t, "/v1/audio/translations", "", "audio-bytes", nil)
+
+		tester.handler.Translation(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "Model cannot be empty")
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		require.NoError(t, writer.WriteField("model", "model1"))
+		require.NoError(t, writer.Close())
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/translations", &body)
+		c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+
+		tester.handler.Translation(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "File cannot be empty")
+	})
+}
+
+func TestAudioTranslationProxyPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		want     string
+	}{
+		{name: "empty endpoint", endpoint: "", want: "/v1/audio/translations"},
+		{name: "host only", endpoint: "http://whisper:8000", want: "/v1/audio/translations"},
+		{name: "root path", endpoint: "http://whisper:8000/", want: "/v1/audio/translations"},
+		{name: "rewrites transcriptions", endpoint: "http://whisper:8000/v1/audio/transcriptions", want: "/v1/audio/translations"},
+		{name: "keeps translations", endpoint: "http://whisper:8000/v1/audio/translations", want: "/v1/audio/translations"},
+		{name: "preserves path prefix", endpoint: "http://gateway/maas/whisper/v1/audio/transcriptions", want: "/maas/whisper/v1/audio/translations"},
+		{name: "unknown path unchanged", endpoint: "http://whisper:8000/custom/asr", want: "/custom/asr"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := audioTranslationProxyPath(tt.endpoint)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func newMultipartTranscriptionRequest(t *testing.T, model, fileContent string, fields map[string]string) *http.Request {
+	return newMultipartAudioSTTRequest(t, "/v1/audio/transcriptions", model, fileContent, fields)
+}
+
+func newMultipartAudioSTTRequest(t *testing.T, path, model, fileContent string, fields map[string]string) *http.Request {
 	t.Helper()
 
 	var body bytes.Buffer
@@ -1813,7 +1949,7 @@ func newMultipartTranscriptionRequest(t *testing.T, model, fileContent string, f
 	}
 	require.NoError(t, writer.Close())
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", &body)
+	req := httptest.NewRequest(http.MethodPost, path, &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	return req
 }

--- a/aigateway/router/aigateway.go
+++ b/aigateway/router/aigateway.go
@@ -79,6 +79,7 @@ func NewRouter(config *config.Config) (*gin.Engine, func(), error) {
 	v1Group.POST("/images/generations", middlewareCollection.Auth.MustUserOrgApiKey, modalAPIRateLimiter, openAIhandler.GenerateImage)
 	v1Group.POST("/images/edits", middlewareCollection.Auth.MustUserOrgApiKey, modalAPIRateLimiter, openAIhandler.EditImage)
 	v1Group.POST("/audio/transcriptions", middlewareCollection.Auth.MustUserOrgApiKey, openAIhandler.Transcription)
+	v1Group.POST("/audio/translations", middlewareCollection.Auth.MustUserOrgApiKey, openAIhandler.Translation)
 	v1Group.POST("/audio/speech", middlewareCollection.Auth.MustUserOrgApiKey, modalAPIRateLimiter, openAIhandler.Speech)
 	v1Group.POST("/audio/speech/batch", middlewareCollection.Auth.MustUserOrgApiKey, modalAPIRateLimiter, openAIhandler.SpeechBatch)
 	v1Group.GET("/audio/voices", middlewareCollection.Auth.MustUserOrgApiKey, modalAPIRateLimiter, openAIhandler.ListVoices)

--- a/aigateway/types/common.go
+++ b/aigateway/types/common.go
@@ -7,6 +7,9 @@ import (
 )
 
 func ApplyRequestAuthHeaders(header http.Header, authHeadStr string) error {
+	// Never forward the caller's Authorization to upstream providers.
+	// Empty AuthHead means the upstream needs no auth (e.g. public Whisper space).
+	header.Del("Authorization")
 	if authHeadStr == "" {
 		return nil
 	}

--- a/aigateway/types/common_test.go
+++ b/aigateway/types/common_test.go
@@ -35,3 +35,19 @@ func TestApplyRequestAuthHeaders_Empty(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, header.Get("Authorization"))
 }
+
+func TestApplyRequestAuthHeaders_EmptyStripsCallerAuthorization(t *testing.T) {
+	header := http.Header{}
+	header.Set("Authorization", "Bearer user-api-key")
+	err := ApplyRequestAuthHeaders(header, "")
+	require.NoError(t, err)
+	require.Empty(t, header.Get("Authorization"))
+}
+
+func TestApplyRequestAuthHeaders_ReplacesCallerAuthorization(t *testing.T) {
+	header := http.Header{}
+	header.Set("Authorization", "Bearer user-api-key")
+	err := ApplyRequestAuthHeaders(header, "Bearer provider-token")
+	require.NoError(t, err)
+	require.Equal(t, "Bearer provider-token", header.Get("Authorization"))
+}

--- a/docker/inference/.dockerignore
+++ b/docker/inference/.dockerignore
@@ -1,0 +1,5 @@
+# Keep unit tests out of runtime images (COPY ./funasr/ ...).
+funasr/test_*.py
+funasr/**/__pycache__/
+**/__pycache__/
+*.pyc

--- a/docker/inference/README.md
+++ b/docker/inference/README.md
@@ -224,6 +224,16 @@ curl --max-time 600 -X POST http://127.0.0.1:8000/v1/audio/transcriptions \
   -F "model=local" \
   -F "response_format=text"
 
+# Call FunASR OpenAI-compatible translation API (any language -> English).
+# Only works when REPO_ID is a multilingual Whisper model (e.g. openai/Whisper-large-v3);
+# Whisper-large-v3-turbo and non-Whisper models (Fun-ASR, SenseVoice, Paraformer, Qwen3-ASR)
+# return 501. Translation is passed to the underlying Whisper model via
+# FunASR's DecodingOptions (task=translate).
+curl --max-time 600 -X POST http://127.0.0.1:8000/v1/audio/translations \
+  -F "file=@/path/to/audio.mp3" \
+  -F "model=local" \
+  -F "response_format=text"
+
 # Run image editing with a CSGHub Diffusers model
 docker run -d \
   --name diffusers-test \

--- a/docker/inference/README.md
+++ b/docker/inference/README.md
@@ -225,10 +225,10 @@ curl --max-time 600 -X POST http://127.0.0.1:8000/v1/audio/transcriptions \
   -F "response_format=text"
 
 # Call FunASR OpenAI-compatible translation API (any language -> English).
-# Only works when REPO_ID is a multilingual Whisper model (e.g. openai/Whisper-large-v3);
-# Whisper-large-v3-turbo and non-Whisper models (Fun-ASR, SenseVoice, Paraformer, Qwen3-ASR)
-# return 501. Translation is passed to the underlying Whisper model via
-# FunASR's DecodingOptions (task=translate).
+# Only works when REPO_ID is a multilingual Whisper model (e.g. openai/whisper-large-v3);
+# turbo, English-only (.en) checkpoints (e.g. openai/whisper-small.en), and non-Whisper
+# models (Fun-ASR, SenseVoice, Paraformer, Qwen3-ASR) return 501. Translation is passed
+# to the underlying Whisper model via FunASR's DecodingOptions (task=translate).
 curl --max-time 600 -X POST http://127.0.0.1:8000/v1/audio/translations \
   -F "file=@/path/to/audio.mp3" \
   -F "model=local" \

--- a/docker/inference/funasr/server.py
+++ b/docker/inference/funasr/server.py
@@ -114,12 +114,23 @@ def detect_architecture(model_path: str) -> str:
     return str(model_type) if model_type else ""
 
 
+def is_english_only_whisper(model_id: str) -> bool:
+    """OpenAI English-only Whisper checkpoints use a ".en" name suffix."""
+    name = model_id.strip().lower().rsplit("/", 1)[-1]
+    return name.endswith(".en")
+
+
 def supports_translation(arch: str, model_id: str = "") -> bool:
     if not arch or "whisper" not in arch.lower():
         return False
+    mid = model_id.lower()
     # Whisper turbo variants do not support translation (task=translate is a
     # no-op and returns the source language); exclude them explicitly.
-    if "turbo" in model_id.lower():
+    if "turbo" in mid:
+        return False
+    # English-only checkpoints (e.g. whisper-small.en) cannot translate
+    # arbitrary source languages into English.
+    if is_english_only_whisper(model_id):
         return False
     return True
 
@@ -296,12 +307,16 @@ async def translate(
     response_format: Optional[str] = Form(default="json"),
     stream: bool = Form(default=True),
 ):
+    # Prefer 503 while the model is still loading: MODEL_ARCH is empty until load
+    # finishes, so supports_translation() would otherwise look like a permanent 501.
+    if ASR_MODEL is None:
+        raise HTTPException(status_code=503, detail="model is not loaded")
     if not supports_translation(MODEL_ARCH, MODEL_ID):
         raise HTTPException(
             status_code=501,
             detail=f"audio translation is not supported by model '{MODEL_ID or 'unknown'}' "
             f"(architecture '{MODEL_ARCH or 'unknown'}'); "
-            "only multilingual Whisper models (non-turbo) support translation",
+            "only multilingual Whisper models (non-turbo, non-.en) support translation",
         )
     return await run_audio_stt(file, model, language, hotwords, response_format, stream, task="translate")
 

--- a/docker/inference/funasr/server.py
+++ b/docker/inference/funasr/server.py
@@ -23,6 +23,7 @@ app = FastAPI(title="FunASR OpenAI-Compatible API", version="1.0.0")
 ASR_MODEL = None
 MODEL_ID = "local"
 MODEL_PATH = ""
+MODEL_ARCH = ""
 DEVICE = "cpu"
 VAD_MODEL = ""
 VAD_MAX_SINGLE_SEGMENT_TIME = 30000
@@ -95,7 +96,40 @@ def load_local_model(model_path: str, device: str, vad_model: str, vad_max_singl
     return model
 
 
-def build_generate_kwargs(input_paths: list[str], language: Optional[str], hotwords: Optional[str]) -> dict:
+def detect_architecture(model_path: str) -> str:
+    config_file = Path(model_path) / "config.json"
+    if not config_file.exists():
+        return ""
+    try:
+        with open(config_file, "r", encoding="utf-8") as handle:
+            config = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return ""
+    architectures = config.get("architectures")
+    if isinstance(architectures, list) and architectures:
+        return str(architectures[0])
+    if isinstance(architectures, str) and architectures:
+        return architectures
+    model_type = config.get("model_type")
+    return str(model_type) if model_type else ""
+
+
+def supports_translation(arch: str, model_id: str = "") -> bool:
+    if not arch or "whisper" not in arch.lower():
+        return False
+    # Whisper turbo variants do not support translation (task=translate is a
+    # no-op and returns the source language); exclude them explicitly.
+    if "turbo" in model_id.lower():
+        return False
+    return True
+
+
+def build_generate_kwargs(
+    input_paths: list[str],
+    language: Optional[str],
+    hotwords: Optional[str],
+    task: str = "transcribe",
+) -> dict:
     generate_kwargs = {
         "input": input_paths,
         "cache": {},
@@ -109,11 +143,21 @@ def build_generate_kwargs(input_paths: list[str], language: Optional[str], hotwo
         generate_kwargs["language"] = language
     if hotwords:
         generate_kwargs["hotwords"] = [word.strip() for word in hotwords.split(",") if word.strip()]
+    if task == "translate":
+        # FunASR's AutoModel.generate does not accept a top-level `task` kwarg;
+        # its Whisper wrapper reads `DecodingOptions` from kwargs and builds a
+        # whisper.DecodingOptions from it, which is where `task` must go.
+        generate_kwargs["DecodingOptions"] = {"task": "translate"}
     return generate_kwargs
 
 
-def transcribe_files(input_paths: list[str], language: Optional[str], hotwords: Optional[str]):
-    generate_kwargs = build_generate_kwargs(input_paths, language, hotwords)
+def transcribe_files(
+    input_paths: list[str],
+    language: Optional[str],
+    hotwords: Optional[str],
+    task: str = "transcribe",
+):
+    generate_kwargs = build_generate_kwargs(input_paths, language, hotwords, task)
     return ASR_MODEL.generate(**generate_kwargs)
 
 
@@ -200,6 +244,7 @@ def stream_transcription(
     hotwords: Optional[str],
     response_format: Optional[str],
     audio_duration: float,
+    task: str = "transcribe",
 ):
     try:
         with tempfile.TemporaryDirectory(prefix="funasr-stream-") as chunk_dir:
@@ -207,7 +252,7 @@ def stream_transcription(
             total_chunks = len(chunks)
             for index, chunk_path in enumerate(chunks, start=1):
                 start = time.time()
-                result = transcribe_files([chunk_path], language, hotwords)
+                result = transcribe_files([chunk_path], language, hotwords, task)
                 elapsed = time.time() - start
                 first_result = result[0] if result else {}
                 text = clean_text(first_result.get("text", ""))
@@ -239,6 +284,37 @@ async def transcribe(
     response_format: Optional[str] = Form(default="json"),
     stream: bool = Form(default=True),
 ):
+    return await run_audio_stt(file, model, language, hotwords, response_format, stream, task="transcribe")
+
+
+@app.post("/v1/audio/translations")
+async def translate(
+    file: UploadFile = File(...),
+    model: str = Form(default="local"),
+    language: Optional[str] = Form(default=None),
+    hotwords: Optional[str] = Form(default=None),
+    response_format: Optional[str] = Form(default="json"),
+    stream: bool = Form(default=True),
+):
+    if not supports_translation(MODEL_ARCH, MODEL_ID):
+        raise HTTPException(
+            status_code=501,
+            detail=f"audio translation is not supported by model '{MODEL_ID or 'unknown'}' "
+            f"(architecture '{MODEL_ARCH or 'unknown'}'); "
+            "only multilingual Whisper models (non-turbo) support translation",
+        )
+    return await run_audio_stt(file, model, language, hotwords, response_format, stream, task="translate")
+
+
+async def run_audio_stt(
+    file: UploadFile,
+    model: str,
+    language: Optional[str],
+    hotwords: Optional[str],
+    response_format: Optional[str],
+    stream: bool,
+    task: str,
+):
     if ASR_MODEL is None:
         raise HTTPException(status_code=503, detail="model is not loaded")
 
@@ -257,15 +333,20 @@ async def transcribe(
             tmp_path = ""
             media_type = "application/x-ndjson" if response_format in {"json", "verbose_json"} else "text/plain"
             return StreamingResponse(
-                stream_transcription(tmp_path_for_stream, language, hotwords, response_format, audio_duration),
+                stream_transcription(tmp_path_for_stream, language, hotwords, response_format, audio_duration, task),
                 media_type=media_type,
                 headers=audio_duration_headers(audio_duration),
             )
 
         start = time.time()
-        result = transcribe_files([tmp_path], language, hotwords)
+        result = transcribe_files([tmp_path], language, hotwords, task)
         elapsed = time.time() - start
-        logger.info("Transcribed FunASR request in %.1fs; audio_duration=%.3fs", elapsed, audio_duration)
+        logger.info(
+            "Processed FunASR %s request in %.1fs; audio_duration=%.3fs",
+            task,
+            elapsed,
+            audio_duration,
+        )
 
         first_result = result[0] if result else {}
         text = clean_text(first_result.get("text", ""))
@@ -287,7 +368,7 @@ async def transcribe(
                 {
                     "text": text,
                     "segments": segments,
-                    "language": language or "auto",
+                    "language": "english" if task == "translate" else (language or "auto"),
                     "duration": round(audio_duration, 3),
                     "model": model or MODEL_ID,
                 },
@@ -296,7 +377,7 @@ async def transcribe(
 
         return JSONResponse({"text": text}, headers=audio_duration_headers(audio_duration))
     except Exception as exc:
-        logger.exception("Transcription error")
+        logger.exception("%s error", task)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     finally:
         if tmp_path and os.path.exists(tmp_path):
@@ -334,6 +415,8 @@ async def health():
         "device": DEVICE,
         "model_id": MODEL_ID,
         "model_path": MODEL_PATH,
+        "model_arch": MODEL_ARCH or None,
+        "supports_translation": supports_translation(MODEL_ARCH, MODEL_ID),
         "vad_model": VAD_MODEL or None,
         "vad_max_single_segment_time": VAD_MAX_SINGLE_SEGMENT_TIME,
         "batch_size": BATCH_SIZE,
@@ -384,7 +467,7 @@ def main():
     if unknown_args:
         logger.warning("Ignoring unsupported server args: %s", unknown_args)
 
-    global ASR_MODEL, DEVICE, MODEL_ID, MODEL_PATH
+    global ASR_MODEL, DEVICE, MODEL_ID, MODEL_PATH, MODEL_ARCH
     global VAD_MODEL, VAD_MAX_SINGLE_SEGMENT_TIME, BATCH_SIZE
     global BATCH_SIZE_S, BATCH_SIZE_THRESHOLD_S, STREAM_CHUNK_SECONDS
     DEVICE = args.device
@@ -402,6 +485,16 @@ def main():
         VAD_MODEL,
         VAD_MAX_SINGLE_SEGMENT_TIME,
     )
+    MODEL_ARCH = detect_architecture(args.model_path)
+    if supports_translation(MODEL_ARCH, MODEL_ID):
+        logger.info("Loaded model '%s' (architecture '%s') supports audio translation", MODEL_ID, MODEL_ARCH)
+    else:
+        logger.info(
+            "Loaded model '%s' (architecture '%s') does not support audio translation; "
+            "/v1/audio/translations will return 501",
+            MODEL_ID,
+            MODEL_ARCH or "unknown",
+        )
 
     logger.info("FunASR API server starting on http://%s:%s", args.host, args.port)
     uvicorn.run(app, host=args.host, port=args.port)

--- a/docker/inference/funasr/test_supports_translation.py
+++ b/docker/inference/funasr/test_supports_translation.py
@@ -1,0 +1,78 @@
+"""Unit tests for Whisper translation capability detection (no FunASR runtime needed)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _load_server_module():
+    """Import server.py with heavy optional deps stubbed out."""
+    for name in ("funasr", "uvicorn", "fastapi", "fastapi.responses"):
+        sys.modules.setdefault(name, MagicMock())
+    # FastAPI decorators must still return callables.
+    fastapi_mock = sys.modules["fastapi"]
+    fastapi_mock.FastAPI.return_value = MagicMock()
+    fastapi_mock.File = MagicMock()
+    fastapi_mock.Form = MagicMock()
+    fastapi_mock.HTTPException = type("HTTPException", (Exception,), {})
+    fastapi_mock.UploadFile = MagicMock()
+
+    path = Path(__file__).resolve().parent / "server.py"
+    spec = importlib.util.spec_from_file_location("funasr_server", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+server = _load_server_module()
+
+
+class SupportsTranslationTests(unittest.TestCase):
+    def test_multilingual_whisper_supports_translation(self):
+        self.assertTrue(
+            server.supports_translation("WhisperForConditionalGeneration", "openai/whisper-large-v3")
+        )
+        self.assertTrue(
+            server.supports_translation("whisper", "openai/whisper-small")
+        )
+
+    def test_turbo_whisper_rejects_translation(self):
+        self.assertFalse(
+            server.supports_translation(
+                "WhisperForConditionalGeneration", "openai/whisper-large-v3-turbo"
+            )
+        )
+        self.assertFalse(
+            server.supports_translation("whisper", "Systran/faster-whisper-large-v3-turbo")
+        )
+
+    def test_english_only_whisper_rejects_translation(self):
+        self.assertFalse(
+            server.supports_translation(
+                "WhisperForConditionalGeneration", "openai/whisper-small.en"
+            )
+        )
+        self.assertFalse(
+            server.supports_translation("whisper", "openai/whisper-medium.en")
+        )
+        self.assertFalse(
+            server.supports_translation("whisper", "whisper-tiny.en")
+        )
+
+    def test_non_whisper_rejects_translation(self):
+        self.assertFalse(server.supports_translation("SenseVoiceSmall", "iic/SenseVoiceSmall"))
+        self.assertFalse(server.supports_translation("", "openai/whisper-large-v3"))
+
+    def test_is_english_only_whisper(self):
+        self.assertTrue(server.is_english_only_whisper("openai/whisper-small.en"))
+        self.assertFalse(server.is_english_only_whisper("openai/whisper-small"))
+        self.assertFalse(server.is_english_only_whisper("openai/whisper-large-v3"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- Add POST /v1/audio/translations to AIGateway by reusing the audio STT proxy path and rewriting upstream endpoints from /audio/transcriptions to /audio/translations. Extend the FunASR inference server with the same route for multilingual Whisper (non-turbo) models via FunASR DecodingOptions, returning 501 for unsupported architectures.
- Strip caller Authorization before applying upstream auth headers. Empty AuthHead previously left the client's Bearer token on the proxied request, so public upstreams (e.g. Whisper spaces) rejected it with `AUTH-ERR-5`.
