### PR TITLE
enable configurable csgclaw sandbox readiness probe and add agent name in shared instance response

### DIFF
--- a/common/errorx/error_agent.go
+++ b/common/errorx/error_agent.go
@@ -25,6 +25,7 @@ const (
 	agentProvisionRequestFieldType
 	agentProvisionRequestFieldEmpty
 	agentProvisionRequestModelUnavailable
+	csgclawTemplateNotFound
 )
 
 var (
@@ -313,6 +314,19 @@ var (
 	//
 	// zh-HK: llm 模型 {{.model}} 不適用於 {{.instance_type}}
 	ErrAgentProvisionRequestModelUnavailable error = CustomError{prefix: errAgentPrefix, code: agentProvisionRequestModelUnavailable}
+
+	// csgclaw agent template not found for the repository path
+	//
+	// Description: No csgclaw agent template matches the repository path in the instance provision request.
+	//
+	// Description_ZH: 未找到与实例部署请求中的仓库路径匹配的 csgclaw 智能体模板。
+	//
+	// en-US: csgclaw template not found for repository path {{.repo_path}}
+	//
+	// zh-CN: 仓库路径 {{.repo_path}} 未找到对应的 csgclaw 模板
+	//
+	// zh-HK: 倉庫路徑 {{.repo_path}} 未找到對應的 csgclaw 模板
+	ErrCSGClawTemplateNotFound error = CustomError{prefix: errAgentPrefix, code: csgclawTemplateNotFound}
 )
 
 func InstanceQuotaExceeded(err error, ctx context) error {
@@ -488,5 +502,14 @@ func AgentProvisionRequestModelUnavailable(err error, ctx context) error {
 		context: ctx,
 		err:     err,
 		code:    int(agentProvisionRequestModelUnavailable),
+	}
+}
+
+func CSGClawTemplateNotFound(err error, ctx context) error {
+	return CustomError{
+		prefix:  errAgentPrefix,
+		context: ctx,
+		err:     err,
+		code:    int(csgclawTemplateNotFound),
 	}
 }

--- a/common/i18n/en-US/err_agent.json
+++ b/common/i18n/en-US/err_agent.json
@@ -64,5 +64,8 @@
     },
     "error.AGENT-ERR-9": {
         "other": "Scheduler start time is in the past; use a future date/time for one-time schedules"
+    },
+    "error.AGENT-ERR-22": {
+        "other": "csgclaw template not found for repository path {{.repo_path}}"
     }
 }

--- a/common/i18n/zh-CN/err_agent.json
+++ b/common/i18n/zh-CN/err_agent.json
@@ -64,5 +64,8 @@
     },
     "error.AGENT-ERR-9": {
         "other": "定时任务开始时间已过去，一次性任务请使用未来的日期/时间"
+    },
+    "error.AGENT-ERR-22": {
+        "other": "仓库路径 {{.repo_path}} 未找到对应的 csgclaw 模板"
     }
 }

--- a/common/i18n/zh-HK/err_agent.json
+++ b/common/i18n/zh-HK/err_agent.json
@@ -64,5 +64,8 @@
     },
     "error.AGENT-ERR-9": {
         "other": "定時任務開始時間已過去，一次性任務請使用未來的日期/時間"
+    },
+    "error.AGENT-ERR-22": {
+        "other": "倉庫路徑 {{.repo_path}} 未找到對應的 csgclaw 模板"
     }
 }

--- a/common/types/agent.go
+++ b/common/types/agent.go
@@ -280,6 +280,7 @@ type AgentSharedInstanceResponse struct {
 	Type              string `json:"type"`
 	Name              string `json:"name"`
 	Description       string `json:"description"`
+	AgentName         string `json:"agent_name"`
 	SharedSandboxName string `json:"shared_sandbox_name"`
 }
 

--- a/common/types/sandbox.go
+++ b/common/types/sandbox.go
@@ -15,17 +15,25 @@ type SandboxVolume struct {
 	ReadOnly            bool   `json:"read_only"`
 }
 
+type SandboxReadinessProbe struct {
+	Protocol            string `json:"protocol,omitempty"`
+	Path                string `json:"path,omitempty"`
+	Port                int    `json:"port,omitempty"`
+	InitialDelaySeconds int    `json:"initial_delay_seconds,omitempty"`
+}
+
 type SandboxCreateRequest struct {
-	UUID         string            `json:"-"`
-	Image        string            `json:"image" binding:"required"`
-	ResourceID   int64             `json:"resource_id"`
-	SandboxName  string            `json:"sandbox_name" binding:"required"`
-	Environments map[string]string `json:"environments,omitempty"`
-	Volumes      []SandboxVolume   `json:"volumes,omitempty"`
-	Port         int               `json:"port,omitempty"`
-	Timeout      int               `json:"timeout,omitempty"`
-	MinCPU       string            `json:"min_cpu"`
-	MinMemory    string            `json:"min_memory"`
+	UUID           string                 `json:"-"`
+	Image          string                 `json:"image" binding:"required"`
+	ResourceID     int64                  `json:"resource_id"`
+	SandboxName    string                 `json:"sandbox_name" binding:"required"`
+	Environments   map[string]string      `json:"environments,omitempty"`
+	Volumes        []SandboxVolume        `json:"volumes,omitempty"`
+	Port           int                    `json:"port,omitempty"`
+	Timeout        int                    `json:"timeout,omitempty"`
+	MinCPU         string                 `json:"min_cpu"`
+	MinMemory      string                 `json:"min_memory"`
+	ReadinessProbe *SandboxReadinessProbe `json:"readiness_probe,omitempty"`
 }
 
 type SandboxUpdateRequest struct {

--- a/component/agent_runtime_profile.go
+++ b/component/agent_runtime_profile.go
@@ -11,25 +11,23 @@ import (
 	"strings"
 
 	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/types"
 )
 
 const csgclawRuntimeProfileName = "sandbox_runtime.csgclaw"
 
 type CSGClawRuntimeProfile struct {
-	AgentType   string                    `json:"agent_type"`
-	Version     string                    `json:"version"`
-	Image       string                    `json:"image"`
-	Port        int                       `json:"port"`
-	Command     []string                  `json:"command"`
-	HealthCheck SandboxRuntimeHealthCheck `json:"health_check"`
-	DefaultEnv  map[string]string         `json:"default_env"`
-	ContentSHA  string                    `json:"content_sha"`
+	AgentType      string                       `json:"agent_type"`
+	Version        string                       `json:"version"`
+	Image          string                       `json:"image"`
+	Port           int                          `json:"port"`
+	Command        []string                     `json:"command"`
+	ReadinessProbe SandboxRuntimeReadinessProbe `json:"readiness_probe"`
+	DefaultEnv     map[string]string            `json:"default_env"`
+	ContentSHA     string                       `json:"content_sha"`
 }
 
-type SandboxRuntimeHealthCheck struct {
-	Protocol string `json:"protocol"`
-	Path     string `json:"path"`
-}
+type SandboxRuntimeReadinessProbe = types.SandboxReadinessProbe
 
 func initAgentRuntimeProfiles(ctx context.Context) error {
 	path, err := agentRuntimeProfilePath("csgclaw.json")
@@ -101,14 +99,14 @@ func validateCSGClawRuntimeProfile(profile *CSGClawRuntimeProfile) error {
 			return fmt.Errorf("csgclaw runtime profile command cannot contain empty arguments")
 		}
 	}
-	if profile.HealthCheck.Protocol == "" && profile.HealthCheck.Path == "" {
+	if profile.ReadinessProbe.Protocol == "" && profile.ReadinessProbe.Path == "" {
 		return nil
 	}
-	if profile.HealthCheck.Protocol != "http" {
-		return fmt.Errorf("csgclaw runtime profile health_check.protocol must be http")
+	if profile.ReadinessProbe.Protocol != "http" {
+		return fmt.Errorf("csgclaw runtime profile readiness_probe.protocol must be http")
 	}
-	if !strings.HasPrefix(profile.HealthCheck.Path, "/") {
-		return fmt.Errorf("csgclaw runtime profile health_check.path must start with /")
+	if !strings.HasPrefix(profile.ReadinessProbe.Path, "/") {
+		return fmt.Errorf("csgclaw runtime profile readiness_probe.path must start with /")
 	}
 	return nil
 }

--- a/configs/agent_runtime/csgclaw.json
+++ b/configs/agent_runtime/csgclaw.json
@@ -8,7 +8,12 @@
     "--",
     "/usr/local/bin/docker-entrypoint.sh"
   ],
-  "health_check": {},
+  "readiness_probe": {
+    "protocol": "http",
+    "path": "/",
+    "port": 8888,
+    "initial_delay_seconds": 10
+  },
   "default_env": {
     "OPENCSG_SANDBOX_TYPE": "csgclaw",
     "CSGCLAW_ROLE": "server",

--- a/runner/types/sandbox.go
+++ b/runner/types/sandbox.go
@@ -8,21 +8,22 @@ import (
 
 // SandboxSpec defines sandbox specification
 type SandboxRequest struct {
-	SandboxName string                `json:"sandbox_name"`
-	Image       string                `json:"image,omitempty"`
-	Hardware    types.HardWare        `json:"hardware,omitempty"`
-	ClusterID   string                `json:"cluster_id"`
-	DeployID    string                `json:"deploy_id"`
-	TaskId      string                `json:"task_id"`
-	UserUUID    string                `json:"user_id"`
-	ResourceID  int64                 `json:"resource_id"`
-	EnvVars     map[string]string     `json:"env_vars,omitempty"`
-	Labels      map[string]string     `json:"labels,omitempty"`
-	TemplateID  string                `json:"templateID,omitempty"`
-	Timeout     int                   `json:"timeout,omitempty"`
-	Volumes     []types.SandboxVolume `json:"volumes,omitempty"`
-	Port        int                   `json:"port,omitempty"`
-	DeployName  string                `json:"deploy_name,omitempty"`
+	SandboxName    string                       `json:"sandbox_name"`
+	Image          string                       `json:"image,omitempty"`
+	Hardware       types.HardWare               `json:"hardware,omitempty"`
+	ClusterID      string                       `json:"cluster_id"`
+	DeployID       string                       `json:"deploy_id"`
+	TaskId         string                       `json:"task_id"`
+	UserUUID       string                       `json:"user_id"`
+	ResourceID     int64                        `json:"resource_id"`
+	EnvVars        map[string]string            `json:"env_vars,omitempty"`
+	Labels         map[string]string            `json:"labels,omitempty"`
+	TemplateID     string                       `json:"templateID,omitempty"`
+	Timeout        int                          `json:"timeout,omitempty"`
+	Volumes        []types.SandboxVolume        `json:"volumes,omitempty"`
+	Port           int                          `json:"port,omitempty"`
+	DeployName     string                       `json:"deploy_name,omitempty"`
+	ReadinessProbe *types.SandboxReadinessProbe `json:"readiness_probe,omitempty"`
 }
 
 type SandboxResponse struct {


### PR DESCRIPTION
Summary:
- Made the csgclaw sandbox readiness probe configurable via `configs/agent_runtime/csgclaw.json` (pointing to port 8888) to prevent prolonged NotReady states during cold starts.
- Added the `agent_name` field to the `get-shared-instance` API response by reading from instance metadata.
- Added i18n support (en-US, zh-CN, zh-HK) for the csgclaw template not found error (`AGENT-ERR-22`).