### PR TITLE
Add user API authorization

### DIFF
--- a/api/router/api.go
+++ b/api/router/api.go
@@ -305,14 +305,7 @@ func NewRouter(config *config.Config, enableSwagger bool) (*gin.Engine, error) {
 
 	createUserRoutes(apiGroup, middlewareCollection, userProxyHandler, userHandler)
 
-	tokenGroup := apiGroup.Group("token")
-	{
-		tokenGroup.POST("/:app/:token_name", userProxyHandler.ProxyToApi("/api/v1/token/%s/%s", "app", "token_name"))
-		tokenGroup.PUT("/:app/:token_name", userProxyHandler.ProxyToApi("/api/v1/token/%s/%s", "app", "token_name"))
-		tokenGroup.DELETE("/:app/:token_name", userProxyHandler.ProxyToApi("/api/v1/token/%s/%s", "app", "token_name"))
-		// check token info
-		tokenGroup.GET("/:token_value", userProxyHandler.ProxyToApi("/api/v1/token/%s", "token_value"))
-	}
+	createTokenRoutes(apiGroup, middlewareCollection, userProxyHandler)
 
 	sshKeyHandler, err := handler.NewSSHKeyHandler(config)
 	if err != nil {
@@ -337,7 +330,6 @@ func NewRouter(config *config.Config, enableSwagger bool) (*gin.Engine, error) {
 	// JWT token
 	apiGroup.POST("/jwt/token", middlewareCollection.Auth.NeedAPIKey, userProxyHandler.Proxy)
 	apiGroup.GET("/jwt/:token", middlewareCollection.Auth.NeedAPIKey, userProxyHandler.ProxyToApi("/api/v1/jwt/%s", "token"))
-	apiGroup.GET("/users", userProxyHandler.Proxy)
 	apiGroup.GET("/users/stream-export", middlewareCollection.Auth.NeedAdmin, userProxyHandler.Proxy)
 
 	// callback
@@ -1023,17 +1015,12 @@ func createUserRoutes(apiGroup *gin.RouterGroup, middlewareCollection middleware
 		keysGroup.DELETE("/:uuid/apikeys/:id", userProxyHandler.Proxy)
 		keysGroup.PUT("/:uuid/apikeys/builtin/refresh", userProxyHandler.Proxy)
 	}
-	// deprecated
-	{
-		apiGroup.POST("/users", userProxyHandler.ProxyToApi("/api/v1/user"))
-		apiGroup.PUT("/users/:username", userProxyHandler.ProxyToApi("/api/v1/user/%v", "username"))
-	}
 
 	{
 		apiGroup.POST("/user", userProxyHandler.Proxy)
 		apiGroup.GET("/user/:username", userProxyHandler.Proxy)
-		apiGroup.PUT("/user/:username", userProxyHandler.Proxy)
-		apiGroup.DELETE("/user/:username", userProxyHandler.Proxy)
+		apiGroup.PUT("/user/:username", middlewareCollection.Auth.NeedLogin, userProxyHandler.Proxy)
+		apiGroup.DELETE("/user/:username", middlewareCollection.Auth.NeedAdmin, userProxyHandler.Proxy)
 		apiGroup.PUT("/user/labels", middlewareCollection.Auth.NeedAdmin, userProxyHandler.Proxy)
 		apiGroup.GET("/user/:username/organizations", userProxyHandler.Proxy)
 	}
@@ -1042,7 +1029,7 @@ func createUserRoutes(apiGroup *gin.RouterGroup, middlewareCollection middleware
 		apiGroup.POST("/user/verify", middlewareCollection.Auth.NeedLogin, userProxyHandler.Proxy)
 		apiGroup.PUT("/user/verify/:id", middlewareCollection.Auth.NeedAdmin, userProxyHandler.ProxyToApi("/api/v1/user/verify/%s", "id"))
 		apiGroup.GET("/user/verify/:id", middlewareCollection.Auth.NeedLogin, userProxyHandler.ProxyToApi("/api/v1/user/verify/%s", "id"))
-		apiGroup.DELETE("/user/:username/close_account", userProxyHandler.Proxy)
+		apiGroup.DELETE("/user/:username/close_account", middlewareCollection.Auth.NeedLogin, userProxyHandler.Proxy)
 		apiGroup.POST("/user/email-verification-code/:email", middlewareCollection.Auth.NeedLogin, userProxyHandler.Proxy)
 	}
 
@@ -1086,7 +1073,7 @@ func createUserRoutes(apiGroup *gin.RouterGroup, middlewareCollection middleware
 	apiGroup.PUT("/user/:username/likes/collections/:id", middlewareCollection.Auth.NeedLogin, userHandler.LikeCollection)
 	apiGroup.DELETE("/user/:username/likes/collections/:id", middlewareCollection.Auth.NeedLogin, userHandler.UnLikeCollection)
 	// user owned tokens
-	apiGroup.GET("/user/:username/tokens", userProxyHandler.ProxyToApi("/api/v1/user/%s/tokens", "username"))
+	apiGroup.GET("/user/:username/tokens", middlewareCollection.Auth.NeedLogin, userProxyHandler.ProxyToApi("/api/v1/user/%s/tokens", "username"))
 
 	// serverless list
 	apiGroup.GET("/user/:username/run/serverless", middlewareCollection.License.Check, middlewareCollection.Auth.NeedAdmin, userHandler.GetRunServerless)
@@ -1101,6 +1088,11 @@ func createUserRoutes(apiGroup *gin.RouterGroup, middlewareCollection middleware
 
 	// Inference Arch
 	createInferenceArchRoutes(apiGroup, middlewareCollection)
+
+	// GET /users returns a paginated user list. Non-admin users receive a
+	// limited response; the admin-only stream-export variant is registered
+	// directly in NewRouter.
+	apiGroup.GET("/users", middlewareCollection.Auth.NeedLogin, userProxyHandler.Proxy)
 
 	createExtendedUserRoutes(apiGroup, middlewareCollection, userProxyHandler)
 }
@@ -1392,13 +1384,24 @@ func createLfsSyncRoutes(apiGroup *gin.RouterGroup, middlewareCollection middlew
 	}
 }
 
+func createTokenRoutes(apiGroup *gin.RouterGroup, middlewareCollection middleware.MiddlewareCollection, userProxyHandler *handler.InternalServiceProxyHandler) {
+	tokenGroup := apiGroup.Group("/token")
+	{
+		tokenGroup.POST("/:app/:token_name", middlewareCollection.Auth.NeedLogin, userProxyHandler.ProxyToApi("/api/v1/token/%s/%s", "app", "token_name"))
+		tokenGroup.PUT("/:app/:token_name", middlewareCollection.Auth.NeedLogin, userProxyHandler.ProxyToApi("/api/v1/token/%s/%s", "app", "token_name"))
+		tokenGroup.DELETE("/:app/:token_name", middlewareCollection.Auth.NeedLogin, userProxyHandler.ProxyToApi("/api/v1/token/%s/%s", "app", "token_name"))
+		// check token info
+		tokenGroup.GET("/:token_value", userProxyHandler.ProxyToApi("/api/v1/token/%s", "token_value"))
+	}
+}
+
 func createOrgRoutes(apiGroup *gin.RouterGroup, middlewareCollection middleware.MiddlewareCollection, userProxyHandler *handler.InternalServiceProxyHandler, orgHandler *handler.OrganizationHandler) {
 	{
 		apiGroup.GET("/organizations", middlewareCollection.License.Check, userProxyHandler.Proxy)
-		apiGroup.POST("/organizations", userProxyHandler.Proxy)
+		apiGroup.POST("/organizations", middlewareCollection.Auth.NeedLogin, userProxyHandler.Proxy)
 		apiGroup.GET("/organization/:namespace", userProxyHandler.ProxyToApi("/api/v1/organization/%s", "namespace"))
-		apiGroup.PUT("/organization/:namespace", userProxyHandler.ProxyToApi("/api/v1/organization/%s", "namespace"))
-		apiGroup.DELETE("/organization/:namespace", userProxyHandler.ProxyToApi("/api/v1/organization/%s", "namespace"))
+		apiGroup.PUT("/organization/:namespace", middlewareCollection.Auth.NeedLogin, userProxyHandler.ProxyToApi("/api/v1/organization/%s", "namespace"))
+		apiGroup.DELETE("/organization/:namespace", middlewareCollection.Auth.NeedLogin, userProxyHandler.ProxyToApi("/api/v1/organization/%s", "namespace"))
 		// Organization assets
 		apiGroup.GET("/organization/:namespace/models", orgHandler.Models)
 		apiGroup.GET("/organization/:namespace/datasets", orgHandler.Datasets)
@@ -1417,10 +1420,10 @@ func createOrgRoutes(apiGroup *gin.RouterGroup, middlewareCollection middleware.
 
 	{
 		apiGroup.GET("/organization/:namespace/members", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members", "namespace"))
-		apiGroup.POST("/organization/:namespace/members", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members", "namespace"))
+		apiGroup.POST("/organization/:namespace/members", middlewareCollection.Auth.NeedLogin, userProxyHandler.ProxyToApi("/api/v1/organization/%s/members", "namespace"))
 		apiGroup.GET("/organization/:namespace/members/:username", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members/%s", "namespace", "username"))
-		apiGroup.PUT("/organization/:namespace/members/:username", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members/%s", "namespace", "username"))
-		apiGroup.DELETE("/organization/:namespace/members/:username", userProxyHandler.ProxyToApi("/api/v1/organization/%s/members/%s", "namespace", "username"))
+		apiGroup.PUT("/organization/:namespace/members/:username", middlewareCollection.Auth.NeedLogin, userProxyHandler.ProxyToApi("/api/v1/organization/%s/members/%s", "namespace", "username"))
+		apiGroup.DELETE("/organization/:namespace/members/:username", middlewareCollection.Auth.NeedLogin, userProxyHandler.ProxyToApi("/api/v1/organization/%s/members/%s", "namespace", "username"))
 	}
 	{
 		apiGroup.POST("/organization/verify", middlewareCollection.Auth.NeedLogin, userProxyHandler.Proxy)

--- a/api/router/api_user_routes_test.go
+++ b/api/router/api_user_routes_test.go
@@ -1,0 +1,400 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"opencsg.com/csghub-server/api/handler"
+	"opencsg.com/csghub-server/api/httpbase"
+	"opencsg.com/csghub-server/api/middleware"
+	"opencsg.com/csghub-server/common/errorx"
+)
+
+// needAdminMock returns a test version of NeedAdmin middleware that does not
+// require a real user-service RPC. It behaves identically to the real
+// middleware.NeedAdmin:
+//   - empty currentUser → 401 Unauthorized
+//   - non-admin user    → 403 Forbidden
+//   - admin user        → next()
+func needAdminMock() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		currentUser := httpbase.GetCurrentUser(c)
+		if currentUser == "" {
+			httpbase.UnauthorizedError(c, errorx.ErrUserNotFound)
+			c.Abort()
+			return
+		}
+		if currentUser != "admin" {
+			httpbase.ForbiddenError(c, errorx.ErrUserNotAdmin)
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+
+// setTestUser is a middleware that reads the X-Test-User header and sets it as
+// the current user in the gin context. This avoids having to inject the user
+// between route registration and request handling.
+func setTestUser(c *gin.Context) {
+	if user := c.GetHeader("X-Test-User"); user != "" {
+		httpbase.SetCurrentUser(c, user)
+	}
+	c.Next()
+}
+
+// newUserRoutesTestRouter creates a gin router with the user routes registered
+// exactly as in production, backed by a local test HTTP server so the proxy
+// returns 200 on success.
+func newUserRoutesTestRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	// Start a local backend that the proxy handler will forward requests to.
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	proxyHandler, err := handler.NewInternalServiceProxyHandler(backend.URL)
+	if err != nil {
+		t.Fatalf("failed to create proxy handler: %v", err)
+	}
+
+	mc := middleware.MiddlewareCollection{}
+	mc.Auth.NeedLogin = middleware.MustLogin()
+	mc.Auth.NeedAdmin = needAdminMock()
+
+	router := gin.New()
+	router.Use(setTestUser)
+
+	apiGroup := router.Group("/api/v1")
+	createUserRoutes(apiGroup, mc, proxyHandler, &handler.UserHandler{})
+
+	return router
+}
+
+func TestUserRoutes_AnonymousAccess_Returns401(t *testing.T) {
+	router := newUserRoutesTestRouter(t)
+
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPut, "/api/v1/user/testuser"},
+		{http.MethodDelete, "/api/v1/user/testuser"},
+		{http.MethodDelete, "/api/v1/user/testuser/close_account"},
+		{http.MethodGet, "/api/v1/user/testuser/tokens"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			assert.Equal(t, http.StatusUnauthorized, resp.Code,
+				"anonymous %s %s should return 401", tc.method, tc.path)
+		})
+	}
+}
+
+func TestUserRoutes_NormalUser_DeleteUser_Returns403(t *testing.T) {
+	router := newUserRoutesTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/user/testuser", nil)
+	req.Header.Set("X-Test-User", "normaluser")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusForbidden, resp.Code,
+		"normal user DELETE /user/:username should return 403 (NeedAdmin)")
+}
+
+func TestUserRoutes_Admin_DeleteUser_PassesThrough(t *testing.T) {
+	router := newUserRoutesTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/user/testuser", nil)
+	req.Header.Set("X-Test-User", "admin")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code,
+		"admin DELETE /user/:username should reach the proxy handler")
+}
+
+func TestUserRoutes_LoginUser_CloseAccount_PassesThrough(t *testing.T) {
+	router := newUserRoutesTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/user/testuser/close_account", nil)
+	req.Header.Set("X-Test-User", "testuser")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code,
+		"logged-in user DELETE close_account should reach the proxy (ownership validated downstream)")
+}
+
+func TestUserRoutes_LoginUser_PutUser_PassesThrough(t *testing.T) {
+	router := newUserRoutesTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/user/testuser", nil)
+	req.Header.Set("X-Test-User", "testuser")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code,
+		"logged-in user PUT /user/:username should reach the proxy")
+}
+
+func TestUserRoutes_LoginUser_GetTokens_PassesThrough(t *testing.T) {
+	router := newUserRoutesTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/user/testuser/tokens", nil)
+	req.Header.Set("X-Test-User", "testuser")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code,
+		"logged-in user GET tokens should reach the proxy (ownership validated downstream)")
+}
+
+// =============================================================================
+// Token write routes (POST/PUT/DELETE /token/:app/:token_name)
+// =============================================================================
+
+func newTokenRoutesTestRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	proxyHandler, err := handler.NewInternalServiceProxyHandler(backend.URL)
+	if err != nil {
+		t.Fatalf("failed to create proxy handler: %v", err)
+	}
+
+	mc := middleware.MiddlewareCollection{}
+	mc.Auth.NeedLogin = middleware.MustLogin()
+
+	router := gin.New()
+	router.Use(setTestUser)
+
+	apiGroup := router.Group("/api/v1")
+	createTokenRoutes(apiGroup, mc, proxyHandler)
+
+	return router
+}
+
+func TestTokenRoutes_AnonymousWriteAccess_Returns401(t *testing.T) {
+	router := newTokenRoutesTestRouter(t)
+
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/token/git/my-token"},
+		{http.MethodPut, "/api/v1/token/git/my-token"},
+		{http.MethodDelete, "/api/v1/token/git/my-token"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			assert.Equal(t, http.StatusUnauthorized, resp.Code,
+				"anonymous %s %s should return 401", tc.method, tc.path)
+		})
+	}
+}
+
+func TestTokenRoutes_VerifyToken_NoAuthRequired(t *testing.T) {
+	router := newTokenRoutesTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/token/some-token-value", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code,
+		"GET /token/:token_value (token verify) should NOT require login")
+}
+
+func TestTokenRoutes_LoginUser_CreateToken_PassesThrough(t *testing.T) {
+	router := newTokenRoutesTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/token/git/my-token", nil)
+	req.Header.Set("X-Test-User", "testuser")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code,
+		"logged-in user POST token should reach the proxy")
+}
+
+// =============================================================================
+// Organization & member write routes
+// =============================================================================
+
+func newOrgRoutesTestRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	proxyHandler, err := handler.NewInternalServiceProxyHandler(backend.URL)
+	if err != nil {
+		t.Fatalf("failed to create proxy handler: %v", err)
+	}
+
+	mc := middleware.MiddlewareCollection{}
+	mc.Auth.NeedLogin = middleware.MustLogin()
+	mc.Auth.NeedAdmin = needAdminMock()
+
+	router := gin.New()
+	router.Use(setTestUser)
+
+	apiGroup := router.Group("/api/v1")
+	createOrgRoutes(apiGroup, mc, proxyHandler, &handler.OrganizationHandler{})
+
+	return router
+}
+
+func TestOrgRoutes_AnonymousWriteAccess_Returns401(t *testing.T) {
+	router := newOrgRoutesTestRouter(t)
+
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/organizations"},
+		{http.MethodPut, "/api/v1/organization/testorg"},
+		{http.MethodDelete, "/api/v1/organization/testorg"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			assert.Equal(t, http.StatusUnauthorized, resp.Code,
+				"anonymous %s %s should return 401", tc.method, tc.path)
+		})
+	}
+}
+
+func TestOrgRoutes_LoginUser_CreateOrg_PassesThrough(t *testing.T) {
+	router := newOrgRoutesTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations", nil)
+	req.Header.Set("X-Test-User", "testuser")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code,
+		"logged-in user POST /organizations should reach the proxy")
+}
+
+func TestMemberRoutes_AnonymousWriteAccess_Returns401(t *testing.T) {
+	router := newOrgRoutesTestRouter(t)
+
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/organization/testorg/members"},
+		{http.MethodPut, "/api/v1/organization/testorg/members/testuser"},
+		{http.MethodDelete, "/api/v1/organization/testorg/members/testuser"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			assert.Equal(t, http.StatusUnauthorized, resp.Code,
+				"anonymous %s %s should return 401", tc.method, tc.path)
+		})
+	}
+}
+
+func TestMemberRoutes_LoginUser_AddMember_PassesThrough(t *testing.T) {
+	router := newOrgRoutesTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/organization/testorg/members", nil)
+	req.Header.Set("X-Test-User", "testuser")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code,
+		"logged-in user POST members should reach the proxy (permission checked downstream)")
+}
+
+// =============================================================================
+// GET /users (registered directly in NewRouter)
+// =============================================================================
+
+func newGetUsersTestRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	proxyHandler, err := handler.NewInternalServiceProxyHandler(backend.URL)
+	if err != nil {
+		t.Fatalf("failed to create proxy handler: %v", err)
+	}
+
+	mc := middleware.MiddlewareCollection{}
+	mc.Auth.NeedLogin = middleware.MustLogin()
+
+	router := gin.New()
+	router.Use(setTestUser)
+
+	apiGroup := router.Group("/api/v1")
+	createUserRoutes(apiGroup, mc, proxyHandler, &handler.UserHandler{})
+
+	return router
+}
+
+func TestUsersListRoute_AnonymousAccess_Returns401(t *testing.T) {
+	router := newGetUsersTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.Code,
+		"anonymous GET /users should return 401")
+}
+
+func TestUsersListRoute_LoginUser_PassesThrough(t *testing.T) {
+	router := newGetUsersTestRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+	req.Header.Set("X-Test-User", "testuser")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code,
+		"logged-in user GET /users should reach the proxy (component returns limited info for non-admin)")
+}


### PR DESCRIPTION
Summary:
- Added `NeedLogin` authorization checks to user write-permission APIs
- Fixed a security gap where unauthenticated users could access write endpoints