### PR TITLE
Check inference and version permission for private endpoint

### DIFF
--- a/_mocks/opencsg.com/csghub-server/component/mock_ModelComponent.go
+++ b/_mocks/opencsg.com/csghub-server/component/mock_ModelComponent.go
@@ -273,17 +273,17 @@ func (_c *MockModelComponent_Delete_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
-// DeleteInferenceVersion provides a mock function with given fields: ctx, id, commitID
-func (_m *MockModelComponent) DeleteInferenceVersion(ctx context.Context, id int64, commitID string) error {
-	ret := _m.Called(ctx, id, commitID)
+// DeleteInferenceVersion provides a mock function with given fields: ctx, verReq, commitID
+func (_m *MockModelComponent) DeleteInferenceVersion(ctx context.Context, verReq types.DeployActReq, commitID string) error {
+	ret := _m.Called(ctx, verReq, commitID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteInferenceVersion")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, string) error); ok {
-		r0 = rf(ctx, id, commitID)
+	if rf, ok := ret.Get(0).(func(context.Context, types.DeployActReq, string) error); ok {
+		r0 = rf(ctx, verReq, commitID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -298,15 +298,15 @@ type MockModelComponent_DeleteInferenceVersion_Call struct {
 
 // DeleteInferenceVersion is a helper method to define mock.On call
 //   - ctx context.Context
-//   - id int64
+//   - verReq types.DeployActReq
 //   - commitID string
-func (_e *MockModelComponent_Expecter) DeleteInferenceVersion(ctx interface{}, id interface{}, commitID interface{}) *MockModelComponent_DeleteInferenceVersion_Call {
-	return &MockModelComponent_DeleteInferenceVersion_Call{Call: _e.mock.On("DeleteInferenceVersion", ctx, id, commitID)}
+func (_e *MockModelComponent_Expecter) DeleteInferenceVersion(ctx interface{}, verReq interface{}, commitID interface{}) *MockModelComponent_DeleteInferenceVersion_Call {
+	return &MockModelComponent_DeleteInferenceVersion_Call{Call: _e.mock.On("DeleteInferenceVersion", ctx, verReq, commitID)}
 }
 
-func (_c *MockModelComponent_DeleteInferenceVersion_Call) Run(run func(ctx context.Context, id int64, commitID string)) *MockModelComponent_DeleteInferenceVersion_Call {
+func (_c *MockModelComponent_DeleteInferenceVersion_Call) Run(run func(ctx context.Context, verReq types.DeployActReq, commitID string)) *MockModelComponent_DeleteInferenceVersion_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(int64), args[2].(string))
+		run(args[0].(context.Context), args[1].(types.DeployActReq), args[2].(string))
 	})
 	return _c
 }
@@ -316,7 +316,7 @@ func (_c *MockModelComponent_DeleteInferenceVersion_Call) Return(_a0 error) *Moc
 	return _c
 }
 
-func (_c *MockModelComponent_DeleteInferenceVersion_Call) RunAndReturn(run func(context.Context, int64, string) error) *MockModelComponent_DeleteInferenceVersion_Call {
+func (_c *MockModelComponent_DeleteInferenceVersion_Call) RunAndReturn(run func(context.Context, types.DeployActReq, string) error) *MockModelComponent_DeleteInferenceVersion_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -630,9 +630,9 @@ func (_c *MockModelComponent_ListAllByRuntimeFramework_Call) RunAndReturn(run fu
 	return _c
 }
 
-// ListInferenceVersions provides a mock function with given fields: ctx, id
-func (_m *MockModelComponent) ListInferenceVersions(ctx context.Context, id int64) ([]types.ListInferenceVersionsResp, error) {
-	ret := _m.Called(ctx, id)
+// ListInferenceVersions provides a mock function with given fields: ctx, verReq
+func (_m *MockModelComponent) ListInferenceVersions(ctx context.Context, verReq types.DeployActReq) ([]types.ListInferenceVersionsResp, error) {
+	ret := _m.Called(ctx, verReq)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListInferenceVersions")
@@ -640,19 +640,19 @@ func (_m *MockModelComponent) ListInferenceVersions(ctx context.Context, id int6
 
 	var r0 []types.ListInferenceVersionsResp
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64) ([]types.ListInferenceVersionsResp, error)); ok {
-		return rf(ctx, id)
+	if rf, ok := ret.Get(0).(func(context.Context, types.DeployActReq) ([]types.ListInferenceVersionsResp, error)); ok {
+		return rf(ctx, verReq)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int64) []types.ListInferenceVersionsResp); ok {
-		r0 = rf(ctx, id)
+	if rf, ok := ret.Get(0).(func(context.Context, types.DeployActReq) []types.ListInferenceVersionsResp); ok {
+		r0 = rf(ctx, verReq)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]types.ListInferenceVersionsResp)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int64) error); ok {
-		r1 = rf(ctx, id)
+	if rf, ok := ret.Get(1).(func(context.Context, types.DeployActReq) error); ok {
+		r1 = rf(ctx, verReq)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -667,14 +667,14 @@ type MockModelComponent_ListInferenceVersions_Call struct {
 
 // ListInferenceVersions is a helper method to define mock.On call
 //   - ctx context.Context
-//   - id int64
-func (_e *MockModelComponent_Expecter) ListInferenceVersions(ctx interface{}, id interface{}) *MockModelComponent_ListInferenceVersions_Call {
-	return &MockModelComponent_ListInferenceVersions_Call{Call: _e.mock.On("ListInferenceVersions", ctx, id)}
+//   - verReq types.DeployActReq
+func (_e *MockModelComponent_Expecter) ListInferenceVersions(ctx interface{}, verReq interface{}) *MockModelComponent_ListInferenceVersions_Call {
+	return &MockModelComponent_ListInferenceVersions_Call{Call: _e.mock.On("ListInferenceVersions", ctx, verReq)}
 }
 
-func (_c *MockModelComponent_ListInferenceVersions_Call) Run(run func(ctx context.Context, id int64)) *MockModelComponent_ListInferenceVersions_Call {
+func (_c *MockModelComponent_ListInferenceVersions_Call) Run(run func(ctx context.Context, verReq types.DeployActReq)) *MockModelComponent_ListInferenceVersions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(int64))
+		run(args[0].(context.Context), args[1].(types.DeployActReq))
 	})
 	return _c
 }
@@ -684,7 +684,7 @@ func (_c *MockModelComponent_ListInferenceVersions_Call) Return(_a0 []types.List
 	return _c
 }
 
-func (_c *MockModelComponent_ListInferenceVersions_Call) RunAndReturn(run func(context.Context, int64) ([]types.ListInferenceVersionsResp, error)) *MockModelComponent_ListInferenceVersions_Call {
+func (_c *MockModelComponent_ListInferenceVersions_Call) RunAndReturn(run func(context.Context, types.DeployActReq) ([]types.ListInferenceVersionsResp, error)) *MockModelComponent_ListInferenceVersions_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1374,17 +1374,17 @@ func (_c *MockModelComponent_Update_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
-// UpdateInferenceVersionTraffic provides a mock function with given fields: ctx, id, req
-func (_m *MockModelComponent) UpdateInferenceVersionTraffic(ctx context.Context, id int64, req []types.UpdateInferenceVersionTrafficReq) error {
-	ret := _m.Called(ctx, id, req)
+// UpdateInferenceVersionTraffic provides a mock function with given fields: ctx, verReq, req
+func (_m *MockModelComponent) UpdateInferenceVersionTraffic(ctx context.Context, verReq types.DeployActReq, req []types.UpdateInferenceVersionTrafficReq) error {
+	ret := _m.Called(ctx, verReq, req)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateInferenceVersionTraffic")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, []types.UpdateInferenceVersionTrafficReq) error); ok {
-		r0 = rf(ctx, id, req)
+	if rf, ok := ret.Get(0).(func(context.Context, types.DeployActReq, []types.UpdateInferenceVersionTrafficReq) error); ok {
+		r0 = rf(ctx, verReq, req)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1399,15 +1399,15 @@ type MockModelComponent_UpdateInferenceVersionTraffic_Call struct {
 
 // UpdateInferenceVersionTraffic is a helper method to define mock.On call
 //   - ctx context.Context
-//   - id int64
+//   - verReq types.DeployActReq
 //   - req []types.UpdateInferenceVersionTrafficReq
-func (_e *MockModelComponent_Expecter) UpdateInferenceVersionTraffic(ctx interface{}, id interface{}, req interface{}) *MockModelComponent_UpdateInferenceVersionTraffic_Call {
-	return &MockModelComponent_UpdateInferenceVersionTraffic_Call{Call: _e.mock.On("UpdateInferenceVersionTraffic", ctx, id, req)}
+func (_e *MockModelComponent_Expecter) UpdateInferenceVersionTraffic(ctx interface{}, verReq interface{}, req interface{}) *MockModelComponent_UpdateInferenceVersionTraffic_Call {
+	return &MockModelComponent_UpdateInferenceVersionTraffic_Call{Call: _e.mock.On("UpdateInferenceVersionTraffic", ctx, verReq, req)}
 }
 
-func (_c *MockModelComponent_UpdateInferenceVersionTraffic_Call) Run(run func(ctx context.Context, id int64, req []types.UpdateInferenceVersionTrafficReq)) *MockModelComponent_UpdateInferenceVersionTraffic_Call {
+func (_c *MockModelComponent_UpdateInferenceVersionTraffic_Call) Run(run func(ctx context.Context, verReq types.DeployActReq, req []types.UpdateInferenceVersionTrafficReq)) *MockModelComponent_UpdateInferenceVersionTraffic_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(int64), args[2].([]types.UpdateInferenceVersionTrafficReq))
+		run(args[0].(context.Context), args[1].(types.DeployActReq), args[2].([]types.UpdateInferenceVersionTrafficReq))
 	})
 	return _c
 }
@@ -1417,7 +1417,7 @@ func (_c *MockModelComponent_UpdateInferenceVersionTraffic_Call) Return(_a0 erro
 	return _c
 }
 
-func (_c *MockModelComponent_UpdateInferenceVersionTraffic_Call) RunAndReturn(run func(context.Context, int64, []types.UpdateInferenceVersionTrafficReq) error) *MockModelComponent_UpdateInferenceVersionTraffic_Call {
+func (_c *MockModelComponent_UpdateInferenceVersionTraffic_Call) RunAndReturn(run func(context.Context, types.DeployActReq, []types.UpdateInferenceVersionTrafficReq) error) *MockModelComponent_UpdateInferenceVersionTraffic_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/api/handler/model.go
+++ b/api/handler/model.go
@@ -1885,6 +1885,7 @@ func (h *ModelHandler) ListQuantizations(ctx *gin.Context) {
 // @Failure      500  {object}  types.APIInternalServerError "Internal server error"
 // @Router       /models/{namespace}/{name}/run/versions/{id} [post]
 func (h *ModelHandler) CreateInferenceVersion(ctx *gin.Context) {
+	currentUser := httpbase.GetCurrentUser(ctx)
 	id, err := strconv.ParseInt(ctx.Param("id"), 10, 64)
 	if err != nil {
 		slog.ErrorContext(ctx.Request.Context(), "Bad request format", "error", err)
@@ -1906,12 +1907,21 @@ func (h *ModelHandler) CreateInferenceVersion(ctx *gin.Context) {
 		return
 	}
 
+	versionReq.CurrentUser = currentUser
 	versionReq.DeployId = id
+
 	err = h.model.CreateInferenceVersion(ctx.Request.Context(), versionReq)
 	if err != nil {
-		slog.ErrorContext(ctx.Request.Context(), "failed to create inference version", "error", err, "req", versionReq)
-		httpbase.ServerError(ctx, err)
-		return
+		if errors.Is(err, errorx.ErrForbidden) {
+			slog.WarnContext(ctx.Request.Context(), "not allowed to create inference version",
+				slog.Any("error", err), slog.Any("req", versionReq))
+			httpbase.ForbiddenError(ctx, err)
+			return
+		} else {
+			slog.ErrorContext(ctx.Request.Context(), "failed to create inference version", "error", err, "req", versionReq)
+			httpbase.ServerError(ctx, err)
+			return
+		}
 	}
 
 	httpbase.OK(ctx, nil)
@@ -1931,6 +1941,7 @@ func (h *ModelHandler) CreateInferenceVersion(ctx *gin.Context) {
 // @Failure      500  {object}  types.APIInternalServerError "Internal server error"
 // @Router       /models/{namespace}/{name}/run/versions/{id} [get]
 func (h *ModelHandler) ListInferenceVersions(ctx *gin.Context) {
+	currentUser := httpbase.GetCurrentUser(ctx)
 	id, err := strconv.ParseInt(ctx.Param("id"), 10, 64)
 	if err != nil {
 		slog.ErrorContext(ctx.Request.Context(), "Bad request format", "error", err)
@@ -1945,11 +1956,22 @@ func (h *ModelHandler) ListInferenceVersions(ctx *gin.Context) {
 		return
 	}
 
-	versions, err := h.model.ListInferenceVersions(ctx.Request.Context(), id)
+	versionReq := types.DeployActReq{
+		CurrentUser: currentUser,
+		DeployID:    id,
+	}
+	versions, err := h.model.ListInferenceVersions(ctx.Request.Context(), versionReq)
 	if err != nil {
-		slog.ErrorContext(ctx.Request.Context(), "failed to list inference versions", "error", err)
-		httpbase.ServerError(ctx, err)
-		return
+		if errors.Is(err, errorx.ErrForbidden) {
+			slog.WarnContext(ctx.Request.Context(), "not allowed to list inference versions",
+				slog.Any("error", err), slog.Any("req", versionReq))
+			httpbase.ForbiddenError(ctx, err)
+			return
+		} else {
+			slog.ErrorContext(ctx.Request.Context(), "failed to list inference versions", "error", err)
+			httpbase.ServerError(ctx, err)
+			return
+		}
 	}
 
 	httpbase.OK(ctx, versions)
@@ -1970,6 +1992,7 @@ func (h *ModelHandler) ListInferenceVersions(ctx *gin.Context) {
 // @Failure      500  {object}  types.APIInternalServerError "Internal server error"
 // @Router       /models/{namespace}/{name}/run/versions/{id}/traffic [put]
 func (h *ModelHandler) UpdateInferenceTraffic(ctx *gin.Context) {
+	currentUser := httpbase.GetCurrentUser(ctx)
 	id, err := strconv.ParseInt(ctx.Param("id"), 10, 64)
 	if err != nil {
 		slog.ErrorContext(ctx.Request.Context(), "Bad request format", "error", err)
@@ -1990,11 +2013,23 @@ func (h *ModelHandler) UpdateInferenceTraffic(ctx *gin.Context) {
 		return
 	}
 
-	err = h.model.UpdateInferenceVersionTraffic(ctx.Request.Context(), id, trafficReq)
+	versionReq := types.DeployActReq{
+		CurrentUser: currentUser,
+		DeployID:    id,
+	}
+
+	err = h.model.UpdateInferenceVersionTraffic(ctx.Request.Context(), versionReq, trafficReq)
 	if err != nil {
-		slog.ErrorContext(ctx.Request.Context(), "failed to update inference version traffic", "error", err)
-		httpbase.ServerError(ctx, err)
-		return
+		if errors.Is(err, errorx.ErrForbidden) {
+			slog.WarnContext(ctx.Request.Context(), "not allowed to update inference version traffic",
+				slog.Any("error", err), slog.Any("req", versionReq))
+			httpbase.ForbiddenError(ctx, err)
+			return
+		} else {
+			slog.ErrorContext(ctx.Request.Context(), "failed to update inference version traffic", "error", err)
+			httpbase.ServerError(ctx, err)
+			return
+		}
 	}
 
 	httpbase.OK(ctx, nil)
@@ -2015,6 +2050,7 @@ func (h *ModelHandler) UpdateInferenceTraffic(ctx *gin.Context) {
 // @Failure      500  {object}  types.APIInternalServerError "Internal server error"
 // @Router       /models/{namespace}/{name}/run/versions/{id}/{commit_id} [delete]
 func (h *ModelHandler) DeleteInferenceVersion(ctx *gin.Context) {
+	currentUser := httpbase.GetCurrentUser(ctx)
 	id, err := strconv.ParseInt(ctx.Param("id"), 10, 64)
 	if err != nil {
 		slog.ErrorContext(ctx.Request.Context(), "Bad request format", "error", err)
@@ -2024,11 +2060,23 @@ func (h *ModelHandler) DeleteInferenceVersion(ctx *gin.Context) {
 	}
 	commit_id := ctx.Param("commit_id")
 
-	err = h.model.DeleteInferenceVersion(ctx.Request.Context(), id, commit_id)
+	versionReq := types.DeployActReq{
+		CurrentUser: currentUser,
+		DeployID:    id,
+	}
+
+	err = h.model.DeleteInferenceVersion(ctx.Request.Context(), versionReq, commit_id)
 	if err != nil {
-		slog.ErrorContext(ctx.Request.Context(), "failed to delete inference version", "error", err)
-		httpbase.ServerError(ctx, err)
-		return
+		if errors.Is(err, errorx.ErrForbidden) {
+			slog.WarnContext(ctx.Request.Context(), "not allowed to delete inference version",
+				slog.Any("error", err), slog.Any("req", versionReq))
+			httpbase.ForbiddenError(ctx, err)
+			return
+		} else {
+			slog.ErrorContext(ctx.Request.Context(), "failed to delete inference version", "error", err)
+			httpbase.ServerError(ctx, err)
+			return
+		}
 	}
 
 	httpbase.OK(ctx, nil)

--- a/api/handler/model_test.go
+++ b/api/handler/model_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	mockcomponent "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/component"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 )
 
@@ -108,6 +109,31 @@ func TestModelHandler_CreateInferenceVersion_ServiceError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
+func TestModelHandler_CreateInferenceVersion_Forbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	mc := mockcomponent.NewMockModelComponent(t)
+	mc.EXPECT().CreateInferenceVersion(mock.Anything, mock.Anything).Return(errorx.ErrForbidden)
+
+	handler := &ModelHandler{
+		model: mc,
+	}
+	router.POST("/api/v1/models/:namespace/:name/run/versions/:id", handler.CreateInferenceVersion)
+
+	req := &types.CreateInferenceVersionReq{
+		CommitID:       "test-commit",
+		TrafficPercent: 50,
+	}
+	body, _ := json.Marshal(req)
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest("POST", "/api/v1/models/test-namespace/test-model/run/versions/123", bytes.NewBuffer(body))
+	request.Header.Set("Content-Type", "application/json")
+
+	router.ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 func TestModelHandler_ListInferenceVersions_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
@@ -119,7 +145,7 @@ func TestModelHandler_ListInferenceVersions_Success(t *testing.T) {
 			IsReady:        true,
 		},
 	}
-	mc.EXPECT().ListInferenceVersions(mock.Anything, int64(123)).Return(expectedVersions, nil)
+	mc.EXPECT().ListInferenceVersions(mock.Anything, types.DeployActReq{DeployID: 123}).Return(expectedVersions, nil)
 
 	handler := &ModelHandler{
 		model: mc,
@@ -156,7 +182,7 @@ func TestModelHandler_ListInferenceVersions_ServiceError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
 	mc := mockcomponent.NewMockModelComponent(t)
-	mc.EXPECT().ListInferenceVersions(mock.Anything, int64(123)).Return(nil, errors.New("service error"))
+	mc.EXPECT().ListInferenceVersions(mock.Anything, types.DeployActReq{DeployID: 123}).Return(nil, errors.New("service error"))
 
 	handler := &ModelHandler{
 		model: mc,
@@ -171,11 +197,30 @@ func TestModelHandler_ListInferenceVersions_ServiceError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
+func TestModelHandler_ListInferenceVersions_Forbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	mc := mockcomponent.NewMockModelComponent(t)
+	mc.EXPECT().ListInferenceVersions(mock.Anything, types.DeployActReq{DeployID: 123}).Return(nil, errorx.ErrForbidden)
+
+	handler := &ModelHandler{
+		model: mc,
+	}
+	router.GET("/api/v1/models/:namespace/:name/run/versions/:id", handler.ListInferenceVersions)
+
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/api/v1/models/test-namespace/test-model/run/versions/123", nil)
+
+	router.ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 func TestModelHandler_UpdateInferenceTraffic_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
 	mc := mockcomponent.NewMockModelComponent(t)
-	mc.EXPECT().UpdateInferenceVersionTraffic(mock.Anything, int64(123), mock.Anything).Return(nil)
+	mc.EXPECT().UpdateInferenceVersionTraffic(mock.Anything, types.DeployActReq{DeployID: 123}, mock.Anything).Return(nil)
 
 	handler := &ModelHandler{
 		model: mc,
@@ -251,7 +296,7 @@ func TestModelHandler_UpdateInferenceTraffic_ServiceError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
 	mc := mockcomponent.NewMockModelComponent(t)
-	mc.EXPECT().UpdateInferenceVersionTraffic(mock.Anything, int64(123), mock.Anything).Return(errors.New("service error"))
+	mc.EXPECT().UpdateInferenceVersionTraffic(mock.Anything, types.DeployActReq{DeployID: 123}, mock.Anything).Return(errors.New("service error"))
 
 	handler := &ModelHandler{
 		model: mc,
@@ -274,11 +319,38 @@ func TestModelHandler_UpdateInferenceTraffic_ServiceError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
+func TestModelHandler_UpdateInferenceTraffic_Forbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	mc := mockcomponent.NewMockModelComponent(t)
+	mc.EXPECT().UpdateInferenceVersionTraffic(mock.Anything, types.DeployActReq{DeployID: 123}, mock.Anything).Return(errorx.ErrForbidden)
+
+	handler := &ModelHandler{
+		model: mc,
+	}
+	router.PUT("/api/v1/models/:namespace/:name/run/versions/:id/traffic", handler.UpdateInferenceTraffic)
+
+	trafficReq := []types.UpdateInferenceVersionTrafficReq{
+		{
+			CommitID:       "commit1",
+			TrafficPercent: 100,
+		},
+	}
+	body, _ := json.Marshal(trafficReq)
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest("PUT", "/api/v1/models/test-namespace/test-model/run/versions/123/traffic", bytes.NewBuffer(body))
+	request.Header.Set("Content-Type", "application/json")
+
+	router.ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 func TestModelHandler_DeleteInferenceVersion_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
 	mc := mockcomponent.NewMockModelComponent(t)
-	mc.EXPECT().DeleteInferenceVersion(mock.Anything, int64(123), "commit123").Return(nil)
+	mc.EXPECT().DeleteInferenceVersion(mock.Anything, types.DeployActReq{DeployID: 123}, "commit123").Return(nil)
 
 	handler := &ModelHandler{
 		model: mc,
@@ -315,7 +387,7 @@ func TestModelHandler_DeleteInferenceVersion_ServiceError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.Default()
 	mc := mockcomponent.NewMockModelComponent(t)
-	mc.EXPECT().DeleteInferenceVersion(mock.Anything, int64(123), "commit123").Return(errors.New("service error"))
+	mc.EXPECT().DeleteInferenceVersion(mock.Anything, types.DeployActReq{DeployID: 123}, "commit123").Return(errors.New("service error"))
 
 	handler := &ModelHandler{
 		model: mc,
@@ -324,6 +396,93 @@ func TestModelHandler_DeleteInferenceVersion_ServiceError(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	request, _ := http.NewRequest("DELETE", "/api/v1/models/test-namespace/test-model/run/versions/123/commit123", nil)
+
+	router.ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestModelHandler_DeleteInferenceVersion_Forbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	mc := mockcomponent.NewMockModelComponent(t)
+	mc.EXPECT().DeleteInferenceVersion(mock.Anything, types.DeployActReq{DeployID: 123}, "commit123").Return(errorx.ErrForbidden)
+
+	handler := &ModelHandler{
+		model: mc,
+	}
+	router.DELETE("/api/v1/models/:namespace/:name/run/versions/:id/:commit_id", handler.DeleteInferenceVersion)
+
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest("DELETE", "/api/v1/models/test-namespace/test-model/run/versions/123/commit123", nil)
+
+	router.ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+func TestModelHandler_IndexV2_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	mc := mockcomponent.NewMockModelComponent(t)
+	mc.EXPECT().IndexV2(mock.Anything, mock.Anything, 10, 2, false).Return([]*types.Model{
+		{ID: 1, Name: "model1", Path: "u/model1"},
+		{ID: 2, Name: "model2", Path: "u/model2"},
+	}, 100, nil)
+
+	handler := &ModelHandler{model: mc}
+	router.GET("/api/v1/models/v2", handler.IndexV2)
+
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/api/v1/models/v2?per=10&page=2&sort=trending", nil)
+
+	router.ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestModelHandler_IndexV2_InvalidSort(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	mc := mockcomponent.NewMockModelComponent(t)
+
+	handler := &ModelHandler{model: mc}
+	router.GET("/api/v1/models/v2", handler.IndexV2)
+
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/api/v1/models/v2?sort=invalid_sort", nil)
+
+	router.ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestModelHandler_IndexV2_InvalidSource(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	mc := mockcomponent.NewMockModelComponent(t)
+
+	handler := &ModelHandler{model: mc}
+	router.GET("/api/v1/models/v2", handler.IndexV2)
+
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/api/v1/models/v2?source=invalid", nil)
+
+	router.ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestModelHandler_IndexV2_ServiceError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	mc := mockcomponent.NewMockModelComponent(t)
+	mc.EXPECT().IndexV2(mock.Anything, mock.Anything, 10, 1, false).Return(nil, 0, errors.New("db error"))
+
+	handler := &ModelHandler{model: mc}
+	router.GET("/api/v1/models/v2", handler.IndexV2)
+
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest("GET", "/api/v1/models/v2?per=10&page=1", nil)
 
 	router.ServeHTTP(w, request)
 

--- a/api/handler/repo_deploy.go
+++ b/api/handler/repo_deploy.go
@@ -328,7 +328,8 @@ func (h *RepoHandler) DeployDetail(ctx *gin.Context) {
 	response, err := h.c.DeployDetail(ctx.Request.Context(), detailReq)
 	if err != nil {
 		if errors.Is(err, errorx.ErrForbidden) {
-			slog.Info("not allowed to get deploy detail", slog.Any("error", err), slog.Any("req", detailReq))
+			slog.WarnContext(ctx.Request.Context(), "not allowed to get deploy detail",
+				slog.Any("error", err), slog.Any("req", detailReq))
 			httpbase.ForbiddenError(ctx, err)
 		} else if errors.Is(err, errorx.ErrDatabaseNoRows) {
 			httpbase.NotFoundError(ctx, err)

--- a/common/types/model.go
+++ b/common/types/model.go
@@ -563,8 +563,9 @@ type Image struct {
 }
 
 type CreateInferenceVersionReq struct {
-	DeployId int64  `json:"-"`
-	CommitID string `json:"commit_id"`
+	CurrentUser string `json:"-"`
+	DeployId    int64  `json:"-"`
+	CommitID    string `json:"commit_id"`
 
 	TrafficPercent int `json:"traffic_percent"`
 }

--- a/component/model.go
+++ b/component/model.go
@@ -91,9 +91,9 @@ type ModelComponent interface {
 	OrgModels(ctx context.Context, req *types.OrgModelsReq) ([]types.Model, int, error)
 	ListQuantizations(ctx context.Context, namespace, name string) ([]*types.File, error)
 	CreateInferenceVersion(ctx context.Context, req types.CreateInferenceVersionReq) error
-	ListInferenceVersions(ctx context.Context, id int64) ([]types.ListInferenceVersionsResp, error)
-	UpdateInferenceVersionTraffic(ctx context.Context, id int64, req []types.UpdateInferenceVersionTrafficReq) error
-	DeleteInferenceVersion(ctx context.Context, id int64, commitID string) error
+	ListInferenceVersions(ctx context.Context, verReq types.DeployActReq) ([]types.ListInferenceVersionsResp, error)
+	UpdateInferenceVersionTraffic(ctx context.Context, verReq types.DeployActReq, req []types.UpdateInferenceVersionTrafficReq) error
+	DeleteInferenceVersion(ctx context.Context, verReq types.DeployActReq, commitID string) error
 }
 
 func NewModelComponent(config *config.Config) (ModelComponent, error) {
@@ -1625,106 +1625,4 @@ func (c *modelComponentImpl) addWeightsToModel(ctx context.Context, repoID int64
 			}
 		}
 	}
-}
-
-func (c *modelComponentImpl) CreateInferenceVersion(ctx context.Context, req types.CreateInferenceVersionReq) error {
-	deploy, err := c.deployTaskStore.GetDeployByID(ctx, req.DeployId)
-	if err != nil {
-		return errorx.ErrDeployNotFoundErr
-	}
-
-	if deploy.Status != dcommon.Running {
-		return errorx.ErrDeployStatusNotMatchErr
-	}
-
-	if req.TrafficPercent > 100 || req.TrafficPercent < 0 {
-		return errorx.ErrTrafficInvalid
-	}
-
-	if req.CommitID == "" {
-		return errorx.ErrCommitIDEmpty
-	}
-	commitID, err := common.ShortenCommitID7(req.CommitID)
-	if err != nil {
-		return errorx.ErrInvalidCommitID
-	}
-
-	req.CommitID = commitID
-
-	return c.imageRunner.CreateRevisions(ctx, &types.CreateRevisionReq{
-		ClusterID:      deploy.ClusterID,
-		SvcName:        deploy.SvcName,
-		Commit:         req.CommitID,
-		InitialTraffic: req.TrafficPercent,
-	})
-}
-
-func (c *modelComponentImpl) ListInferenceVersions(ctx context.Context, id int64) ([]types.ListInferenceVersionsResp, error) {
-	deploy, err := c.deployTaskStore.GetDeployByID(ctx, id)
-	if err != nil {
-		return nil, errorx.ErrDeployNotFoundErr
-	}
-	var resp = []types.ListInferenceVersionsResp{}
-
-	versions, err := c.imageRunner.ListKsvcVersions(ctx, deploy.ClusterID, deploy.SvcName)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, version := range versions {
-		resp = append(resp, types.ListInferenceVersionsResp{
-			Commit:         version.Commit,
-			CreateTime:     version.CreateTime,
-			IsReady:        version.IsReady,
-			TrafficPercent: version.TrafficPercent,
-			RevisionName:   version.RevisionName,
-			Message:        version.Message,
-			Reason:         version.Reason,
-		})
-	}
-
-	return resp, nil
-}
-
-func (c *modelComponentImpl) UpdateInferenceVersionTraffic(ctx context.Context, id int64, req []types.UpdateInferenceVersionTrafficReq) error {
-	deploy, err := c.deployTaskStore.GetDeployByID(ctx, id)
-	if err != nil {
-		return errorx.ErrDeployNotFoundErr
-	}
-
-	if deploy.Status != dcommon.Running {
-		return errorx.ErrDeployStatusNotMatchErr
-	}
-
-	params := []types.TrafficReq{}
-	for _, item := range req {
-		params = append(params, types.TrafficReq{
-			Commit:         item.CommitID,
-			TrafficPercent: item.TrafficPercent,
-		})
-	}
-	err = c.imageRunner.SetVersionsTraffic(ctx, deploy.ClusterID, deploy.SvcName, params)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (c *modelComponentImpl) DeleteInferenceVersion(ctx context.Context, id int64, commitID string) error {
-	deploy, err := c.deployTaskStore.GetDeployByID(ctx, id)
-	if err != nil {
-		return errorx.ErrDeployNotFoundErr
-	}
-
-	if deploy.Status != dcommon.Running {
-		return errorx.ErrDeployStatusNotMatchErr
-	}
-
-	shortCommitId, err := common.ShortenCommitID7(commitID)
-	if err != nil {
-		return errorx.ErrInvalidCommitID
-	}
-
-	return c.imageRunner.DeleteKsvcVersion(ctx, deploy.ClusterID, deploy.SvcName, shortCommitId)
 }

--- a/component/model_version.go
+++ b/component/model_version.go
@@ -1,0 +1,117 @@
+package component
+
+import (
+	"context"
+
+	dcommon "opencsg.com/csghub-server/builder/deploy/common"
+	"opencsg.com/csghub-server/common/errorx"
+	"opencsg.com/csghub-server/common/types"
+	"opencsg.com/csghub-server/common/utils/common"
+)
+
+func (c *modelComponentImpl) CreateInferenceVersion(ctx context.Context, req types.CreateInferenceVersionReq) error {
+	verReq := types.DeployActReq{
+		CurrentUser: req.CurrentUser,
+		DeployID:    req.DeployId,
+	}
+	_, deploy, err := c.repoComponent.CheckDeployPermissionForUser(ctx, verReq)
+	if err != nil {
+		return err
+	}
+
+	if deploy.Status != dcommon.Running {
+		return errorx.ErrDeployStatusNotMatchErr
+	}
+
+	if req.TrafficPercent > 100 || req.TrafficPercent < 0 {
+		return errorx.ErrTrafficInvalid
+	}
+
+	if req.CommitID == "" {
+		return errorx.ErrCommitIDEmpty
+	}
+	commitID, err := common.ShortenCommitID7(req.CommitID)
+	if err != nil {
+		return errorx.ErrInvalidCommitID
+	}
+
+	req.CommitID = commitID
+
+	return c.imageRunner.CreateRevisions(ctx, &types.CreateRevisionReq{
+		ClusterID:      deploy.ClusterID,
+		SvcName:        deploy.SvcName,
+		Commit:         req.CommitID,
+		InitialTraffic: req.TrafficPercent,
+	})
+}
+
+func (c *modelComponentImpl) ListInferenceVersions(ctx context.Context, verReq types.DeployActReq) ([]types.ListInferenceVersionsResp, error) {
+	_, deploy, err := c.repoComponent.CheckDeployPermissionForUser(ctx, verReq)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp = []types.ListInferenceVersionsResp{}
+
+	versions, err := c.imageRunner.ListKsvcVersions(ctx, deploy.ClusterID, deploy.SvcName)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, version := range versions {
+		resp = append(resp, types.ListInferenceVersionsResp{
+			Commit:         version.Commit,
+			CreateTime:     version.CreateTime,
+			IsReady:        version.IsReady,
+			TrafficPercent: version.TrafficPercent,
+			RevisionName:   version.RevisionName,
+			Message:        version.Message,
+			Reason:         version.Reason,
+		})
+	}
+
+	return resp, nil
+}
+
+func (c *modelComponentImpl) UpdateInferenceVersionTraffic(ctx context.Context, verReq types.DeployActReq, req []types.UpdateInferenceVersionTrafficReq) error {
+	_, deploy, err := c.repoComponent.CheckDeployPermissionForUser(ctx, verReq)
+	if err != nil {
+		return err
+	}
+
+	if deploy.Status != dcommon.Running {
+		return errorx.ErrDeployStatusNotMatchErr
+	}
+
+	params := []types.TrafficReq{}
+	for _, item := range req {
+		params = append(params, types.TrafficReq{
+			Commit:         item.CommitID,
+			TrafficPercent: item.TrafficPercent,
+		})
+	}
+	err = c.imageRunner.SetVersionsTraffic(ctx, deploy.ClusterID, deploy.SvcName, params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *modelComponentImpl) DeleteInferenceVersion(ctx context.Context, verReq types.DeployActReq, commitID string) error {
+	_, deploy, err := c.repoComponent.CheckDeployPermissionForUser(ctx, verReq)
+	if err != nil {
+		return err
+	}
+
+	if deploy.Status != dcommon.Running {
+		return errorx.ErrDeployStatusNotMatchErr
+	}
+
+	shortCommitId, err := common.ShortenCommitID7(commitID)
+	if err != nil {
+		return errorx.ErrInvalidCommitID
+	}
+
+	return c.imageRunner.DeleteKsvcVersion(ctx, deploy.ClusterID, deploy.SvcName, shortCommitId)
+}

--- a/component/repo_ce_test.go
+++ b/component/repo_ce_test.go
@@ -33,6 +33,7 @@ func TestRepoComponent_DeployUpdate(t *testing.T) {
 		SvcName:          "svc",
 		ClusterID:        "cluster",
 		RuntimeFramework: "fm",
+		SecureLevel:      types.EndpointPublic,
 	}
 	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(1)).Return(deploy, nil)
 	repo.mocks.stores.SpaceResourceMock().EXPECT().FindByID(ctx, int64(111)).Return(&database.SpaceResource{
@@ -84,6 +85,7 @@ func TestRepoComponent_DeployStart(t *testing.T) {
 		ClusterID:        "cluster",
 		RuntimeFramework: "fm",
 		SKU:              "111",
+		SecureLevel:      types.EndpointPublic,
 	}
 	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(1)).Return(deploy, nil)
 
@@ -131,6 +133,7 @@ func TestRepoComponent_DeployStart_ExistAndRunning(t *testing.T) {
 		ClusterID:        "cluster",
 		RuntimeFramework: "fm",
 		SKU:              "111",
+		SecureLevel:      types.EndpointPublic,
 	}
 	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(1)).Return(deploy, nil)
 
@@ -181,6 +184,7 @@ func TestRepoComponent_DeployStart_ExistButNotRunning(t *testing.T) {
 		ClusterID:        "cluster",
 		RuntimeFramework: "fm",
 		SKU:              "111",
+		SecureLevel:      types.EndpointPublic,
 	}
 	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(1)).Return(deploy, nil)
 

--- a/component/repo_deploy.go
+++ b/component/repo_deploy.go
@@ -329,15 +329,33 @@ func (c *repoComponentImpl) CheckDeployPermissionForUser(ctx context.Context, de
 	}
 	deploy, err := c.deployTaskStore.GetDeployByID(ctx, deployReq.DeployID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("fail to get user deploy %v, %w", deployReq.DeployID, err)
+		return nil, nil, fmt.Errorf("failed to get user deploy %v, %w", deployReq.DeployID, err)
 	}
 	if deploy == nil {
 		return nil, nil, fmt.Errorf("do not found user deploy %v", deployReq.DeployID)
 	}
 
-	if deploy.UserID == user.ID || c.IsAdminRole(user) || c.IsInSameOrg(ctx, user.ID, deploy.UserID) {
+	// Creator is always allowed, regardless of SecureLevel for backward compatibility.
+	if deploy.UserID == user.ID {
 		return &user, deploy, nil
 	}
+
+	switch deploy.SecureLevel {
+	case types.EndpointPublic:
+		if c.IsAdminRole(user) || c.IsInSameOrg(ctx, user.ID, deploy.UserID) {
+			return &user, deploy, nil
+		}
+	case types.EndpointPrivate:
+		// Only creator is allowed for private endpoints;
+		// fall through to forbidden below
+	default:
+		// Default to public behavior for backward compatibility
+		// with existing deployments that have SecureLevel = 0 (unset)
+		if c.IsAdminRole(user) || c.IsInSameOrg(ctx, user.ID, deploy.UserID) {
+			return &user, deploy, nil
+		}
+	}
+
 	return nil, nil, errorx.ErrForbiddenMsg("deploy was not created by user")
 }
 

--- a/component/repo_deploy_test.go
+++ b/component/repo_deploy_test.go
@@ -33,10 +33,11 @@ func TestRepoComponent_DeployInstanceLastLogs_NormalUser(t *testing.T) {
 		RoleMask: "",
 	}
 	dbDeploy := &database.Deploy{
-		ID:        1,
-		UserID:    123,
-		SvcName:   "svc-1",
-		ClusterID: "cluster-1",
+		ID:           1,
+		UserID:       123,
+		SvcName:      "svc-1",
+		ClusterID:    "cluster-1",
+		SecureLevel:  types.EndpointPublic,
 	}
 
 	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "test-user").Return(dbUser, nil)
@@ -97,10 +98,11 @@ func TestRepoComponent_DeployInstanceLastLogs_SingleStream(t *testing.T) {
 		RoleMask: "",
 	}
 	dbDeploy := &database.Deploy{
-		ID:        2,
-		UserID:    123,
-		SvcName:   "svc-2",
-		ClusterID: "cluster-2",
+		ID:           2,
+		UserID:       123,
+		SvcName:      "svc-2",
+		ClusterID:    "cluster-2",
+		SecureLevel:  types.EndpointPublic,
 	}
 
 	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "test-user").Return(dbUser, nil)
@@ -150,10 +152,11 @@ func TestRepoComponent_DeployInstanceLastLogs_EmptyResult(t *testing.T) {
 		RoleMask: "",
 	}
 	dbDeploy := &database.Deploy{
-		ID:        3,
-		UserID:    123,
-		SvcName:   "svc-3",
-		ClusterID: "cluster-3",
+		ID:           3,
+		UserID:       123,
+		SvcName:      "svc-3",
+		ClusterID:    "cluster-3",
+		SecureLevel:  types.EndpointPublic,
 	}
 
 	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "test-user").Return(dbUser, nil)
@@ -192,10 +195,11 @@ func TestRepoComponent_DeployInstanceLastLogs_DeployerError(t *testing.T) {
 		RoleMask: "",
 	}
 	dbDeploy := &database.Deploy{
-		ID:        4,
-		UserID:    123,
-		SvcName:   "svc-4",
-		ClusterID: "cluster-4",
+		ID:           4,
+		UserID:       123,
+		SvcName:      "svc-4",
+		ClusterID:    "cluster-4",
+		SecureLevel:  types.EndpointPublic,
 	}
 
 	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "test-user").Return(dbUser, nil)
@@ -206,6 +210,238 @@ func TestRepoComponent_DeployInstanceLastLogs_DeployerError(t *testing.T) {
 	result, err := repo.DeployInstanceLastLogs(ctx, logReq)
 	require.Error(t, err)
 	require.Nil(t, result)
+}
+
+func TestCheckDeployPermissionForUser_ZeroSecureLevel_OwnerAllowed(t *testing.T) {
+	ctx := context.TODO()
+	repo := initializeTestRepoComponent(ctx, t)
+
+	dbUser := database.User{
+		ID:       123,
+		RoleMask: "",
+	}
+	dbDeploy := &database.Deploy{
+		ID:          1,
+		UserID:      123,
+		SvcName:     "svc-1",
+		ClusterID:   "cluster-1",
+		SecureLevel: 0,
+	}
+
+	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "owner-user").Return(dbUser, nil)
+	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(1)).Return(dbDeploy, nil)
+
+	user, deploy, err := repo.CheckDeployPermissionForUser(ctx, types.DeployActReq{
+		CurrentUser: "owner-user",
+		DeployID:    1,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	require.NotNil(t, deploy)
+	require.Equal(t, int64(123), user.ID)
+}
+
+func TestCheckDeployPermissionForUser_ZeroSecureLevel_NonOwnerForbidden(t *testing.T) {
+	ctx := context.TODO()
+	repo := initializeTestRepoComponent(ctx, t)
+	repo.orgStore = repo.mocks.stores.Org
+
+	dbUser := database.User{
+		ID:       456,
+		RoleMask: "",
+	}
+	dbDeploy := &database.Deploy{
+		ID:          1,
+		UserID:      123,
+		SvcName:     "svc-1",
+		ClusterID:   "cluster-1",
+		SecureLevel: 0,
+	}
+
+	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "other-user").Return(dbUser, nil)
+	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(1)).Return(dbDeploy, nil)
+	repo.mocks.stores.OrgMock().EXPECT().GetSharedOrgIDs(ctx, []int64{456, 123}).Return([]int64{}, nil)
+
+	user, deploy, err := repo.CheckDeployPermissionForUser(ctx, types.DeployActReq{
+		CurrentUser: "other-user",
+		DeployID:    1,
+	})
+	require.Error(t, err)
+	require.Nil(t, user)
+	require.Nil(t, deploy)
+}
+
+func TestCheckDeployPermissionForUser_PrivateEndpoint_OwnerAllowed(t *testing.T) {
+	ctx := context.TODO()
+	repo := initializeTestRepoComponent(ctx, t)
+
+	dbUser := database.User{
+		ID:       123,
+		RoleMask: "",
+	}
+	dbDeploy := &database.Deploy{
+		ID:          1,
+		UserID:      123,
+		SvcName:     "svc-1",
+		ClusterID:   "cluster-1",
+		SecureLevel: types.EndpointPrivate,
+	}
+
+	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "owner-user").Return(dbUser, nil)
+	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(1)).Return(dbDeploy, nil)
+
+	user, deploy, err := repo.CheckDeployPermissionForUser(ctx, types.DeployActReq{
+		CurrentUser: "owner-user",
+		DeployID:    1,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	require.NotNil(t, deploy)
+}
+
+func TestCheckDeployPermissionForUser_PrivateEndpoint_AdminForbidden(t *testing.T) {
+	ctx := context.TODO()
+	repo := initializeTestRepoComponent(ctx, t)
+
+	dbUser := database.User{
+		ID:       456,
+		RoleMask: "admin",
+	}
+	dbDeploy := &database.Deploy{
+		ID:          1,
+		UserID:      123,
+		SvcName:     "svc-1",
+		ClusterID:   "cluster-1",
+		SecureLevel: types.EndpointPrivate,
+	}
+
+	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "admin-user").Return(dbUser, nil)
+	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(1)).Return(dbDeploy, nil)
+
+	user, deploy, err := repo.CheckDeployPermissionForUser(ctx, types.DeployActReq{
+		CurrentUser: "admin-user",
+		DeployID:    1,
+	})
+	require.Error(t, err)
+	require.Nil(t, user)
+	require.Nil(t, deploy)
+}
+
+func TestCheckDeployPermissionForUser_PublicEndpoint_OwnerAllowed(t *testing.T) {
+	ctx := context.TODO()
+	repo := initializeTestRepoComponent(ctx, t)
+
+	dbUser := database.User{
+		ID:       123,
+		RoleMask: "",
+	}
+	dbDeploy := &database.Deploy{
+		ID:          1,
+		UserID:      123,
+		SvcName:     "svc-1",
+		ClusterID:   "cluster-1",
+		SecureLevel: types.EndpointPublic,
+	}
+
+	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "owner-user").Return(dbUser, nil)
+	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(1)).Return(dbDeploy, nil)
+
+	user, deploy, err := repo.CheckDeployPermissionForUser(ctx, types.DeployActReq{
+		CurrentUser: "owner-user",
+		DeployID:    1,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	require.NotNil(t, deploy)
+	require.Equal(t, int64(123), user.ID)
+}
+
+func TestCheckDeployPermissionForUser_PublicEndpoint_AdminAllowed(t *testing.T) {
+	ctx := context.TODO()
+	repo := initializeTestRepoComponent(ctx, t)
+
+	dbUser := database.User{
+		ID:       456,
+		RoleMask: "admin",
+	}
+	dbDeploy := &database.Deploy{
+		ID:          1,
+		UserID:      123,
+		SvcName:     "svc-1",
+		ClusterID:   "cluster-1",
+		SecureLevel: types.EndpointPublic,
+	}
+
+	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "admin-user").Return(dbUser, nil)
+	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(1)).Return(dbDeploy, nil)
+
+	user, deploy, err := repo.CheckDeployPermissionForUser(ctx, types.DeployActReq{
+		CurrentUser: "admin-user",
+		DeployID:    1,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	require.NotNil(t, deploy)
+}
+
+func TestCheckDeployPermissionForUser_PublicEndpoint_SameOrgAllowed(t *testing.T) {
+	ctx := context.TODO()
+	repo := initializeTestRepoComponent(ctx, t)
+	repo.orgStore = repo.mocks.stores.Org
+
+	dbUser := database.User{
+		ID:       456,
+		RoleMask: "",
+	}
+	dbDeploy := &database.Deploy{
+		ID:          1,
+		UserID:      123,
+		SvcName:     "svc-1",
+		ClusterID:   "cluster-1",
+		SecureLevel: types.EndpointPublic,
+	}
+
+	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "org-member").Return(dbUser, nil)
+	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(1)).Return(dbDeploy, nil)
+	repo.mocks.stores.OrgMock().EXPECT().GetSharedOrgIDs(ctx, []int64{456, 123}).Return([]int64{10}, nil)
+
+	user, deploy, err := repo.CheckDeployPermissionForUser(ctx, types.DeployActReq{
+		CurrentUser: "org-member",
+		DeployID:    1,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	require.NotNil(t, deploy)
+}
+
+func TestCheckDeployPermissionForUser_PublicEndpoint_DifferentOrgForbidden(t *testing.T) {
+	ctx := context.TODO()
+	repo := initializeTestRepoComponent(ctx, t)
+	repo.orgStore = repo.mocks.stores.Org
+
+	dbUser := database.User{
+		ID:       456,
+		RoleMask: "",
+	}
+	dbDeploy := &database.Deploy{
+		ID:          1,
+		UserID:      123,
+		SvcName:     "svc-1",
+		ClusterID:   "cluster-1",
+		SecureLevel: types.EndpointPublic,
+	}
+
+	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "other-user").Return(dbUser, nil)
+	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(1)).Return(dbDeploy, nil)
+	repo.mocks.stores.OrgMock().EXPECT().GetSharedOrgIDs(ctx, []int64{456, 123}).Return([]int64{}, nil)
+
+	user, deploy, err := repo.CheckDeployPermissionForUser(ctx, types.DeployActReq{
+		CurrentUser: "other-user",
+		DeployID:    1,
+	})
+	require.Error(t, err)
+	require.Nil(t, user)
+	require.Nil(t, deploy)
 }
 
 func TestRepoComponent_DeployInstanceLastLogs_ServerlessType(t *testing.T) {
@@ -227,10 +463,11 @@ func TestRepoComponent_DeployInstanceLastLogs_ServerlessType(t *testing.T) {
 		RoleMask: "admin",
 	}
 	dbDeploy := &database.Deploy{
-		ID:        6,
-		UserID:    1,
-		SvcName:   "svc-6",
-		ClusterID: "cluster-6",
+		ID:           6,
+		UserID:       1,
+		SvcName:      "svc-6",
+		ClusterID:    "cluster-6",
+		SecureLevel:  types.EndpointPublic,
 	}
 
 	repo.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "admin-user").Return(dbUser, nil)

--- a/component/repo_test.go
+++ b/component/repo_test.go
@@ -1342,6 +1342,7 @@ func TestRepoComponent_DeleteDeploy(t *testing.T) {
 		UserUUID:      "uuid",
 		OrderDetailID: 11,
 		ClusterID:     "cluster",
+		SecureLevel:   types.EndpointPublic,
 	}, nil)
 	repo.mocks.stores.DeployTaskMock().EXPECT().DeleteDeploy(
 		ctx, types.ModelRepo, int64(1), int64(0), int64(3),
@@ -1377,6 +1378,7 @@ func TestRepoComponent_DeployDetail(t *testing.T) {
 		SvcName:       "svc",
 		Status:        deployStatus.Running,
 		Type:          types.InferenceType,
+		SecureLevel:   types.EndpointPublic,
 	}, nil)
 
 	repo.mocks.deployer.EXPECT().CheckClusterHealthy(ctx, "cluster").Return(true, nil)
@@ -1404,7 +1406,8 @@ func TestRepoComponent_DeployDetail(t *testing.T) {
 		Status:         "Running",
 		ClusterID:      "cluster",
 		Instances:      []types.Instance{{Name: "i1"}},
-		Private:        true,
+		Private:        false,
+		SecureLevel:    types.EndpointPublic,
 		SvcName:        "svc",
 		Endpoint:       "endpoint/svc",
 		Type:           types.InferenceType,
@@ -1442,6 +1445,7 @@ func TestRepoComponent_DeployDetailWithPD(t *testing.T) {
 		SvcName:       "svc",
 		Status:        deployStatus.Running,
 		PD:            pdConfig,
+		SecureLevel:   types.EndpointPublic,
 	}, nil)
 
 	repo.mocks.deployer.EXPECT().CheckClusterHealthy(ctx, "cluster").Return(true, nil)
@@ -1486,6 +1490,7 @@ func TestRepoComponent_DeployInstanceLogs(t *testing.T) {
 		ClusterID:     "cluster",
 		SvcName:       "svc",
 		Status:        deployStatus.Running,
+		SecureLevel:   types.EndpointPublic,
 	}, nil)
 
 	m := &deploy.MultiLogReader{}
@@ -1525,7 +1530,8 @@ func TestRepoComponent_DeployStop_WithForce(t *testing.T) {
 		ID: 2,
 	}, nil)
 	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(3)).Return(&database.Deploy{
-		UserID: 2,
+		UserID:      2,
+		SecureLevel: types.EndpointPublic,
 	}, nil)
 
 	err := repo.DeployStop(ctx, types.DeployActReq{
@@ -1556,7 +1562,8 @@ func TestRepoComponent_DeployStop_ForceFalse_CallsExist(t *testing.T) {
 		ID: 2,
 	}, nil)
 	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(3)).Return(&database.Deploy{
-		UserID: 2,
+		UserID:      2,
+		SecureLevel: types.EndpointPublic,
 	}, nil)
 
 	err := repo.DeployStop(ctx, types.DeployActReq{
@@ -1648,7 +1655,8 @@ func TestRepoComponent_DeployStop(t *testing.T) {
 		ID: 2,
 	}, nil)
 	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(3)).Return(&database.Deploy{
-		UserID: 2,
+		UserID:      2,
+		SecureLevel: types.EndpointPublic,
 	}, nil)
 
 	err := repo.DeployStop(ctx, types.DeployActReq{
@@ -1678,7 +1686,8 @@ func TestRepoComponent_DeployStop_ErrNoRows(t *testing.T) {
 		ID: 2,
 	}, nil)
 	repo.mocks.stores.DeployTaskMock().EXPECT().GetDeployByID(ctx, int64(3)).Return(&database.Deploy{
-		UserID: 2,
+		UserID:      2,
+		SecureLevel: types.EndpointPublic,
 	}, nil)
 
 	err := repo.DeployStop(ctx, types.DeployActReq{


### PR DESCRIPTION
Summary:
- Added permission checks to inference version endpoints to restrict access for private instances (`SecureLevel=EndpointPrivate`) exclusively to the creator, preventing admins and same-org users from bypassing this restriction.
- Refactored inference version methods into a new `model_version.go` file, updating their signatures to accept `DeployActReq` and `CurrentUser` for proper authorization validation.
- Updated API handlers to pass the current user context and correctly return a 403 status on `ErrForbidden` instead of 500.