### PR TITLE
[Manual Sync Required] Optimize models index API

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_ModelStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_ModelStore.go
@@ -268,6 +268,65 @@ func (_c *MockModelStore_ByRepoIDs_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+// ByRepoIDsBasic provides a mock function with given fields: ctx, repoIDs
+func (_m *MockModelStore) ByRepoIDsBasic(ctx context.Context, repoIDs []int64) ([]database.Model, error) {
+	ret := _m.Called(ctx, repoIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ByRepoIDsBasic")
+	}
+
+	var r0 []database.Model
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []int64) ([]database.Model, error)); ok {
+		return rf(ctx, repoIDs)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []int64) []database.Model); ok {
+		r0 = rf(ctx, repoIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Model)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []int64) error); ok {
+		r1 = rf(ctx, repoIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockModelStore_ByRepoIDsBasic_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ByRepoIDsBasic'
+type MockModelStore_ByRepoIDsBasic_Call struct {
+	*mock.Call
+}
+
+// ByRepoIDsBasic is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repoIDs []int64
+func (_e *MockModelStore_Expecter) ByRepoIDsBasic(ctx interface{}, repoIDs interface{}) *MockModelStore_ByRepoIDsBasic_Call {
+	return &MockModelStore_ByRepoIDsBasic_Call{Call: _e.mock.On("ByRepoIDsBasic", ctx, repoIDs)}
+}
+
+func (_c *MockModelStore_ByRepoIDsBasic_Call) Run(run func(ctx context.Context, repoIDs []int64)) *MockModelStore_ByRepoIDsBasic_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]int64))
+	})
+	return _c
+}
+
+func (_c *MockModelStore_ByRepoIDsBasic_Call) Return(models []database.Model, err error) *MockModelStore_ByRepoIDsBasic_Call {
+	_c.Call.Return(models, err)
+	return _c
+}
+
+func (_c *MockModelStore_ByRepoIDsBasic_Call) RunAndReturn(run func(context.Context, []int64) ([]database.Model, error)) *MockModelStore_ByRepoIDsBasic_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ByUsername provides a mock function with given fields: ctx, username, per, page, onlyPublic
 func (_m *MockModelStore) ByUsername(ctx context.Context, username string, per int, page int, onlyPublic bool) ([]database.Model, int, error) {
 	ret := _m.Called(ctx, username, per, page, onlyPublic)

--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoStore.go
@@ -2107,6 +2107,77 @@ func (_c *MockRepoStore_PublicToUser_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
+// PublicToUserV2 provides a mock function with given fields: ctx, repoType, ownerNamespaces, filter, per, page, isAdmin
+func (_m *MockRepoStore) PublicToUserV2(ctx context.Context, repoType types.RepositoryType, ownerNamespaces []string, filter *types.RepoFilter, per int, page int, isAdmin bool) ([]*database.Repository, int, error) {
+	ret := _m.Called(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PublicToUserV2")
+	}
+
+	var r0 []*database.Repository
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, []string, *types.RepoFilter, int, int, bool) ([]*database.Repository, int, error)); ok {
+		return rf(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, []string, *types.RepoFilter, int, int, bool) []*database.Repository); ok {
+		r0 = rf(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*database.Repository)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, types.RepositoryType, []string, *types.RepoFilter, int, int, bool) int); ok {
+		r1 = rf(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, types.RepositoryType, []string, *types.RepoFilter, int, int, bool) error); ok {
+		r2 = rf(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// MockRepoStore_PublicToUserV2_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PublicToUserV2'
+type MockRepoStore_PublicToUserV2_Call struct {
+	*mock.Call
+}
+
+// PublicToUserV2 is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repoType types.RepositoryType
+//   - ownerNamespaces []string
+//   - filter *types.RepoFilter
+//   - per int
+//   - page int
+//   - isAdmin bool
+func (_e *MockRepoStore_Expecter) PublicToUserV2(ctx interface{}, repoType interface{}, ownerNamespaces interface{}, filter interface{}, per interface{}, page interface{}, isAdmin interface{}) *MockRepoStore_PublicToUserV2_Call {
+	return &MockRepoStore_PublicToUserV2_Call{Call: _e.mock.On("PublicToUserV2", ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)}
+}
+
+func (_c *MockRepoStore_PublicToUserV2_Call) Run(run func(ctx context.Context, repoType types.RepositoryType, ownerNamespaces []string, filter *types.RepoFilter, per int, page int, isAdmin bool)) *MockRepoStore_PublicToUserV2_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.RepositoryType), args[2].([]string), args[3].(*types.RepoFilter), args[4].(int), args[5].(int), args[6].(bool))
+	})
+	return _c
+}
+
+func (_c *MockRepoStore_PublicToUserV2_Call) Return(repos []*database.Repository, count int, err error) *MockRepoStore_PublicToUserV2_Call {
+	_c.Call.Return(repos, count, err)
+	return _c
+}
+
+func (_c *MockRepoStore_PublicToUserV2_Call) RunAndReturn(run func(context.Context, types.RepositoryType, []string, *types.RepoFilter, int, int, bool) ([]*database.Repository, int, error)) *MockRepoStore_PublicToUserV2_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RefreshLFSObjectsSize provides a mock function with given fields: ctx, id
 func (_m *MockRepoStore) RefreshLFSObjectsSize(ctx context.Context, id int64) error {
 	ret := _m.Called(ctx, id)

--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_TagStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_TagStore.go
@@ -848,6 +848,65 @@ func (_c *MockTagStore_AllTagsWithPagination_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// ByRepoIDs provides a mock function with given fields: ctx, repoIDs
+func (_m *MockTagStore) ByRepoIDs(ctx context.Context, repoIDs []int64) (map[int64][]database.Tag, error) {
+	ret := _m.Called(ctx, repoIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ByRepoIDs")
+	}
+
+	var r0 map[int64][]database.Tag
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []int64) (map[int64][]database.Tag, error)); ok {
+		return rf(ctx, repoIDs)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []int64) map[int64][]database.Tag); ok {
+		r0 = rf(ctx, repoIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[int64][]database.Tag)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []int64) error); ok {
+		r1 = rf(ctx, repoIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockTagStore_ByRepoIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ByRepoIDs'
+type MockTagStore_ByRepoIDs_Call struct {
+	*mock.Call
+}
+
+// ByRepoIDs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repoIDs []int64
+func (_e *MockTagStore_Expecter) ByRepoIDs(ctx interface{}, repoIDs interface{}) *MockTagStore_ByRepoIDs_Call {
+	return &MockTagStore_ByRepoIDs_Call{Call: _e.mock.On("ByRepoIDs", ctx, repoIDs)}
+}
+
+func (_c *MockTagStore_ByRepoIDs_Call) Run(run func(ctx context.Context, repoIDs []int64)) *MockTagStore_ByRepoIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]int64))
+	})
+	return _c
+}
+
+func (_c *MockTagStore_ByRepoIDs_Call) Return(_a0 map[int64][]database.Tag, _a1 error) *MockTagStore_ByRepoIDs_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockTagStore_ByRepoIDs_Call) RunAndReturn(run func(context.Context, []int64) (map[int64][]database.Tag, error)) *MockTagStore_ByRepoIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CheckTagIDsExist provides a mock function with given fields: ctx, ids
 func (_m *MockTagStore) CheckTagIDsExist(ctx context.Context, ids []int64) error {
 	ret := _m.Called(ctx, ids)

--- a/_mocks/opencsg.com/csghub-server/component/mock_ModelComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_ModelComponent.go
@@ -570,6 +570,75 @@ func (_c *MockModelComponent_Index_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
+// IndexV2 provides a mock function with given fields: ctx, filter, per, page, needOpWeight
+func (_m *MockModelComponent) IndexV2(ctx context.Context, filter *types.RepoFilter, per int, page int, needOpWeight bool) ([]*types.Model, int, error) {
+	ret := _m.Called(ctx, filter, per, page, needOpWeight)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IndexV2")
+	}
+
+	var r0 []*types.Model
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, *types.RepoFilter, int, int, bool) ([]*types.Model, int, error)); ok {
+		return rf(ctx, filter, per, page, needOpWeight)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *types.RepoFilter, int, int, bool) []*types.Model); ok {
+		r0 = rf(ctx, filter, per, page, needOpWeight)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*types.Model)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *types.RepoFilter, int, int, bool) int); ok {
+		r1 = rf(ctx, filter, per, page, needOpWeight)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, *types.RepoFilter, int, int, bool) error); ok {
+		r2 = rf(ctx, filter, per, page, needOpWeight)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// MockModelComponent_IndexV2_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IndexV2'
+type MockModelComponent_IndexV2_Call struct {
+	*mock.Call
+}
+
+// IndexV2 is a helper method to define mock.On call
+//   - ctx context.Context
+//   - filter *types.RepoFilter
+//   - per int
+//   - page int
+//   - needOpWeight bool
+func (_e *MockModelComponent_Expecter) IndexV2(ctx interface{}, filter interface{}, per interface{}, page interface{}, needOpWeight interface{}) *MockModelComponent_IndexV2_Call {
+	return &MockModelComponent_IndexV2_Call{Call: _e.mock.On("IndexV2", ctx, filter, per, page, needOpWeight)}
+}
+
+func (_c *MockModelComponent_IndexV2_Call) Run(run func(ctx context.Context, filter *types.RepoFilter, per int, page int, needOpWeight bool)) *MockModelComponent_IndexV2_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*types.RepoFilter), args[2].(int), args[3].(int), args[4].(bool))
+	})
+	return _c
+}
+
+func (_c *MockModelComponent_IndexV2_Call) Return(_a0 []*types.Model, _a1 int, _a2 error) *MockModelComponent_IndexV2_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *MockModelComponent_IndexV2_Call) RunAndReturn(run func(context.Context, *types.RepoFilter, int, int, bool) ([]*types.Model, int, error)) *MockModelComponent_IndexV2_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListAllByRuntimeFramework provides a mock function with given fields: ctx, currentUser, deployType
 func (_m *MockModelComponent) ListAllByRuntimeFramework(ctx context.Context, currentUser string, deployType int) ([]database.RuntimeFramework, error) {
 	ret := _m.Called(ctx, currentUser, deployType)

--- a/_mocks/opencsg.com/csghub-server/component/mock_RepoComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_RepoComponent.go
@@ -3831,6 +3831,76 @@ func (_c *MockRepoComponent_PublicToUser_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// PublicToUserV2 provides a mock function with given fields: ctx, repoType, userName, filter, per, page
+func (_m *MockRepoComponent) PublicToUserV2(ctx context.Context, repoType types.RepositoryType, userName string, filter *types.RepoFilter, per int, page int) ([]*database.Repository, int, error) {
+	ret := _m.Called(ctx, repoType, userName, filter, per, page)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PublicToUserV2")
+	}
+
+	var r0 []*database.Repository
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, string, *types.RepoFilter, int, int) ([]*database.Repository, int, error)); ok {
+		return rf(ctx, repoType, userName, filter, per, page)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, types.RepositoryType, string, *types.RepoFilter, int, int) []*database.Repository); ok {
+		r0 = rf(ctx, repoType, userName, filter, per, page)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*database.Repository)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, types.RepositoryType, string, *types.RepoFilter, int, int) int); ok {
+		r1 = rf(ctx, repoType, userName, filter, per, page)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, types.RepositoryType, string, *types.RepoFilter, int, int) error); ok {
+		r2 = rf(ctx, repoType, userName, filter, per, page)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// MockRepoComponent_PublicToUserV2_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PublicToUserV2'
+type MockRepoComponent_PublicToUserV2_Call struct {
+	*mock.Call
+}
+
+// PublicToUserV2 is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repoType types.RepositoryType
+//   - userName string
+//   - filter *types.RepoFilter
+//   - per int
+//   - page int
+func (_e *MockRepoComponent_Expecter) PublicToUserV2(ctx interface{}, repoType interface{}, userName interface{}, filter interface{}, per interface{}, page interface{}) *MockRepoComponent_PublicToUserV2_Call {
+	return &MockRepoComponent_PublicToUserV2_Call{Call: _e.mock.On("PublicToUserV2", ctx, repoType, userName, filter, per, page)}
+}
+
+func (_c *MockRepoComponent_PublicToUserV2_Call) Run(run func(ctx context.Context, repoType types.RepositoryType, userName string, filter *types.RepoFilter, per int, page int)) *MockRepoComponent_PublicToUserV2_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(types.RepositoryType), args[2].(string), args[3].(*types.RepoFilter), args[4].(int), args[5].(int))
+	})
+	return _c
+}
+
+func (_c *MockRepoComponent_PublicToUserV2_Call) Return(repos []*database.Repository, count int, err error) *MockRepoComponent_PublicToUserV2_Call {
+	_c.Call.Return(repos, count, err)
+	return _c
+}
+
+func (_c *MockRepoComponent_PublicToUserV2_Call) RunAndReturn(run func(context.Context, types.RepositoryType, string, *types.RepoFilter, int, int) ([]*database.Repository, int, error)) *MockRepoComponent_PublicToUserV2_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RelatedRepos provides a mock function with given fields: ctx, repoID, currentUser
 func (_m *MockRepoComponent) RelatedRepos(ctx context.Context, repoID int64, currentUser string) (map[types.RepositoryType][]*database.Repository, error) {
 	ret := _m.Called(ctx, repoID, currentUser)

--- a/api/handler/model.go
+++ b/api/handler/model.go
@@ -115,6 +115,103 @@ func (h *ModelHandler) Index(ctx *gin.Context) {
 	httpbase.OKWithTotal(ctx, models, total)
 }
 
+// IndexV2 godoc
+// @Security     ApiKey
+// @Summary      Get visible models (V2 - basic data only, fast)
+// @Description  get visible models returning only basic repository fields for fast initial render. Use /models/enrich for enrichment data.
+// @Tags         Model
+// @Accept       json
+// @Produce      json
+// @Param        current_user query string false "current user"
+// @Param        search query string false "search text"
+// @Param        task_tag query string false "filter by task tag, deprecated"
+// @Param        framework_tag query string false "filter by framework tag, deprecated"
+// @Param        license_tag query string false "filter by license tag, deprecated"
+// @Param        language_tag query string false "filter by language tag, deprecated"
+// @Param        tag_category query string false "filter by tag category"
+// @Param        tag_name query string false "filter by tag name"
+// @Param        tag_group query string false "filter by tag group"
+// @Param        sort query string false "sort by"
+// @Param        source query string false "source" Enums(opencsg, huggingface, local)
+// @Param        xnet_migration_status query string false "filter by xnet migration status"
+// @Param        per query int false "per" default(20)
+// @Param        page query int false "per page" default(1)
+// @Param        model_tree query string false "example: base_model:finetune:1"
+// @Param        list_serverless query bool false "list serverless" default(false)
+// @Param        model_params_min query number false "minimum model parameters in billions"
+// @Param        model_params_max query number false "maximum model parameters in billions"
+// @Success      200  {object}  types.ResponseWithTotal{data=[]types.Model,total=int} "OK"
+// @Failure      400  {object}  types.APIBadRequest "Bad request"
+// @Failure      500  {object}  types.APIInternalServerError "Internal server error"
+// @Router       /models/v2 [get]
+func (h *ModelHandler) IndexV2(ctx *gin.Context) {
+	filter := new(types.RepoFilter)
+	filter.Tags = parseTagReqs(ctx)
+	tree, err := parseTreeReqs(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx.Request.Context(), "Bad request format", "error", err)
+		httpbase.BadRequestWithExt(ctx, err)
+		return
+	}
+	filter.Tree = tree
+	filter.Username = httpbase.GetCurrentUser(ctx)
+	per, page, err := common.GetPerAndPageFromContext(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx.Request.Context(), "Bad request format", "error", err)
+		httpbase.BadRequestWithExt(ctx, err)
+		return
+	}
+	filter = getFilterFromContext(ctx, filter)
+	filter.ModelParamsMin, filter.ModelParamsMax, err = parseFloatRangeFromContext(ctx, "model_params_min", "model_params_max")
+	if err != nil {
+		slog.ErrorContext(ctx.Request.Context(), "Bad model params range request format,", slog.Any("error", err))
+		httpbase.BadRequestWithExt(ctx, errorx.ReqParamInvalid(err, errorx.Ctx().Set("query", "model_params_range")))
+		return
+	}
+	if !slices.Contains(types.Sorts, filter.Sort) {
+		msg := fmt.Sprintf("sort parameter must be one of %v", types.Sorts)
+		err := errorx.ReqParamInvalid(errors.New(msg),
+			errorx.Ctx().
+				Set("param", "sort").
+				Set("provided", filter.Sort).
+				Set("allowed", types.Sorts))
+		slog.ErrorContext(ctx.Request.Context(), "Bad request format,", slog.String("error", msg))
+		httpbase.BadRequestWithExt(ctx, err)
+		return
+	}
+
+	if filter.Source != "" && !slices.Contains(types.Sources, filter.Source) {
+		msg := fmt.Sprintf("source parameter must be one of %v", types.Sources)
+		err := errorx.ReqParamInvalid(errors.New(msg),
+			errorx.Ctx().
+				Set("param", "source").
+				Set("provided", filter.Source).
+				Set("allowed", types.Sources))
+		slog.ErrorContext(ctx.Request.Context(), "Bad request format,", slog.String("error", msg))
+		httpbase.BadRequestWithExt(ctx, err)
+		return
+	}
+
+	qNeedOpWeight := ctx.Query("need_op_weight")
+	needOpWeight, err := strconv.ParseBool(qNeedOpWeight)
+	if err != nil {
+		needOpWeight = false
+	}
+	listServerlessQ := ctx.Query("list_serverless")
+	if listServerlessQ != "" {
+		listServerless, _ := strconv.ParseBool(listServerlessQ)
+		filter.ListServerless = listServerless
+	}
+	models, total, err := h.model.IndexV2(ctx.Request.Context(), filter, per, page, needOpWeight)
+	if err != nil {
+		slog.ErrorContext(ctx.Request.Context(), "Failed to get models v2", slog.Any("error", err))
+		httpbase.ServerError(ctx, err)
+		return
+	}
+	slog.Info("Get public models v2 succeed", slog.Int("count", total))
+	httpbase.OKWithTotal(ctx, models, total)
+}
+
 // CreateModel   godoc
 // @Security     ApiKey
 // @Summary      Create a new model

--- a/api/handler/model_test.go
+++ b/api/handler/model_test.go
@@ -329,3 +329,74 @@ func TestModelHandler_DeleteInferenceVersion_ServiceError(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
+
+func TestModelHandler_IndexV2_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	mc := mockcomponent.NewMockModelComponent(t)
+	mc.EXPECT().IndexV2(mock.Anything, mock.Anything, 10, 2, false).Return([]*types.Model{
+		{ID: 1, Name: "model1", Path: "u/model1"},
+		{ID: 2, Name: "model2", Path: "u/model2"},
+	}, 100, nil)
+
+	handler := &ModelHandler{model: mc}
+	router.GET("/api/v1/models/v2", handler.IndexV2)
+
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/api/v1/models/v2?per=10&page=2&sort=trending", nil)
+
+	router.ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestModelHandler_IndexV2_InvalidSort(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	mc := mockcomponent.NewMockModelComponent(t)
+
+	handler := &ModelHandler{model: mc}
+	router.GET("/api/v1/models/v2", handler.IndexV2)
+
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/api/v1/models/v2?sort=invalid_sort", nil)
+
+	router.ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestModelHandler_IndexV2_InvalidSource(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	mc := mockcomponent.NewMockModelComponent(t)
+
+	handler := &ModelHandler{model: mc}
+	router.GET("/api/v1/models/v2", handler.IndexV2)
+
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/api/v1/models/v2?source=invalid", nil)
+
+	router.ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestModelHandler_IndexV2_ServiceError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	mc := mockcomponent.NewMockModelComponent(t)
+	mc.EXPECT().IndexV2(mock.Anything, mock.Anything, 10, 1, false).Return(nil, 0, errors.New("db error"))
+
+	handler := &ModelHandler{model: mc}
+	router.GET("/api/v1/models/v2", handler.IndexV2)
+
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/api/v1/models/v2?per=10&page=1", nil)
+
+	router.ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+

--- a/api/router/api.go
+++ b/api/router/api.go
@@ -644,6 +644,8 @@ func createModelRoutes(config *config.Config,
 	{
 		modelsGroup.POST("", middlewareCollection.Auth.NeedPhoneVerified, modelHandler.Create)
 		modelsGroup.GET("", cache.Cache(memoryStore, time.Minute, middleware.CacheStrategyTrendingRepos()), modelHandler.Index)
+		// V2 API for faster model list loading
+		modelsGroup.GET("/v2", modelHandler.IndexV2)
 		modelsGroup.PUT("/:namespace/:name", middlewareCollection.Auth.NeedLogin, modelHandler.Update)
 		modelsGroup.DELETE("/:namespace/:name", middlewareCollection.Auth.NeedLogin, modelHandler.Delete)
 		modelsGroup.GET("/:namespace/:name", cache.Cache(memoryStore, time.Minute*2, middleware.CacheRepoInfo()), modelHandler.Show)

--- a/builder/store/database/model.go
+++ b/builder/store/database/model.go
@@ -32,6 +32,9 @@ type ModelStore interface {
 	ByID(ctx context.Context, id int64) (*Model, error)
 	CreateIfNotExist(ctx context.Context, input Model) (*Model, error)
 	CreateAndUpdateRepoPath(ctx context.Context, input Model, path string) (*Model, error)
+	// ByRepoIDsBasic returns model rows without any Relation eager-loading.
+	// Only model table columns (ID, RepositoryID) are populated — fast for ID mapping.
+	ByRepoIDsBasic(ctx context.Context, repoIDs []int64) (models []Model, err error)
 }
 
 func NewModelStore() ModelStore {
@@ -64,6 +67,17 @@ func (s *modelStoreImpl) ByRepoIDs(ctx context.Context, repoIDs []int64) (models
 		Relation("Repository").
 		Relation("Repository.Mirror").
 		Relation("Repository.Mirror.CurrentTask").
+		Where("model.repository_id in (?)", bun.In(repoIDs)).
+		Scan(ctx)
+	err = errorx.HandleDBError(err, nil)
+	return
+}
+
+// ByRepoIDsBasic returns model rows without any Relation eager-loading.
+// Only model table columns (ID, RepositoryID) are populated. Fast for ID mapping.
+func (s *modelStoreImpl) ByRepoIDsBasic(ctx context.Context, repoIDs []int64) (models []Model, err error) {
+	err = s.db.Operator.Core.NewSelect().
+		Model(&models).
 		Where("model.repository_id in (?)", bun.In(repoIDs)).
 		Scan(ctx)
 	err = errorx.HandleDBError(err, nil)

--- a/builder/store/database/repository.go
+++ b/builder/store/database/repository.go
@@ -78,6 +78,8 @@ type RepoStore interface {
 	TagIDs(ctx context.Context, repoID int64, category string) (tagIDs []int64, err error)
 	SetUpdateTimeByPath(ctx context.Context, repoType types.RepositoryType, namespace, name string, update time.Time) error
 	PublicToUser(ctx context.Context, repoType types.RepositoryType, ownerNamespaces []string, filter *types.RepoFilter, per, page int, isAdmin bool) (repos []*Repository, count int, err error)
+	// PublicToUserV2 is like PublicToUser but skips eager-loading of Tags for faster list queries
+	PublicToUserV2(ctx context.Context, repoType types.RepositoryType, ownerNamespaces []string, filter *types.RepoFilter, per, page int, isAdmin bool) (repos []*Repository, count int, err error)
 	IsMirrorRepo(ctx context.Context, repoType types.RepositoryType, namespace, name string) (bool, error)
 	ListRepoByDeployType(ctx context.Context, repoType types.RepositoryType, userID int64, search, sort string, deployType, per, page int) (repos []*Repository, count int, err error)
 	WithMirror(ctx context.Context, per, page int) (repos []Repository, count int, err error)
@@ -1087,6 +1089,317 @@ func (s *repoStoreImpl) publicToUserTrending(ctx context.Context, repoType types
 			repos[i].Tags = tagMap[repos[i].ID]
 		}
 	}
+
+	return
+}
+
+// PublicToUserV2 is like PublicToUser but skips eager-loading of Tags.
+// Tags and mirror data are fetched separately via the enrichment API for better list performance.
+func (s *repoStoreImpl) PublicToUserV2(ctx context.Context, repoType types.RepositoryType, ownerNamespaces []string, filter *types.RepoFilter, per, page int, isAdmin bool) (repos []*Repository, count int, err error) {
+	if filter.Sort == "trending" && strings.TrimSpace(filter.Search) == "" {
+		return s.publicToUserTrendingV2(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
+	}
+
+	q := s.db.Operator.Core.
+		NewSelect().
+		Column("repository.*").
+		Model(&repos)
+	// V2: skip Relation("Tags") - tags are fetched via enrichment API
+
+	q.Where("repository.repository_type = ?", repoType)
+	if filter.Owner != "" {
+		q.Where("repository.path LIKE ? ESCAPE '\\'", fmt.Sprintf("%s/%%", escapeLikePattern(filter.Owner)))
+	}
+
+	switch repoType {
+	case types.ModelRepo:
+		q.Join("INNER JOIN models ON models.repository_id = repository.id")
+	case types.DatasetRepo:
+		q.Join("INNER JOIN datasets ON datasets.repository_id = repository.id")
+	case types.CodeRepo:
+		q.Join("INNER JOIN codes ON codes.repository_id = repository.id")
+	case types.SpaceRepo:
+		q.Join("INNER JOIN spaces ON spaces.repository_id = repository.id")
+	case types.PromptRepo:
+		q.Join("INNER JOIN prompts ON prompts.repository_id = repository.id")
+	case types.MCPServerRepo:
+		q.Join("INNER JOIN mcp_servers ON mcp_servers.repository_id = repository.id")
+	case types.SkillRepo:
+		q.Join("INNER JOIN skills ON skills.repository_id = repository.id")
+	}
+
+	if !isAdmin {
+		if len(ownerNamespaces) > 0 {
+			q.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
+				q = q.Where("repository.private = ?", false)
+				for _, namespace := range ownerNamespaces {
+					q = q.WhereOr("repository.path LIKE ? ESCAPE '\\'", fmt.Sprintf("%s/%%", escapeLikePattern(namespace)))
+				}
+				return q
+			})
+		} else {
+			q.Where("repository.private = ?", false)
+		}
+	}
+
+	needDistinct := false
+	if filter.Source != "" {
+		if filter.Source == "local" {
+			q.Where(`(
+				repository.source = 'local'
+				OR EXISTS (
+					SELECT 1 FROM mirrors m
+					JOIN mirror_tasks mt ON mt.mirror_id = m.id
+					WHERE m.repository_id = repository.id
+					  AND mt.status = ?
+				)
+			)`, types.MirrorLfsSyncFinished)
+		} else {
+			q.Where("repository.source = ?", filter.Source)
+		}
+	}
+
+	if filter.XnetMigrationStatus != nil {
+		q.Join("LEFT JOIN xnet_migration_tasks ON xnet_migration_tasks.id = repository.current_xnet_migration_task_id").
+			Where("xnet_migration_tasks.status = ?", *filter.XnetMigrationStatus)
+		needDistinct = true
+	}
+
+	if filter.Tree != nil {
+		q.Where("repository.id IN (SELECT target_repo_id FROM model_trees WHERE source_repo_id = ? and relation = ?)", filter.Tree.RepoId, filter.Tree.Relation)
+	}
+
+	if filter.ListServerless {
+		q.Where("repository.id IN (SELECT repo_id FROM deploys WHERE type = ? and status = ?)", types.ServerlessType, common.Running)
+	}
+
+	if len(filter.SpaceSDK) > 0 {
+		q.Where("EXISTS (SELECT 1 FROM spaces s WHERE s.repository_id = repository.id AND s.sdk = ?)", filter.SpaceSDK)
+	}
+
+	if repoType == types.DatasetRepo && filter.DatasetType != "" {
+		q.Where("datasets.dataset_type = ?", filter.DatasetType)
+	}
+	applyRepoRangeFilters(q, repoType, "repository", filter)
+
+	if repoType == types.DatasetRepo && filter.UserPurchased && filter.Username != "" {
+		var purchasedDatasetIDs []int64
+		userUUIDQuery := s.db.Operator.Core.NewSelect().
+			Column("uuid").
+			Model(&User{}).
+			Where("username = ?", filter.Username)
+
+		err := s.db.Operator.Core.NewSelect().
+			ColumnExpr("CAST(resource_id AS bigint) as dataset_id").
+			Model(&AccountStatement{}).
+			Where("scene = ?", types.SceneDatasetPurchase).
+			Where("user_uuid = (?)", userUUIDQuery).
+			Where("value < 0").
+			Scan(ctx, &purchasedDatasetIDs)
+
+		if err == nil && len(purchasedDatasetIDs) > 0 {
+			q.Where("datasets.related_dataset_id IN (?)", bun.In(purchasedDatasetIDs))
+		} else {
+			return []*Repository{}, 0, nil
+		}
+	}
+
+	if len(filter.Tags) > 0 {
+		for i, tag := range filter.Tags {
+			var asRepoTag = fmt.Sprintf("%s%d", "rt", i)
+			var asTag = fmt.Sprintf("%s%d", "ts", i)
+			q.Join(fmt.Sprintf("JOIN repository_tags AS %s ON repository.id = %s.repository_id", asRepoTag, asRepoTag)).
+				Join(fmt.Sprintf("JOIN tags AS %s ON %s.tag_id = %s.id", asTag, asRepoTag, asTag))
+			if tag.Category != "" {
+				q.Where(fmt.Sprintf("%s.category = ?", asTag), tag.Category)
+			}
+			if tag.Name != "" {
+				q.Where(fmt.Sprintf("%s.name = ?", asTag), tag.Name)
+			}
+			if tag.Group != "" {
+				q.Where(fmt.Sprintf("%s.group = ?", asTag), tag.Group)
+			}
+		}
+		needDistinct = true
+	}
+
+	if needDistinct {
+		q.Distinct()
+	}
+
+	filter.Search = strings.TrimSpace(filter.Search)
+	if filter.Search != "" {
+		filter.Search = strings.ToLower(filter.Search)
+		repos, count, err = s.SearchRepoWithCache(ctx, q, repoType, filter, per, page)
+		err = errorx.HandleDBError(err, errorx.Ctx().
+			Set("repo_type", repoType).
+			Set("filter", filter),
+		)
+		return
+	}
+
+	q.Order(sortBy[filter.Sort])
+
+	count, err = q.Count(ctx)
+	err = errorx.HandleDBError(err, errorx.Ctx().
+		Set("repo_type", repoType).
+		Set("filter", filter),
+	)
+	if err != nil {
+		return
+	}
+
+	err = q.Limit(per).Offset((page - 1) * per).Scan(ctx)
+
+	return
+}
+
+// publicToUserTrendingV2 is like publicToUserTrending but skips post-hoc tag batch loading.
+func (s *repoStoreImpl) publicToUserTrendingV2(ctx context.Context, repoType types.RepositoryType, ownerNamespaces []string, filter *types.RepoFilter, per, page int, isAdmin bool) (repos []*Repository, count int, err error) {
+	repoTypeTable := map[types.RepositoryType]string{
+		types.ModelRepo:     "models",
+		types.DatasetRepo:   "datasets",
+		types.CodeRepo:      "codes",
+		types.SpaceRepo:     "spaces",
+		types.PromptRepo:    "prompts",
+		types.MCPServerRepo: "mcp_servers",
+		types.SkillRepo:     "skills",
+	}
+	bizTable, ok := repoTypeTable[repoType]
+	if !ok {
+		return
+	}
+
+	q := s.db.Operator.Core.
+		NewSelect().
+		ColumnExpr("r.*, rrs.score AS popularity").
+		TableExpr("recom_repo_scores AS rrs").
+		Join("JOIN repositories AS r ON r.id = rrs.repository_id").
+		Where("rrs.weight_name = ?", RecomWeightTotal).
+		Where("r.repository_type = ?", repoType)
+	if filter.Owner != "" {
+		q.Where("r.path LIKE ? ESCAPE '\\'", fmt.Sprintf("%s/%%", escapeLikePattern(filter.Owner)))
+	}
+
+	q.Join(fmt.Sprintf("INNER JOIN %s ON %s.repository_id = r.id", bizTable, bizTable))
+
+	if repoType == types.DatasetRepo && filter.DatasetType != "" {
+		q.Where("datasets.dataset_type = ?", filter.DatasetType)
+	}
+	applyRepoRangeFilters(q, repoType, "r", filter)
+
+	if repoType == types.DatasetRepo && filter.UserPurchased && filter.Username != "" {
+		var purchasedDatasetIDs []int64
+		userUUIDQuery := s.db.Operator.Core.NewSelect().
+			Column("uuid").
+			Model(&User{}).
+			Where("username = ?", filter.Username)
+
+		err := s.db.Operator.Core.NewSelect().
+			ColumnExpr("CAST(resource_id AS bigint) as dataset_id").
+			Model(&AccountStatement{}).
+			Where("scene = ?", types.SceneDatasetPurchase).
+			Where("user_uuid = (?)", userUUIDQuery).
+			Where("value < 0").
+			Scan(ctx, &purchasedDatasetIDs)
+
+		if err == nil && len(purchasedDatasetIDs) > 0 {
+			q.Where("datasets.related_dataset_id IN (?)", bun.In(purchasedDatasetIDs))
+		} else {
+			return []*Repository{}, 0, nil
+		}
+	}
+
+	q.Where("r.deleted_at IS NULL").
+		Where(fmt.Sprintf("EXISTS (SELECT 1 FROM %s m WHERE m.repository_id = r.id)", bizTable))
+
+	if !isAdmin {
+		if len(ownerNamespaces) > 0 {
+			q.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
+				q = q.Where("r.private = ?", false)
+				for _, namespace := range ownerNamespaces {
+					q = q.WhereOr("r.path LIKE ? ESCAPE '\\'", fmt.Sprintf("%s/%%", escapeLikePattern(namespace)))
+				}
+				return q
+			})
+		} else {
+			q.Where("r.private = ?", false)
+		}
+	}
+
+	if filter.Source != "" {
+		if filter.Source == "local" {
+			q.Where(`(
+				r.source = 'local'
+				OR EXISTS (
+					SELECT 1 FROM mirrors m
+					JOIN mirror_tasks mt ON mt.mirror_id = m.id
+					WHERE m.repository_id = r.id
+					  AND mt.status = ?
+				)
+			)`, types.MirrorLfsSyncFinished)
+		} else {
+			q.Where("r.source = ?", filter.Source)
+		}
+	}
+
+	if filter.XnetMigrationStatus != nil {
+		q.Where(`EXISTS (
+			SELECT 1 FROM xnet_migration_tasks xmt
+			WHERE xmt.id = r.current_xnet_migration_task_id
+			  AND xmt.status = ?
+		)`, *filter.XnetMigrationStatus)
+	}
+
+	if filter.Tree != nil {
+		q.Where("r.id IN (SELECT target_repo_id FROM model_trees WHERE source_repo_id = ? AND relation = ?)", filter.Tree.RepoId, filter.Tree.Relation)
+	}
+
+	if filter.ListServerless {
+		q.Where("r.id IN (SELECT repo_id FROM deploys WHERE type = ? AND status = ?)", types.ServerlessType, common.Running)
+	}
+
+	if len(filter.SpaceSDK) > 0 {
+		q.Where("EXISTS (SELECT 1 FROM spaces s WHERE s.repository_id = r.id AND s.sdk = ?)", filter.SpaceSDK)
+	}
+
+	if len(filter.Tags) > 0 {
+		for i, tag := range filter.Tags {
+			asRepoTag := fmt.Sprintf("rt%d", i)
+			asTag := fmt.Sprintf("ts%d", i)
+			q.Join(fmt.Sprintf("JOIN repository_tags AS %s ON r.id = %s.repository_id", asRepoTag, asRepoTag)).
+				Join(fmt.Sprintf("JOIN tags AS %s ON %s.tag_id = %s.id", asTag, asRepoTag, asTag))
+			if tag.Category != "" {
+				q.Where(fmt.Sprintf("%s.category = ?", asTag), tag.Category)
+			}
+			if tag.Name != "" {
+				q.Where(fmt.Sprintf("%s.name = ?", asTag), tag.Name)
+			}
+			if tag.Group != "" {
+				q.Where(fmt.Sprintf("%s.group = ?", asTag), tag.Group)
+			}
+		}
+		q.Distinct()
+	}
+
+	count, err = q.Count(ctx)
+	err = errorx.HandleDBError(err, errorx.Ctx().
+		Set("repo_type", repoType).
+		Set("filter", filter),
+	)
+	if err != nil {
+		return
+	}
+
+	err = q.OrderExpr("rrs.score DESC NULLS LAST").
+		Limit(per).
+		Offset((page-1)*per).
+		Scan(ctx, &repos)
+	err = errorx.HandleDBError(err, errorx.Ctx().
+		Set("repo_type", repoType).
+		Set("filter", filter),
+	)
+	// V2: skip post-hoc tag batch loading - tags are fetched via enrichment API
 
 	return
 }

--- a/builder/store/database/tag.go
+++ b/builder/store/database/tag.go
@@ -55,6 +55,8 @@ type TagStore interface {
 	DeleteCategory(ctx context.Context, id int64) error
 	CheckTagIDsExist(ctx context.Context, ids []int64) error
 	CheckTagIDsExistInScope(ctx context.Context, ids []int64, scope types.TagScope, category string) error
+	// ByRepoIDs returns tags grouped by repository ID for batch enrichment
+	ByRepoIDs(ctx context.Context, repoIDs []int64) (map[int64][]Tag, error)
 }
 
 func NewTagStore() TagStore {
@@ -663,6 +665,32 @@ func (ts *tagStoreImpl) CheckTagIDsExistInScope(ctx context.Context, ids []int64
 		return ErrTagIDsNotFoundInScope
 	}
 	return nil
+}
+
+// ByRepoIDs returns tags grouped by repository ID for the given repo IDs.
+func (ts *tagStoreImpl) ByRepoIDs(ctx context.Context, repoIDs []int64) (map[int64][]Tag, error) {
+	if len(repoIDs) == 0 {
+		return make(map[int64][]Tag), nil
+	}
+
+	var repoTags []RepositoryTag
+	err := ts.db.Operator.Core.
+		NewSelect().
+		Model(&repoTags).
+		Relation("Tag").
+		Where("repository_tag.repository_id IN (?)", bun.In(repoIDs)).
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tags by repo ids: %w", err)
+	}
+
+	result := make(map[int64][]Tag, len(repoIDs))
+	for _, rt := range repoTags {
+		if rt.Tag != nil {
+			result[rt.RepositoryID] = append(result[rt.RepositoryID], *rt.Tag)
+		}
+	}
+	return result, nil
 }
 
 // ErrTagIDsNotFoundInScope is returned when some tag IDs do not exist or belong to the wrong scope/category.

--- a/common/types/repo.go
+++ b/common/types/repo.go
@@ -467,9 +467,14 @@ type BatchRepoExtraReq struct {
 }
 
 type RepoExtraItem struct {
-	RepoID         int64 `json:"repo_id"`
-	Size           int64 `json:"size"`
-	LastCommitSize int64 `json:"last_commit_size"`
+	RepoID           int64            `json:"repo_id"`
+	Size             int64            `json:"size"`
+	LastCommitSize   int64            `json:"last_commit_size"`
+	Tags             []RepoTag        `json:"tags,omitempty"`
+	MirrorTaskStatus MirrorTaskStatus `json:"mirror_task_status,omitempty"`
+	MultiSource      MultiSource      `json:"multi_source,omitempty"`
+	Repository       *Repository      `json:"repository,omitempty"`
+	ReportURL        string           `json:"report_url,omitempty"`
 }
 
 type RepoSizeResponse struct {

--- a/component/model.go
+++ b/component/model.go
@@ -69,6 +69,8 @@ saved_model/**/* filter=lfs diff=lfs merge=lfs -text
 
 type ModelComponent interface {
 	Index(ctx context.Context, filter *types.RepoFilter, per, page int, needOpWeight bool) ([]*types.Model, int, error)
+	// IndexV2 returns basic model data only (no tags, mirror, enrichment) for fast list rendering
+	IndexV2(ctx context.Context, filter *types.RepoFilter, per, page int, needOpWeight bool) ([]*types.Model, int, error)
 	Create(ctx context.Context, req *types.CreateModelReq) (*types.Model, error)
 	Update(ctx context.Context, req *types.UpdateModelReq) (*types.Model, error)
 	Delete(ctx context.Context, namespace, name, currentUser string) error
@@ -277,6 +279,59 @@ func (c *modelComponentImpl) Index(ctx context.Context, filter *types.RepoFilter
 	if needOpWeight {
 		c.addOpWeightToModel(ctx, repoIDs, resModels)
 	}
+	return resModels, total, nil
+}
+
+// IndexV2 returns basic model data only (no tags, mirror status, or other enrichment data).
+// Use Enrich() to fetch the enrichment data asynchronously.
+func (c *modelComponentImpl) IndexV2(ctx context.Context, filter *types.RepoFilter, per, page int, needOpWeight bool) ([]*types.Model, int, error) {
+	repos, total, err := c.repoComponent.PublicToUserV2(ctx, types.ModelRepo, filter.Username, filter, per, page)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get public model repos v2, error: %w", err)
+	}
+
+	var repoIDs []int64
+	for _, repo := range repos {
+		repoIDs = append(repoIDs, repo.ID)
+	}
+
+	// Load real model IDs (no Relations — fast)
+	modelMap := make(map[int64]int64, len(repos))
+	if len(repoIDs) > 0 {
+		models, err := c.modelStore.ByRepoIDsBasic(ctx, repoIDs)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to get model ids by repo ids, error: %w", err)
+		}
+		for _, m := range models {
+			modelMap[m.RepositoryID] = m.ID
+		}
+	}
+
+	resModels := make([]*types.Model, 0, len(repos))
+	for _, repo := range repos {
+		modelID := modelMap[repo.ID]
+		resModels = append(resModels, &types.Model{
+			ID:           modelID,
+			Name:         repo.Name,
+			Nickname:     repo.Nickname,
+			Description:  repo.Description,
+			Likes:        repo.Likes,
+			Downloads:    repo.DownloadCount,
+			Path:         repo.Path,
+			RepositoryID: repo.ID,
+			Private:      repo.Private,
+			CreatedAt:    repo.CreatedAt,
+			UpdatedAt:    repo.UpdatedAt,
+			Source:       repo.Source,
+			SyncStatus:   repo.SyncStatus,
+			License:      repo.License,
+		})
+	}
+
+	if needOpWeight {
+		c.addOpWeightToModel(ctx, repoIDs, resModels)
+	}
+
 	return resModels, total, nil
 }
 

--- a/component/model_test.go
+++ b/component/model_test.go
@@ -1191,5 +1191,56 @@ func TestModelComponent_ListALLRuntimeFramework(t *testing.T) {
 	runs, err := mc.ListAllByRuntimeFramework(ctx, "", 0)
 	require.Nil(t, err)
 	require.Equal(t, 2, len(runs))
+}
 
+func TestModelComponent_IndexV2(t *testing.T) {
+	ctx := context.TODO()
+	mc := initializeTestModelComponent(ctx, t)
+
+	filter := &types.RepoFilter{Username: "user"}
+	mc.mocks.components.repo.EXPECT().PublicToUserV2(ctx, types.ModelRepo, "user", filter, 10, 1).Return(
+		[]*database.Repository{
+			{ID: 10, Name: "model1", Nickname: "Model 1", Description: "desc1", Likes: 10, DownloadCount: 100, Path: "u/model1", Private: false, Source: "local", SyncStatus: "completed", License: "MIT"},
+			{ID: 20, Name: "model2", Nickname: "Model 2", Description: "desc2", Likes: 20, DownloadCount: 200, Path: "u/model2", Private: true, Source: "opencsg", SyncStatus: "completed", License: "Apache-2.0"},
+		}, 200, nil,
+	)
+
+	// model.ID ≠ repo.ID to lock contract
+	mc.mocks.stores.ModelMock().EXPECT().ByRepoIDsBasic(ctx, []int64{10, 20}).Return([]database.Model{
+		{ID: 110, RepositoryID: 10},
+		{ID: 220, RepositoryID: 20},
+	}, nil)
+
+	data, total, err := mc.IndexV2(ctx, filter, 10, 1, false)
+	require.Nil(t, err)
+	require.Equal(t, 200, total)
+	require.Len(t, data, 2)
+
+	require.Equal(t, []*types.Model{
+		{
+			ID: 110, Name: "model1", Nickname: "Model 1", Description: "desc1",
+			Likes: 10, Downloads: 100, Path: "u/model1", RepositoryID: 10,
+			Private: false, Source: "local", SyncStatus: "completed", License: "MIT",
+		},
+		{
+			ID: 220, Name: "model2", Nickname: "Model 2", Description: "desc2",
+			Likes: 20, Downloads: 200, Path: "u/model2", RepositoryID: 20,
+			Private: true, Source: "opencsg", SyncStatus: "completed", License: "Apache-2.0",
+		},
+	}, data)
+}
+
+func TestModelComponent_IndexV2_Empty(t *testing.T) {
+	ctx := context.TODO()
+	mc := initializeTestModelComponent(ctx, t)
+
+	filter := &types.RepoFilter{Username: "user", Sort: "trending"}
+	mc.mocks.components.repo.EXPECT().PublicToUserV2(ctx, types.ModelRepo, "user", filter, 10, 1).Return(
+		[]*database.Repository{}, 0, nil,
+	)
+
+	data, total, err := mc.IndexV2(ctx, filter, 10, 1, false)
+	require.Nil(t, err)
+	require.Equal(t, 0, total)
+	require.Len(t, data, 0)
 }

--- a/component/repo.go
+++ b/component/repo.go
@@ -103,6 +103,8 @@ type repoComponentImpl struct {
 	pendingDeletion                database.PendingDeletionStore
 	xnetClient                     rpc.XnetSvcClient
 	clusterComponent               ClusterComponent
+	modelStore                     database.ModelStore
+	tagStore                       database.TagStore
 	extendRepoImpl
 }
 
@@ -114,6 +116,8 @@ type RepoComponent interface {
 	CreateFork(ctx context.Context, req types.CreateForkReq) (*database.Repository, error)
 	// PublicToUser gets visible repos of the given user and user's orgs
 	PublicToUser(ctx context.Context, repoType types.RepositoryType, userName string, filter *types.RepoFilter, per, page int) (repos []*database.Repository, count int, err error)
+	// PublicToUserV2 is like PublicToUser but skips Tag eager-loading for faster list queries
+	PublicToUserV2(ctx context.Context, repoType types.RepositoryType, userName string, filter *types.RepoFilter, per, page int) (repos []*database.Repository, count int, err error)
 	CreateFile(ctx context.Context, req *types.CreateFileReq) (*types.CreateFileResp, error)
 	UpdateFile(ctx context.Context, req *types.UpdateFileReq) (*types.UpdateFileResp, error)
 	DeleteFile(ctx context.Context, req *types.DeleteFileReq) (*types.DeleteFileResp, error)
@@ -699,6 +703,26 @@ func (c *repoComponentImpl) PublicToUser(ctx context.Context, repoType types.Rep
 	repos, count, err = c.repoStore.PublicToUser(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get user public repos, error: %w", err)
+	}
+
+	return repos, count, nil
+}
+
+// PublicToUserV2 gets visible repos without eager-loading Tags for faster list queries.
+func (c *repoComponentImpl) PublicToUserV2(ctx context.Context, repoType types.RepositoryType, userName string, filter *types.RepoFilter, per, page int) (repos []*database.Repository, count int, err error) {
+	var ownerNamespaces []string
+	var isAdmin bool
+
+	if len(userName) > 0 {
+		user, err := c.userSvcClient.GetUserInfo(ctx, userName, userName)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to get user info, error: %w", err)
+		}
+		ownerNamespaces, isAdmin = buildAccessibleNamespaces(user)
+	}
+	repos, count, err = c.repoStore.PublicToUserV2(ctx, repoType, ownerNamespaces, filter, per, page, isAdmin)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get user public repos v2, error: %w", err)
 	}
 
 	return repos, count, nil
@@ -3269,6 +3293,12 @@ func (c *repoComponentImpl) BatchGetRepoExtra(ctx context.Context, repoIDs []int
 		}
 	}
 
+	// Collect readable repo IDs for enrichment queries
+	readableRepoIDs := make([]int64, len(readableRepos))
+	for i, repo := range readableRepos {
+		readableRepoIDs[i] = repo.ID
+	}
+
 	// Collect repos that have a default branch for statistics lookup
 	repoDefaultBranches := make(map[int64]string, len(readableRepos))
 	for _, repo := range readableRepos {
@@ -3300,13 +3330,69 @@ func (c *repoComponentImpl) BatchGetRepoExtra(ctx context.Context, repoIDs []int
 		}
 	}
 
+	// Load enrichment data (tags, mirror, multi-source, clone info)
+	var tagMap map[int64][]database.Tag
+	var modelMap map[int64]database.Model
+	if len(readableRepoIDs) > 0 {
+		if c.tagStore != nil {
+			tm, err := c.tagStore.ByRepoIDs(ctx, readableRepoIDs)
+			if err != nil {
+				slog.Warn("failed to load tags for repo extras", "error", err)
+			} else {
+				tagMap = tm
+			}
+		}
+		if c.modelStore != nil {
+			models, err := c.modelStore.ByRepoIDs(ctx, readableRepoIDs)
+			if err != nil {
+				slog.Warn("failed to load models for repo extras", "error", err)
+			} else {
+				modelMap = make(map[int64]database.Model, len(models))
+				for _, m := range models {
+					modelMap[m.RepositoryID] = m
+				}
+			}
+		}
+	}
+
 	result := make([]types.RepoExtraItem, 0, len(readableRepos))
 	for _, repo := range readableRepos {
-		result = append(result, types.RepoExtraItem{
+		item := types.RepoExtraItem{
 			RepoID:         repo.ID,
 			Size:           sizeMap[repo.ID],
 			LastCommitSize: lastCommitSizeMap[repo.ID],
-		})
+		}
+		// Populate enrichment fields
+		if tagMap != nil {
+			if tags, ok := tagMap[repo.ID]; ok {
+				for _, t := range tags {
+					item.Tags = append(item.Tags, types.RepoTag{
+						Name:      t.Name,
+						Category:  t.Category,
+						Group:     t.Group,
+						BuiltIn:   t.BuiltIn,
+						ShowName:  t.I18nKey,
+						I18nKey:   t.I18nKey,
+						CreatedAt: t.CreatedAt,
+						UpdatedAt: t.UpdatedAt,
+					})
+				}
+			}
+		}
+		if m, ok := modelMap[repo.ID]; ok {
+			if m.Repository.Mirror.CurrentTask != nil {
+				item.MirrorTaskStatus = m.Repository.Mirror.CurrentTask.Status
+			}
+			item.MultiSource = types.MultiSource{
+				HFPath:  m.Repository.HFPath,
+				MSPath:  m.Repository.MSPath,
+				CSGPath: m.Repository.CSGPath,
+			}
+			cloneInfo := common.BuildCloneInfo(c.config, m.Repository)
+			item.Repository = &cloneInfo
+			item.ReportURL = m.ReportURL
+		}
+		result = append(result, item)
 	}
 	slices.SortFunc(result, func(a, b types.RepoExtraItem) int {
 		return cmp.Compare(a.RepoID, b.RepoID)

--- a/component/repo_ce.go
+++ b/component/repo_ce.go
@@ -29,6 +29,8 @@ func NewRepoComponent(config *config.Config) (RepoComponent, error) {
 	c.namespaceStore = database.NewNamespaceStore()
 	c.userStore = database.NewUserStore()
 	c.orgStore = database.NewOrgStore()
+	c.modelStore = database.NewModelStore()
+	c.tagStore = database.NewTagStore()
 	c.repoStore = database.NewRepoStore()
 	c.repoFileStore = database.NewRepoFileStore()
 	c.repoRelationsStore = database.NewRepoRelationsStore()

--- a/component/repo_test.go
+++ b/component/repo_test.go
@@ -2736,6 +2736,10 @@ func TestRepoComponent_BatchGetRepoExtra(t *testing.T) {
 		}
 		repoComp.mocks.stores.RepositoryStatisticsMock().EXPECT().FindByRepositoryIDs(ctx, []int64{1, 2}).Return(stats, nil)
 
+
+				repoComp.mocks.stores.TagMock().EXPECT().ByRepoIDs(ctx, []int64{1, 2}).Return(nil, nil)
+		repoComp.mocks.stores.ModelMock().EXPECT().ByRepoIDs(ctx, []int64{1, 2}).Return(nil, nil)
+
 		result, err := repoComp.BatchGetRepoExtra(ctx, []int64{1, 2}, "admin")
 		require.Nil(t, err)
 		require.Equal(t, []types.RepoExtraItem{{RepoID: 1, Size: 1024, LastCommitSize: 100}, {RepoID: 2, Size: 2048}}, result)
@@ -2768,6 +2772,9 @@ func TestRepoComponent_BatchGetRepoExtra(t *testing.T) {
 			{RepositoryID: 3, Branch: "main", TotalSize: 300},
 		}
 		repoComp.mocks.stores.RepositoryStatisticsMock().EXPECT().FindByRepositoryIDs(ctx, []int64{1, 2, 3}).Return(stats, nil)
+
+				repoComp.mocks.stores.TagMock().EXPECT().ByRepoIDs(ctx, []int64{1, 2, 3}).Return(nil, nil)
+		repoComp.mocks.stores.ModelMock().EXPECT().ByRepoIDs(ctx, []int64{1, 2, 3}).Return(nil, nil)
 
 		result, err := repoComp.BatchGetRepoExtra(ctx, []int64{1, 2, 3, 4}, "user1")
 		require.Nil(t, err)
@@ -2807,6 +2814,9 @@ func TestRepoComponent_BatchGetRepoExtra(t *testing.T) {
 		}
 		repoComp.mocks.stores.RepositoryStatisticsMock().EXPECT().FindByRepositoryIDs(ctx, []int64{1, 2, 3}).Return(stats, nil)
 
+				repoComp.mocks.stores.TagMock().EXPECT().ByRepoIDs(ctx, []int64{1, 2, 3}).Return(nil, nil)
+		repoComp.mocks.stores.ModelMock().EXPECT().ByRepoIDs(ctx, []int64{1, 2, 3}).Return(nil, nil)
+
 		result, err := repoComp.BatchGetRepoExtra(ctx, []int64{1, 2, 3, 4}, "user1")
 		require.Nil(t, err)
 		require.Equal(t, []types.RepoExtraItem{{RepoID: 1, Size: 100}, {RepoID: 2, Size: 200}, {RepoID: 3, Size: 300}}, result)
@@ -2826,6 +2836,9 @@ func TestRepoComponent_BatchGetRepoExtra(t *testing.T) {
 			{RepositoryID: 2, Branch: "main", TotalSize: 500},
 		}
 		repoComp.mocks.stores.RepositoryStatisticsMock().EXPECT().FindByRepositoryIDs(ctx, []int64{2}).Return(stats, nil)
+
+				repoComp.mocks.stores.TagMock().EXPECT().ByRepoIDs(ctx, []int64{2}).Return(nil, nil)
+		repoComp.mocks.stores.ModelMock().EXPECT().ByRepoIDs(ctx, []int64{2}).Return(nil, nil)
 
 		result, err := repoComp.BatchGetRepoExtra(ctx, []int64{1, 2}, "")
 		require.Nil(t, err)
@@ -2847,6 +2860,10 @@ func TestRepoComponent_BatchGetRepoExtra(t *testing.T) {
 			{ID: 1, UserID: 1, Path: "user1/repo1", Private: true, DefaultBranch: ""},
 		}
 		repoComp.mocks.stores.RepoMock().EXPECT().FindByIds(ctx, []int64{1}).Return(repos, nil)
+
+
+				repoComp.mocks.stores.TagMock().EXPECT().ByRepoIDs(ctx, []int64{1}).Return(nil, nil)
+		repoComp.mocks.stores.ModelMock().EXPECT().ByRepoIDs(ctx, []int64{1}).Return(nil, nil)
 
 		result, err := repoComp.BatchGetRepoExtra(ctx, []int64{1}, "user1")
 		require.Nil(t, err)
@@ -2873,6 +2890,9 @@ func TestRepoComponent_BatchGetRepoExtra(t *testing.T) {
 			{RepositoryID: 1, Branch: "dev", TotalSize: 100},
 		}
 		repoComp.mocks.stores.RepositoryStatisticsMock().EXPECT().FindByRepositoryIDs(ctx, []int64{1}).Return(stats, nil)
+
+				repoComp.mocks.stores.TagMock().EXPECT().ByRepoIDs(ctx, []int64{1}).Return(nil, nil)
+		repoComp.mocks.stores.ModelMock().EXPECT().ByRepoIDs(ctx, []int64{1}).Return(nil, nil)
 
 		result, err := repoComp.BatchGetRepoExtra(ctx, []int64{1}, "user1")
 		require.Nil(t, err)

--- a/component/wireset_ce.go
+++ b/component/wireset_ce.go
@@ -140,5 +140,7 @@ func NewTestRepoComponent(config *config.Config, stores *tests.MockStores, rpcUs
 		xnetClient:                     xnetClient,
 		clusterComponent:               clusterComponent,
 		repoStatisticsStore:            stores.RepositoryStatistics,
+		modelStore:                     stores.Model,
+		tagStore:                       stores.Tag,
 	}
 }


### PR DESCRIPTION
Summary:
- Optimized the slow `GET /api/v1/models` endpoint (at 140k model scale) by removing eager loading of heavy associations (Tags, Mirror, etc.) that blocked initial card rendering.
- Split the data fetching into two stages: a new `GET /models/v2` route returns basic fields for fast skeleton rendering, while an extended `POST /repos/extra` asynchronously loads remaining details (tags, mirror status, size, etc.).
- Retained all existing filtering and sorting logic in the first request by using SQL JOINs strictly for WHERE/ORDER BY clauses without returning the associated data.

Manual handling required:
- Dev-agent failed to cherry-pick this GitLab MR: Git克隆命令执行失败: Command '['git', '--git-dir', '/root/gitlab-to-github/dev-agent/agent/.cache/mirrors/csghub-server-17ac110fb8ee.git', 'fetch', '--prune', 'origin']' returned non-zero exit status 128.
错误输出: fatal: unable to access 'https://github.com/OpenCSGs/csghub-server/': GnuTLS recv error (-110): The TLS connection was non-properly terminated.

- Source GitLab MR: !2825
- Source ref: 70340b8b4e918ad2c11be0f4de59d5e96d2567de
- Files in sync scope: 18
- The GitLab MR patch was applied with git's 3-way apply. Please review before merging.