### PR TITLE
Support add xpu memory size for physical xpu and mig

### DIFF
--- a/common/types/hardware.go
+++ b/common/types/hardware.go
@@ -25,6 +25,7 @@ const (
 	UnAvailableTypeDisableScheduling    ResourceReasonType = "disable_scheduling"
 	UnAvailableTypeNodeOffline          ResourceReasonType = "node_offline"
 	UnAvailableTypePriceUndefined       ResourceReasonType = "price_undefined"
+	UnAvailableTypeWrongMemResource     ResourceReasonType = "wrong_mem_resource"
 )
 
 type (


### PR DESCRIPTION
Summary:
- Main scope: 支持独立显卡和 MIG 配置显存（mem_size）后，修正 `checkNodeResource` 中的调度判断逻辑，避免物理GPU填写了 `mem_size` 后被错误拒绝调度。.
- Additional context: Issue #2513 要求独立显卡配置算力规格时增加显存配置（`mem_size`）。但当前 `checkNodeResource` 中有一段逻辑：.