### PR TITLE
[Manual Sync Required] Remove user create API

### DIFF
--- a/api/router/api.go
+++ b/api/router/api.go
@@ -1030,7 +1030,6 @@ func createUserRoutes(apiGroup *gin.RouterGroup, middlewareCollection middleware
 	}
 
 	{
-		apiGroup.POST("/user", userProxyHandler.Proxy)
 		apiGroup.GET("/user/:username", userProxyHandler.Proxy)
 		apiGroup.PUT("/user/:username", userProxyHandler.Proxy)
 		apiGroup.DELETE("/user/:username", userProxyHandler.Proxy)


### PR DESCRIPTION
Summary:
- Removed the `POST /api/v1/user` API from the server to align with its prior removal in the user service
- Eliminates a dead endpoint that was no longer backed by the underlying service
- Resolves issue #1201

Manual handling required:
- Dev-agent failed to cherry-pick this GitLab MR: Git克隆命令执行失败: Command '['git', '--git-dir', '/root/gitlab-to-github/dev-agent/agent/.cache/mirrors/csghub-server-17ac110fb8ee.git', 'fetch', '--prune', 'origin']' returned non-zero exit status 128.
错误输出: fatal: unable to access 'https://github.com/OpenCSGs/csghub-server/': Failed to connect to github.com port 443 after 130282 ms: Connection timed out

- Source GitLab MR: !2809
- Source ref: 7c8403a0629dd12ed02057428ff1f20729caca2d
- Files in sync scope: 1
- The GitLab MR patch was applied with git's 3-way apply. Please review before merging.