### PR TITLE
Bump GitPython from 3.1.45 to 3.1.58

### DIFF
--- a/docker/spaces/space/base_requirements.txt
+++ b/docker/spaces/space/base_requirements.txt
@@ -26,7 +26,7 @@ filelock==3.20.1
 frozenlist==1.8.0
 fsspec==2025.12.0
 gitdb==4.0.12
-GitPython==3.1.45
+GitPython==3.1.58
 gradio==6.2.0
 gradio_client==2.0.2
 groovy==0.1.2


### PR DESCRIPTION
Bumps `GitPython` from `3.1.45` to `3.1.58` in `docker/spaces/space/base_requirements.txt`.

**Cleared advisories (23 total):**
- GHSA-4gmw-gg2m-w46p (CVSS 8.1, High) — unguarded git read-tree option forwarding enables arbitrary file overwrite
- PYSEC-2026-2161 (CVSS 9.8) + 21 additional GitPython advisories (GHSA-2f96, GHSA-3f7w, GHSA-3rp5, GHSA-539m, GHSA-6p8h, GHSA-94p4, GHSA-956x, GHSA-9rj7, GHSA-fjr4, GHSA-hh9p, GHSA-hmq2, GHSA-jm78, GHSA-mv93, GHSA-p538, GHSA-r9mr, GHSA-rwj8, GHSA-wvpp, PYSEC-2026-2160, PYSEC-2026-2162, PYSEC-2026-2163, GHSA-7545, GHSA-v87r, GHSA-rpm5)

**Verification:** osv-scanner before: 23 GitPython findings on 3.1.45; after: 0 findings on 3.1.58.

No changes to application logic. Only version pin in requirements file.

Reference: https://github.com/advisories/GHSA-4gmw-gg2m-w46p