### PR TITLE
Support prompt cached token in accounting

### DIFF
--- a/builder/store/database/account_bill.go
+++ b/builder/store/database/account_bill.go
@@ -35,27 +35,28 @@ func NewAccountBillStoreWithDB(db *DB) AccountBillStore {
 }
 
 type AccountBill struct {
-	ID              int64             `bun:",pk,autoincrement" json:"id"`
-	BillDate        time.Time         `bun:"type:date" json:"bill_date"`
-	UserUUID        string            `bun:",notnull" json:"user_uuid"`
-	Scene           types.SceneType   `bun:",notnull" json:"scene"`
-	CustomerID      string            `bun:",notnull" json:"customer_id"`
-	Value           float64           `bun:",notnull" json:"value"`
-	Consumption     float64           `bun:",notnull" json:"consumption"`
-	PromptToken     float64           `bun:",notnull" json:"prompt_token"`
-	CompletionToken float64           `bun:",notnull" json:"completion_token"`
-	APIKey          string            `bun:",notnull,default:''" json:"api_key"`
-	Count           float64           `bun:",notnull,default:0" json:"count"`
-	TokenID         int64             `bun:",notnull,default:0" json:"token_id"`
-	DataType        string            `bun:",notnull,default:''" json:"data_type"`
-	Resolution      string            `bun:",notnull,default:''" json:"resolution"`
-	Duration        float64           `bun:",notnull,default:0" json:"duration"`
-	VoucherNo       string            `bun:",notnull,default:''" json:"voucher_no"`
-	VoucherValue    float64           `bun:",notnull,default:0" json:"voucher_value"`
-	CashValue       float64           `bun:",notnull,default:0" json:"cash_value"`
-	UnitType        types.SkuUnitType `bun:",notnull,default:''" json:"unit_type"`
-	ClusterID       string            `bun:",notnull,default:''" json:"cluster_id"`
-	HardwareType    string            `bun:",notnull,default:''" json:"hardware_type"`
+	ID                int64             `bun:",pk,autoincrement" json:"id"`
+	BillDate          time.Time         `bun:"type:date" json:"bill_date"`
+	UserUUID          string            `bun:",notnull" json:"user_uuid"`
+	Scene             types.SceneType   `bun:",notnull" json:"scene"`
+	CustomerID        string            `bun:",notnull" json:"customer_id"`
+	Value             float64           `bun:",notnull" json:"value"`
+	Consumption       float64           `bun:",notnull" json:"consumption"`
+	PromptToken       float64           `bun:",notnull" json:"prompt_token"`
+	PromptCachedToken float64           `bun:",notnull" json:"prompt_cached_token"`
+	CompletionToken   float64           `bun:",notnull" json:"completion_token"`
+	APIKey            string            `bun:",notnull,default:''" json:"api_key"`
+	Count             float64           `bun:",notnull,default:0" json:"count"`
+	TokenID           int64             `bun:",notnull,default:0" json:"token_id"`
+	DataType          string            `bun:",notnull,default:''" json:"data_type"`
+	Resolution        string            `bun:",notnull,default:''" json:"resolution"`
+	Duration          float64           `bun:",notnull,default:0" json:"duration"`
+	VoucherNo         string            `bun:",notnull,default:''" json:"voucher_no"`
+	VoucherValue      float64           `bun:",notnull,default:0" json:"voucher_value"`
+	CashValue         float64           `bun:",notnull,default:0" json:"cash_value"`
+	UnitType          types.SkuUnitType `bun:",notnull,default:''" json:"unit_type"`
+	ClusterID         string            `bun:",notnull,default:''" json:"cluster_id"`
+	HardwareType      string            `bun:",notnull,default:''" json:"hardware_type"`
 	times
 }
 
@@ -72,14 +73,15 @@ type BillResource struct {
 }
 
 type TotalResult struct {
-	TotalValue           float64 `bun:"total_value"`
-	TotalConsumption     float64 `bun:"total_consumption"`
-	TotalPromptToken     float64 `bun:"total_prompt_token"`
-	TotalCompletionToken float64 `bun:"total_completion_token"`
-	TotalVoucherValue    float64 `bun:"total_voucher_value"`
-	TotalCashValue       float64 `bun:"total_cash_value"`
-	TotalDuration        float64 `bun:"total_duration"`
-	TotalCount           float64 `bun:"total_count"`
+	TotalValue             float64 `bun:"total_value"`
+	TotalConsumption       float64 `bun:"total_consumption"`
+	TotalPromptToken       float64 `bun:"total_prompt_token"`
+	TotalPromptCachedToken float64 `bun:"total_prompt_cached_token"`
+	TotalCompletionToken   float64 `bun:"total_completion_token"`
+	TotalVoucherValue      float64 `bun:"total_voucher_value"`
+	TotalCashValue         float64 `bun:"total_cash_value"`
+	TotalDuration          float64 `bun:"total_duration"`
+	TotalCount             float64 `bun:"total_count"`
 }
 
 type AccountBillRes struct {
@@ -103,6 +105,7 @@ func (s *accountBillStoreImpl) ListByUserIDAndDate(ctx context.Context, req type
 		ColumnExpr("sum(value) as value").
 		ColumnExpr("sum(consumption) as consumption").
 		ColumnExpr("sum(prompt_token) as prompt_token").
+		ColumnExpr("sum(prompt_cached_token) as prompt_cached_token").
 		ColumnExpr("sum(completion_token) as completion_token").
 		ColumnExpr("sum(voucher_value) as voucher_value").
 		ColumnExpr("sum(cash_value) as cash_value").
@@ -145,6 +148,7 @@ func (s *accountBillStoreImpl) ListByUserIDAndDate(ctx context.Context, req type
 		ColumnExpr("SUM(value) AS total_value").
 		ColumnExpr("SUM(consumption) as total_consumption").
 		ColumnExpr("SUM(prompt_token) as total_prompt_token").
+		ColumnExpr("SUM(prompt_cached_token) as total_prompt_cached_token").
 		ColumnExpr("SUM(completion_token) as total_completion_token").
 		ColumnExpr("SUM(voucher_value) as total_voucher_value").
 		ColumnExpr("SUM(cash_value) as total_cash_value").
@@ -168,15 +172,16 @@ func (s *accountBillStoreImpl) ListByUserIDAndDate(ctx context.Context, req type
 	return AccountBillRes{
 		Data: res,
 		AcctSummary: types.AcctSummary{
-			Total:                count,
-			TotalValue:           totalResult.TotalValue,
-			TotalConsumption:     totalResult.TotalConsumption,
-			TotalPromptToken:     totalResult.TotalPromptToken,
-			TotalCompletionToken: totalResult.TotalCompletionToken,
-			TotalVoucherValue:    totalResult.TotalVoucherValue,
-			TotalCashValue:       totalResult.TotalCashValue,
-			TotalDuration:        totalResult.TotalDuration,
-			TotalCount:           totalResult.TotalCount,
+			Total:                  count,
+			TotalValue:             totalResult.TotalValue,
+			TotalConsumption:       totalResult.TotalConsumption,
+			TotalPromptToken:       totalResult.TotalPromptToken,
+			TotalPromptCachedToken: totalResult.TotalPromptCachedToken,
+			TotalCompletionToken:   totalResult.TotalCompletionToken,
+			TotalVoucherValue:      totalResult.TotalVoucherValue,
+			TotalCashValue:         totalResult.TotalCashValue,
+			TotalDuration:          totalResult.TotalDuration,
+			TotalCount:             totalResult.TotalCount,
 		},
 	}, err
 }

--- a/builder/store/database/account_price.go
+++ b/builder/store/database/account_price.go
@@ -65,6 +65,7 @@ type AccountPrice struct {
 	UseLimitPrice    int64             `json:"use_limit_price"`
 	Resolution       string            `json:"resolution"`
 	SkuStatus        types.SkuStatus   `bun:",default:1" json:"sku_status"`
+	SkuCachedPrice   int64             `json:"sku_cached_price"`
 	times
 }
 
@@ -238,12 +239,13 @@ func (a *accountPriceStoreImpl) ListByIds(ctx context.Context, ids []int64) ([]*
 	res := make([]*types.AcctPriceResp, len(result))
 	for index, price := range result {
 		res[index] = &types.AcctPriceResp{
-			Id:        price.ID,
-			SkuType:   price.SkuType,
-			SkuPrice:  price.SkuPrice,
-			SkuKind:   price.SkuKind,
-			SkuDesc:   price.SkuDesc,
-			SkuStatus: price.SkuStatus,
+			Id:             price.ID,
+			SkuType:        price.SkuType,
+			SkuPrice:       price.SkuPrice,
+			SkuKind:        price.SkuKind,
+			SkuDesc:        price.SkuDesc,
+			SkuStatus:      price.SkuStatus,
+			SkuCachedPrice: price.SkuCachedPrice,
 		}
 	}
 

--- a/builder/store/database/account_statement.go
+++ b/builder/store/database/account_statement.go
@@ -50,45 +50,46 @@ func NewAccountStatementStoreWithDB(db *DB) AccountStatementStore {
 }
 
 type AccountStatement struct {
-	ID               int64                 `bun:",pk,autoincrement" json:"id"`
-	EventUUID        uuid.UUID             `bun:"type:uuid,notnull" json:"event_uuid"`
-	UserUUID         string                `bun:",notnull" json:"user_uuid"`
-	Value            float64               `bun:",notnull" json:"value"`
-	Scene            types.SceneType       `bun:",notnull" json:"scene"`
-	OpUID            string                `bun:",nullzero" json:"op_uid"`
-	CreatedAt        time.Time             `bun:",notnull,skipupdate,default:current_timestamp" json:"created_at"`
-	CustomerID       string                `json:"customer_id"`
-	EventDate        time.Time             `bun:"type:date" json:"event_date"`
-	Price            float64               `json:"price"`
-	PriceUnit        string                `json:"price_unit"`
-	Consumption      float64               `json:"consumption"`
-	ValueType        types.ChargeValueType `json:"value_type"`
-	ResourceID       string                `json:"resource_id"`
-	ResourceName     string                `json:"resource_name"`
-	SkuID            int64                 `json:"sku_id"`
-	RecordedAt       time.Time             `json:"recorded_at"`
-	SkuUnit          int64                 `json:"sku_unit"`
-	SkuUnitType      types.SkuUnitType     `json:"sku_unit_type"`
-	SkuPriceCurrency string                `json:"sku_price_currency"`
-	BalanceType      string                `json:"balance_type"`
-	BalanceValue     float64               `json:"balance_value"`
-	IsCancel         bool                  `json:"is_cancel"`
-	EventValue       float64               `json:"event_value"`
-	Present          *AccountPresent       `bun:"rel:has-one,join:event_uuid=event_uuid"`
-	Quota            float64               `bun:",nullzero" json:"quota"`
-	SubBillID        int64                 `bun:",nullzero" json:"sub_bill_id"`
-	Discount         float64               `json:"discount"`
-	RegularValue     float64               `json:"regular_value"`
-	PromptToken      float64               `json:"prompt_token"`
-	CompletionToken  float64               `json:"completion_token"`
-	APIKey           string                `bun:",notnull,default:''" json:"api_key"`
-	TokenID          int64                 `bun:",notnull,default:0" json:"token_id"`
-	Purpose          types.RechargePurpose `bun:",nullzero" json:"purpose"`
-	PurposeDesc      string                `bun:",nullzero" json:"purpose_desc"`
-	DataType         string                `bun:",notnull,default:''" json:"data_type"`
-	Resolution       string                `bun:",notnull,default:''" json:"resolution"`
-	Duration         float64               `bun:",notnull,default:0" json:"duration"`
-	VoucherNo        string                `bun:",nullzero" json:"voucher_no"`
+	ID                int64                 `bun:",pk,autoincrement" json:"id"`
+	EventUUID         uuid.UUID             `bun:"type:uuid,notnull" json:"event_uuid"`
+	UserUUID          string                `bun:",notnull" json:"user_uuid"`
+	Value             float64               `bun:",notnull" json:"value"`
+	Scene             types.SceneType       `bun:",notnull" json:"scene"`
+	OpUID             string                `bun:",nullzero" json:"op_uid"`
+	CreatedAt         time.Time             `bun:",notnull,skipupdate,default:current_timestamp" json:"created_at"`
+	CustomerID        string                `json:"customer_id"`
+	EventDate         time.Time             `bun:"type:date" json:"event_date"`
+	Price             float64               `json:"price"`
+	PriceUnit         string                `json:"price_unit"`
+	Consumption       float64               `json:"consumption"`
+	ValueType         types.ChargeValueType `json:"value_type"`
+	ResourceID        string                `json:"resource_id"`
+	ResourceName      string                `json:"resource_name"`
+	SkuID             int64                 `json:"sku_id"`
+	RecordedAt        time.Time             `json:"recorded_at"`
+	SkuUnit           int64                 `json:"sku_unit"`
+	SkuUnitType       types.SkuUnitType     `json:"sku_unit_type"`
+	SkuPriceCurrency  string                `json:"sku_price_currency"`
+	BalanceType       string                `json:"balance_type"`
+	BalanceValue      float64               `json:"balance_value"`
+	IsCancel          bool                  `json:"is_cancel"`
+	EventValue        float64               `json:"event_value"`
+	Present           *AccountPresent       `bun:"rel:has-one,join:event_uuid=event_uuid"`
+	Quota             float64               `bun:",nullzero" json:"quota"`
+	SubBillID         int64                 `bun:",nullzero" json:"sub_bill_id"`
+	Discount          float64               `json:"discount"`
+	RegularValue      float64               `json:"regular_value"`
+	PromptToken       float64               `json:"prompt_token"`
+	PromptCachedToken float64               `json:"prompt_cached_token"`
+	CompletionToken   float64               `json:"completion_token"`
+	APIKey            string                `bun:",notnull,default:''" json:"api_key"`
+	TokenID           int64                 `bun:",notnull,default:0" json:"token_id"`
+	Purpose           types.RechargePurpose `bun:",nullzero" json:"purpose"`
+	PurposeDesc       string                `bun:",nullzero" json:"purpose_desc"`
+	DataType          string                `bun:",notnull,default:''" json:"data_type"`
+	Resolution        string                `bun:",notnull,default:''" json:"resolution"`
+	Duration          float64               `bun:",notnull,default:0" json:"duration"`
+	VoucherNo         string                `bun:",nullzero" json:"voucher_no"`
 }
 
 type AccountStatementRes struct {
@@ -655,24 +656,25 @@ func updateFeeBill(ctx context.Context, tx bun.Tx, input AccountStatement, billV
 	if billValues.TotalValue != 0 {
 		// calculate bill
 		bill := AccountBill{
-			BillDate:        input.EventDate,
-			UserUUID:        input.UserUUID,
-			Scene:           input.Scene,
-			CustomerID:      input.CustomerID,
-			Value:           billValues.TotalValue,
-			Consumption:     billValues.Consumption,
-			PromptToken:     input.PromptToken,
-			CompletionToken: input.CompletionToken,
-			Count:           1,
-			TokenID:         input.TokenID,
-			DataType:        input.DataType,
-			Resolution:      input.Resolution,
-			Duration:        input.Duration,
-			VoucherNo:       input.VoucherNo,
-			VoucherValue:    billValues.VoucherValue,
-			CashValue:       billValues.CashValue,
-			ClusterID:       billRes.ClusterID,
-			HardwareType:    billRes.HardwareType,
+			BillDate:          input.EventDate,
+			UserUUID:          input.UserUUID,
+			Scene:             input.Scene,
+			CustomerID:        input.CustomerID,
+			Value:             billValues.TotalValue,
+			Consumption:       billValues.Consumption,
+			PromptToken:       input.PromptToken,
+			PromptCachedToken: input.PromptCachedToken,
+			CompletionToken:   input.CompletionToken,
+			Count:             1,
+			TokenID:           input.TokenID,
+			DataType:          input.DataType,
+			Resolution:        input.Resolution,
+			Duration:          input.Duration,
+			VoucherNo:         input.VoucherNo,
+			VoucherValue:      billValues.VoucherValue,
+			CashValue:         billValues.CashValue,
+			ClusterID:         billRes.ClusterID,
+			HardwareType:      billRes.HardwareType,
 		}
 		if input.Scene == types.SceneMultiModalServerless {
 			bill.UnitType = input.SkuUnitType
@@ -684,6 +686,7 @@ func updateFeeBill(ctx context.Context, tx bun.Tx, input AccountStatement, billV
 			Set("value = account_bill.value + ?", billValues.TotalValue).
 			Set("consumption = account_bill.consumption + ?", billValues.Consumption).
 			Set("prompt_token = account_bill.prompt_token + ?", input.PromptToken).
+			Set("prompt_cached_token = account_bill.prompt_cached_token + ?", input.PromptCachedToken).
 			Set("completion_token = account_bill.completion_token + ?", input.CompletionToken).
 			Set("duration = account_bill.duration + ?", input.Duration).
 			Set("count = account_bill.count + ?", 1).

--- a/builder/store/database/migrations/20260803095321_add_columns_for_cached_token_to_account.down.sql
+++ b/builder/store/database/migrations/20260803095321_add_columns_for_cached_token_to_account.down.sql
@@ -1,0 +1,13 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE account_prices DROP COLUMN IF EXISTS sku_cached_price;
+
+--bun:split
+
+ALTER TABLE account_statements DROP COLUMN IF EXISTS prompt_cached_token;
+
+--bun:split
+
+ALTER TABLE account_bills DROP COLUMN IF EXISTS prompt_cached_token;

--- a/builder/store/database/migrations/20260803095321_add_columns_for_cached_token_to_account.up.sql
+++ b/builder/store/database/migrations/20260803095321_add_columns_for_cached_token_to_account.up.sql
@@ -1,0 +1,14 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE account_prices ADD COLUMN IF NOT EXISTS sku_cached_price bigint DEFAULT -1;
+
+--bun:split
+
+ALTER TABLE account_statements ADD COLUMN IF NOT EXISTS prompt_cached_token DOUBLE PRECISION DEFAULT 0;
+
+--bun:split
+
+ALTER TABLE account_bills ADD COLUMN IF NOT EXISTS prompt_cached_token DOUBLE PRECISION DEFAULT 0;
+

--- a/common/types/accounting.go
+++ b/common/types/accounting.go
@@ -20,6 +20,7 @@ const (
 	OrderDetailID        = "order_detail_id"
 	MeterFromSource      = "from_source"
 	PromptTokenNum       = "prompt_token_num"
+	PromptTokenCacheNum  = "prompt_token_cache_num"
 	CompletionTokenNum   = "completion_token_num"
 	OwnerType            = "owner_type"
 	ConsumeApiKey        = "api_key"
@@ -131,7 +132,7 @@ var (
 	SceneModelFinetune        SceneType = 12 // model finetune
 	SceneMultiSync            SceneType = 13 // multi source sync
 	SceneEvaluation           SceneType = 14 // model evaluation
-	SceneModelServerless      SceneType = 15 // serverless and external model from aigateway
+	SceneModelServerless      SceneType = 15 // serverless and external model text from aigateway
 	SceneMultiModalServerless SceneType = 16 // Multi modal model from aigateway for image/audio/video/ocr
 	// starship
 	SceneStarship SceneType = 20 // starship is deprecated
@@ -181,36 +182,37 @@ var (
 )
 
 type AcctEventReq struct {
-	EventUUID        uuid.UUID       `json:"event_uuid"`
-	UserUUID         string          `json:"user_uuid"`
-	Value            float64         `json:"value"`
-	Scene            SceneType       `json:"scene"`
-	OpUID            string          `json:"op_uid"`
-	CustomerID       string          `json:"customer_id"`
-	EventDate        time.Time       `json:"event_date"`
-	Price            float64         `json:"price"`
-	PriceUnit        string          `json:"price_unit"`
-	Consumption      float64         `json:"consumption"`
-	ValueType        ChargeValueType `json:"value_type"`
-	ResourceID       string          `json:"resource_id"`
-	ResourceName     string          `json:"resource_name"`
-	SkuID            int64           `json:"sku_id"`
-	RecordedAt       time.Time       `json:"recorded_at"`
-	SkuUnit          int64           `json:"sku_unit"`
-	SkuUnitType      SkuUnitType     `json:"sku_unit_type"`
-	SkuPriceCurrency string          `json:"sku_price_currency"`
-	Quota            float64         `json:"quota"`
-	SubBillID        int64           `json:"sub_bill_id"`
-	Discount         float64         `json:"discount"`
-	RegularValue     float64         `json:"regular_value"`
-	PromptToken      float64         `json:"prompt_token"`
-	CompletionToken  float64         `json:"completion_token"`
-	ApiKey           string          `json:"api_key"`
-	Purpose          RechargePurpose `json:"purpose"`
-	PurposeDesc      string          `json:"purpose_desc"`
-	DataType         string          `json:"data_type"`
-	Resolution       string          `json:"resolution"`
-	Duration         float64         `json:"duration"`
+	EventUUID         uuid.UUID       `json:"event_uuid"`
+	UserUUID          string          `json:"user_uuid"`
+	Value             float64         `json:"value"`
+	Scene             SceneType       `json:"scene"`
+	OpUID             string          `json:"op_uid"`
+	CustomerID        string          `json:"customer_id"`
+	EventDate         time.Time       `json:"event_date"`
+	Price             float64         `json:"price"`
+	PriceUnit         string          `json:"price_unit"`
+	Consumption       float64         `json:"consumption"`
+	ValueType         ChargeValueType `json:"value_type"`
+	ResourceID        string          `json:"resource_id"`
+	ResourceName      string          `json:"resource_name"`
+	SkuID             int64           `json:"sku_id"`
+	RecordedAt        time.Time       `json:"recorded_at"`
+	SkuUnit           int64           `json:"sku_unit"`
+	SkuUnitType       SkuUnitType     `json:"sku_unit_type"`
+	SkuPriceCurrency  string          `json:"sku_price_currency"`
+	Quota             float64         `json:"quota"`
+	SubBillID         int64           `json:"sub_bill_id"`
+	Discount          float64         `json:"discount"`
+	RegularValue      float64         `json:"regular_value"`
+	PromptToken       float64         `json:"prompt_token"`
+	PromptCachedToken float64         `json:"prompt_cached_token"`
+	CompletionToken   float64         `json:"completion_token"`
+	ApiKey            string          `json:"api_key"`
+	Purpose           RechargePurpose `json:"purpose"`
+	PurposeDesc       string          `json:"purpose_desc"`
+	DataType          string          `json:"data_type"`
+	Resolution        string          `json:"resolution"`
+	Duration          float64         `json:"duration"`
 }
 
 // generate charge event from client
@@ -343,36 +345,38 @@ type AcctQuotaStatementReq struct {
 }
 
 type AcctSummary struct {
-	Total                int     `json:"total"`
-	TotalValue           float64 `json:"total_value"`
-	TotalConsumption     float64 `json:"total_consumption"`
-	TotalPromptToken     float64 `json:"total_prompt_token"`
-	TotalCompletionToken float64 `json:"total_completion_token"`
-	TotalVoucherValue    float64 `json:"total_voucher_value"`
-	TotalCashValue       float64 `json:"total_cash_value"`
-	TotalDuration        float64 `json:"total_duration"`
-	TotalCount           float64 `json:"total_count"`
+	Total                  int     `json:"total"`
+	TotalValue             float64 `json:"total_value"`
+	TotalConsumption       float64 `json:"total_consumption"`
+	TotalPromptToken       float64 `json:"total_prompt_token"`
+	TotalPromptCachedToken float64 `json:"total_prompt_cached_token"`
+	TotalCompletionToken   float64 `json:"total_completion_token"`
+	TotalVoucherValue      float64 `json:"total_voucher_value"`
+	TotalCashValue         float64 `json:"total_cash_value"`
+	TotalDuration          float64 `json:"total_duration"`
+	TotalCount             float64 `json:"total_count"`
 }
 
 type ITEM struct {
-	Consumption     float64     `json:"consumption"`
-	InstanceName    string      `json:"instance_name"`
-	Value           float64     `json:"value"`
-	CreatedAt       time.Time   `json:"created_at"`
-	Status          string      `json:"status"`
-	RepoPath        string      `json:"repo_path"`
-	DeployID        int64       `json:"deploy_id"`
-	DeployName      string      `json:"deploy_name"`
-	DeployUser      string      `json:"deploy_user"`
-	PromptToken     float64     `json:"prompt_token"`
-	CompletionToken float64     `json:"completion_token"`
-	VoucherValue    float64     `json:"voucher_value"`
-	CashValue       float64     `json:"cash_value"`
-	Duration        float64     `json:"duration"`
-	Count           float64     `json:"count"`
-	DataType        string      `json:"data_type"`
-	Resolution      string      `json:"resolution"`
-	UnitType        SkuUnitType `json:"unit_type"`
+	Consumption       float64     `json:"consumption"`
+	InstanceName      string      `json:"instance_name"`
+	Value             float64     `json:"value"`
+	CreatedAt         time.Time   `json:"created_at"`
+	Status            string      `json:"status"`
+	RepoPath          string      `json:"repo_path"`
+	DeployID          int64       `json:"deploy_id"`
+	DeployName        string      `json:"deploy_name"`
+	DeployUser        string      `json:"deploy_user"`
+	PromptToken       float64     `json:"prompt_token"`
+	PromptCachedToken float64     `json:"prompt_cached_token"`
+	CompletionToken   float64     `json:"completion_token"`
+	VoucherValue      float64     `json:"voucher_value"`
+	CashValue         float64     `json:"cash_value"`
+	Duration          float64     `json:"duration"`
+	Count             float64     `json:"count"`
+	DataType          string      `json:"data_type"`
+	Resolution        string      `json:"resolution"`
+	UnitType          SkuUnitType `json:"unit_type"`
 }
 
 type BILLS struct {
@@ -414,6 +418,7 @@ type AcctPriceCreateReq struct {
 	UseLimitPrice    int64       `json:"use_limit_price"`
 	Resolution       string      `json:"resolution"`
 	SkuStatus        SkuStatus   `json:"sku_status" binding:"required,oneof=1 9"`
+	SkuCachedPrice   *int64      `json:"sku_cached_price"`
 }
 
 type AcctPriceBatchCreateReq struct {
@@ -435,6 +440,7 @@ type AcctPriceUpdateReq struct {
 	UseLimitPrice    *int64       `json:"use_limit_price"`
 	Resolution       *string      `json:"resolution"`
 	SkuStatus        *SkuStatus   `json:"sku_status"`
+	SkuCachedPrice   *int64       `json:"sku_cached_price"`
 }
 
 type AcctPriceResp struct {
@@ -450,6 +456,7 @@ type AcctPriceResp struct {
 	Quota            string    `json:"quota"`
 	SkuPriceID       int64     `json:"sku_price_id"`
 	SkuStatus        SkuStatus `json:"sku_status"`
+	SkuCachedPrice   int64     `json:"sku_cached_price"`
 }
 
 type AcctPriceQueryReq struct {
@@ -557,6 +564,7 @@ type AcctPriceDetail struct {
 	UseLimitPrice    int64       `json:"use_limit_price"`
 	Resolution       string      `json:"resolution"`
 	CreatedAt        time.Time   `json:"created_at"`
+	SkuCachedPrice   int64       `json:"sku_cached_price"`
 }
 
 type AcctRechargeReq struct {


### PR DESCRIPTION
Summary:
- Main scope: 当前 AI Gateway 仅对 input tokens 和 output tokens 统一计费，未区分缓存命中（cache_read）的 prompt tokens。主流模型（如智谱 GLM、OpenAI、Anthropic）已支持 .