### PR TITLE
Record cached prompt tokens in usage metering

### DIFF
--- a/aigateway/component/openai.go
+++ b/aigateway/component/openai.go
@@ -657,12 +657,13 @@ func (m *openaiComponentImpl) resolveUsageOwnerType(c context.Context, nsUUID st
 
 // usageMeteringExtra is serialized into MeteringEvent.Extra for usage billing breakdown.
 type usageMeteringExtra struct {
-	PromptTokenNum     string                     `json:"prompt_token_num"`
-	CompletionTokenNum string                     `json:"completion_token_num"`
-	OwnerType          commontypes.TokenUsageType `json:"owner_type"`
-	APIKey             string                     `json:"api_key"`
-	Provider           string                     `json:"provider"`
-	ModelName          string                     `json:"model_name"`
+	PromptTokenNum      string                     `json:"prompt_token_num"`
+	PromptTokenCacheNum string                     `json:"prompt_token_cache_num"`
+	CompletionTokenNum  string                     `json:"completion_token_num"`
+	OwnerType           commontypes.TokenUsageType `json:"owner_type"`
+	APIKey              string                     `json:"api_key"`
+	Provider            string                     `json:"provider"`
+	ModelName           string                     `json:"model_name"`
 	// multiModalMeteringExtra is serialized into MeteringEvent.Extra for multi-modal billing.
 	CompletionDataType   string `json:"completion_data_type"`
 	CompletionResolution string `json:"completion_resolution"`
@@ -682,6 +683,7 @@ func sanitizeMeteringEventForLog(event commontypes.MeteringEvent) commontypes.Me
 func buildUsageExtraData(usageModel *types.Model, upstreamModelName string, usage *token.Usage, apikey string, meteringInfo usageMeteringInfo) (string, error) {
 	extra := usageMeteringExtra{
 		PromptTokenNum:       fmt.Sprintf("%d", usage.PromptTokens),
+		PromptTokenCacheNum:  fmt.Sprintf("%d", usage.CachedPromptTokens),
 		CompletionTokenNum:   fmt.Sprintf("%d", usage.CompletionTokens),
 		OwnerType:            meteringInfo.OwnerType,
 		APIKey:               apikey,

--- a/aigateway/component/openai_test.go
+++ b/aigateway/component/openai_test.go
@@ -771,9 +771,10 @@ func TestOpenAIComponentImpl_RecordUsage(t *testing.T) {
 					organStore:  mockOrgStore,
 				}
 				mockCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{
-					PromptTokens:     100,
-					CompletionTokens: 50,
-					TotalTokens:      150,
+					PromptTokens:       100,
+					CachedPromptTokens: 40,
+					CompletionTokens:   50,
+					TotalTokens:        150,
 				}, nil)
 				user := &database.User{
 					ID:       1,
@@ -798,15 +799,17 @@ func TestOpenAIComponentImpl_RecordUsage(t *testing.T) {
 					require.Equal(t, commontypes.TokenNumberType, evt.ValueType)
 					require.Equal(t, int64(150), evt.Value)
 					var tokenUsageExtra struct {
-						PromptTokenNum     string                     `json:"prompt_token_num"`
-						CompletionTokenNum string                     `json:"completion_token_num"`
-						OwnerType          commontypes.TokenUsageType `json:"owner_type"`
-						Provider           string                     `json:"provider"`
-						ModelName          string                     `json:"model_name"`
+						PromptTokenNum      string                     `json:"prompt_token_num"`
+						PromptTokenCacheNum string                     `json:"prompt_token_cache_num"`
+						CompletionTokenNum  string                     `json:"completion_token_num"`
+						OwnerType           commontypes.TokenUsageType `json:"owner_type"`
+						Provider            string                     `json:"provider"`
+						ModelName           string                     `json:"model_name"`
 					}
 					err = json.Unmarshal([]byte(evt.Extra), &tokenUsageExtra)
 					require.NoError(t, err)
 					require.Equal(t, "100", tokenUsageExtra.PromptTokenNum)
+					require.Equal(t, "40", tokenUsageExtra.PromptTokenCacheNum)
 					require.Equal(t, "50", tokenUsageExtra.CompletionTokenNum)
 					require.Equal(t, commontypes.CSGHubOtherDeployedInference, tokenUsageExtra.OwnerType)
 					require.Empty(t, tokenUsageExtra.Provider)
@@ -1213,6 +1216,41 @@ func TestOpenAIComponentImpl_RecordUsage(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestBuildUsageExtraDataIncludesCachedPromptTokens(t *testing.T) {
+	meteringInfo := usageMeteringInfo{OwnerType: commontypes.ExternalInference}
+
+	for _, tt := range []struct {
+		name               string
+		cachedPromptTokens int64
+		wantCachedTokens   string
+	}{
+		{
+			name:               "cached prompt tokens reported",
+			cachedPromptTokens: 40,
+			wantCachedTokens:   "40",
+		},
+		{
+			name:             "cached prompt tokens absent",
+			wantCachedTokens: "0",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			extraData, err := buildUsageExtraData(&types.Model{}, "target-model", &token.Usage{
+				PromptTokens:       100,
+				CachedPromptTokens: tt.cachedPromptTokens,
+				CompletionTokens:   50,
+			}, "", meteringInfo)
+			require.NoError(t, err)
+
+			var extra usageMeteringExtra
+			require.NoError(t, json.Unmarshal([]byte(extraData), &extra))
+			require.Equal(t, "100", extra.PromptTokenNum)
+			require.Equal(t, tt.wantCachedTokens, extra.PromptTokenCacheNum)
+			require.Equal(t, "50", extra.CompletionTokenNum)
 		})
 	}
 }

--- a/configs/inference/amd-vllm.json
+++ b/configs/inference/amd-vllm.json
@@ -88,6 +88,11 @@
       "format": "--enable-prefix-caching"
     },
     {
+      "name": "enable-prompt-tokens-details",
+      "value": "disable",
+      "format": "--enable-prompt-tokens-details"
+    },
+    {
       "name": "enable-chunked-prefill",
       "value": "enable",
       "format": "--enable-chunked-prefill"

--- a/configs/inference/nvidia-vllm.json
+++ b/configs/inference/nvidia-vllm.json
@@ -88,6 +88,11 @@
       "format": "--enable-prefix-caching"
     },
     {
+      "name": "enable-prompt-tokens-details",
+      "value": "disable",
+      "format": "--enable-prompt-tokens-details"
+    },
+    {
       "name": "enable-chunked-prefill",
       "value": "enable",
       "format": "--enable-chunked-prefill"

--- a/configs/inference/vllm.json
+++ b/configs/inference/vllm.json
@@ -250,8 +250,8 @@
     },
     {
       "compute_type": "cpu",
-      "image": "opencsghq/vllm-cpu:2.4",
-      "engine_version": "0.4.12-fix1"
+      "image": "opencsghq/vllm-cpu:v0.24.0",
+      "engine_version": "v0.24.0"
     }
   ],
   "engine_args": [
@@ -329,6 +329,11 @@
       "name": "enable-prefix-caching",
       "value": "enable",
       "format": "--enable-prefix-caching"
+    },
+    {
+      "name": "enable-prompt-tokens-details",
+      "value": "disable",
+      "format": "--enable-prompt-tokens-details"
     },
     {
       "name": "enable-chunked-prefill",

--- a/docker/inference/Dockerfile.vllm-cpu
+++ b/docker/inference/Dockerfile.vllm-cpu
@@ -1,6 +1,6 @@
-FROM cledge/vllm-cpu:0.4.12-fix1 
-RUN pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip install --no-cache-dir csghub-sdk==0.4.6
+FROM vllm/vllm-openai-cpu:v0.24.0
+RUN pip config set global.index-url https://mirrors.aliyun.com/pypi/simple
+RUN pip install --no-cache-dir csghub-sdk==0.7.3
 
 WORKDIR /workspace/
 

--- a/docker/inference/README.md
+++ b/docker/inference/README.md
@@ -26,8 +26,8 @@ docker buildx build --platform linux/amd64 \
   -f Dockerfile.vllm-amd \
   --push .
   
-# For vllm cpu only: opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/vllm-cpu:2.3
-export IMAGE_TAG=2.4
+# For vllm cpu only: opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/vllm-cpu:v0.24.0
+export IMAGE_TAG=v0.24.0
 docker buildx build --platform linux/amd64,linux/arm64 \
   -t ${OPENCSG_ACR}/opencsghq/vllm-cpu:${IMAGE_TAG} \
   -t ${OPENCSG_ACR}/opencsghq/vllm-cpu:latest \
@@ -328,7 +328,7 @@ curl -o result.mp4 \
 |text generation / embedding / reranking / text to speech| vllm | v0.24.0 | 13.0 |pooling runner support for embedding and reranking; vllm-omni 0.24.0 for text-to-speech (/v1/audio/speech)|
 |text generation / embedding / reranking| amd-vllm | rocm7.2.1_vllm_0.24.0 | - |ROCm 7.2.1, vLLM 0.24.0|
 |text generation| vllm | v0.8.5 | 12.4 |fix hf hub timestamp|
-|text generation| vllm-cpu | 2.4 | -|fix hf hub timestamp |
+|text generation| vllm-cpu | v0.24.0 | - |vLLM 0.24.0, supports --enable-prompt-tokens-details|
 |text generation| tgi | 2.2 | 12.1 |- |
 |text generation| tgi | 3.2 | 12.4 |fix hf hub timestamp|
 |image generation| hf-inference-toolkit | 0.5.3 | 12.1 |-|


### PR DESCRIPTION
Summary:
- Added `prompt_token_cache_num` to AIGateway usage metering to report vLLM's cached prompt tokens for visibility into prefix caching hits.
- Introduced the `enable-prompt-tokens-details` engine parameter (disabled by default) to control the vLLM flag without altering existing instance behavior.
- Upgraded the vLLM CPU base image to v0.24.0 to support the new caching details flag and align with the GPU image version.