### PR TITLE
Report source line and dataset row counts in LLM log sync email

### DIFF
--- a/common/types/llm_log.go
+++ b/common/types/llm_log.go
@@ -42,3 +42,8 @@ type LLMLogRequest struct {
 	Tools    []openai.ChatCompletionToolUnionParam
 	Stream   bool
 }
+
+type LLMLogSyncFilesResult struct {
+	SourceLineCount int64
+	DatasetRowCount int64
+}

--- a/common/types/notification.go
+++ b/common/types/notification.go
@@ -350,6 +350,8 @@ type EmailLLMLogSyncNotification struct {
 	Date            string   `json:"date"`
 	Status          string   `json:"status"`
 	FileCount       int      `json:"file_count"`
+	SourceLineCount int64    `json:"source_line_count"`
+	DatasetRowCount int64    `json:"dataset_row_count"`
 	DataflowStarted bool     `json:"dataflow_started"`
 	DataflowJobID   string   `json:"dataflow_job_id"`
 	ArgoTaskID      string   `json:"argo_task_id"`
@@ -365,6 +367,8 @@ type SendLLMLogSyncMailInput struct {
 	Date            string
 	Status          string
 	FileCount       int
+	SourceLineCount int64
+	DatasetRowCount int64
 	DataflowStarted bool
 	DataflowJobID   string
 	ArgoTaskID      string

--- a/notification/tmplmgr/templates/llmlog-sync/email.en-US.tpl
+++ b/notification/tmplmgr/templates/llmlog-sync/email.en-US.tpl
@@ -23,6 +23,14 @@ LLM log sync {{.status}} for {{.date}}
                             <td style="padding:8px 12px;border-bottom:1px solid #d8dee4;">{{.file_count}}</td>
                         </tr>
                         <tr>
+                            <td style="width:220px;padding:8px 12px;border-bottom:1px solid #d8dee4;color:#57606a;">Source log lines</td>
+                            <td style="padding:8px 12px;border-bottom:1px solid #d8dee4;">{{.source_line_count}}</td>
+                        </tr>
+                        <tr>
+                            <td style="width:220px;padding:8px 12px;border-bottom:1px solid #d8dee4;color:#57606a;">Dataset rows</td>
+                            <td style="padding:8px 12px;border-bottom:1px solid #d8dee4;">{{.dataset_row_count}}</td>
+                        </tr>
+                        <tr>
                             <td style="width:220px;padding:8px 12px;border-bottom:1px solid #d8dee4;color:#57606a;">Started at</td>
                             <td style="padding:8px 12px;border-bottom:1px solid #d8dee4;">{{.started_at}}</td>
                         </tr>


### PR DESCRIPTION
Summary:
- Added source line count and dataset row count metrics to the LLM log sync pipeline, propagating them to the email notification template.
- Fixed `CSGHUB_ENDPOINT` in dataflow startup to use `config.Model.DownloadEndpoint` instead of `config.APIServer.PublicDomain`.