### PR TITLE
refactor(aigateway): move populateDerivedFields out of DB store, add WithLLMConfig to llm.Client

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/llm/mock_LLMSvcClient.go
+++ b/_mocks/opencsg.com/csghub-server/builder/llm/mock_LLMSvcClient.go
@@ -5,6 +5,9 @@ package llm
 import (
 	context "context"
 
+	llm "opencsg.com/csghub-server/builder/llm"
+	database "opencsg.com/csghub-server/builder/store/database"
+
 	mock "github.com/stretchr/testify/mock"
 
 	types "opencsg.com/csghub-server/common/types"
@@ -263,6 +266,54 @@ func (_c *MockLLMSvcClient_Tokenize_Call) Return(_a0 []byte, _a1 error) *MockLLM
 }
 
 func (_c *MockLLMSvcClient_Tokenize_Call) RunAndReturn(run func(context.Context, string, string, interface{}) ([]byte, error)) *MockLLMSvcClient_Tokenize_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// WithLLMConfig provides a mock function with given fields: llmConfig
+func (_m *MockLLMSvcClient) WithLLMConfig(llmConfig *database.LLMConfig) llm.LLMSvcClient {
+	ret := _m.Called(llmConfig)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithLLMConfig")
+	}
+
+	var r0 llm.LLMSvcClient
+	if rf, ok := ret.Get(0).(func(*database.LLMConfig) llm.LLMSvcClient); ok {
+		r0 = rf(llmConfig)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(llm.LLMSvcClient)
+		}
+	}
+
+	return r0
+}
+
+// MockLLMSvcClient_WithLLMConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithLLMConfig'
+type MockLLMSvcClient_WithLLMConfig_Call struct {
+	*mock.Call
+}
+
+// WithLLMConfig is a helper method to define mock.On call
+//   - llmConfig *database.LLMConfig
+func (_e *MockLLMSvcClient_Expecter) WithLLMConfig(llmConfig interface{}) *MockLLMSvcClient_WithLLMConfig_Call {
+	return &MockLLMSvcClient_WithLLMConfig_Call{Call: _e.mock.On("WithLLMConfig", llmConfig)}
+}
+
+func (_c *MockLLMSvcClient_WithLLMConfig_Call) Run(run func(llmConfig *database.LLMConfig)) *MockLLMSvcClient_WithLLMConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*database.LLMConfig))
+	})
+	return _c
+}
+
+func (_c *MockLLMSvcClient_WithLLMConfig_Call) Return(_a0 llm.LLMSvcClient) *MockLLMSvcClient_WithLLMConfig_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockLLMSvcClient_WithLLMConfig_Call) RunAndReturn(run func(*database.LLMConfig) llm.LLMSvcClient) *MockLLMSvcClient_WithLLMConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/builder/llm/client.go
+++ b/builder/llm/client.go
@@ -12,11 +12,13 @@ import (
 	"strings"
 
 	"opencsg.com/csghub-server/builder/rpc"
+	"opencsg.com/csghub-server/builder/store/database"
 
 	"opencsg.com/csghub-server/common/types"
 )
 
 type LLMSvcClient interface {
+	WithLLMConfig(llmConfig *database.LLMConfig) LLMSvcClient
 	Chat(ctx context.Context, endpoint, host string, headers map[string]string, data types.LLMReqBody) (string, error)
 	ChatStream(ctx context.Context, endpoint, host string, headers map[string]string, data types.LLMReqBody) (<-chan string, error)
 	Tokenize(ctx context.Context, endpoint, host string, req interface{}) ([]byte, error)
@@ -24,7 +26,8 @@ type LLMSvcClient interface {
 }
 
 type Client struct {
-	client rpc.HttpDoer
+	client    rpc.HttpDoer
+	llmConfig *database.LLMConfig
 }
 
 func NewClient() *Client {
@@ -33,7 +36,47 @@ func NewClient() *Client {
 	}
 }
 
+// WithLLMConfig returns a new Client that derives endpoint, headers, and model name
+// from the given LLMConfig's best available upstream. PopulateDerivedFields is called
+// internally to select the best upstream. The original client is not modified, making
+// this method safe for concurrent use.
+func (c *Client) WithLLMConfig(llmConfig *database.LLMConfig) LLMSvcClient {
+	if llmConfig != nil {
+		llmConfig.PopulateDerivedFields()
+	}
+	return &Client{
+		client:    c.client,
+		llmConfig: llmConfig,
+	}
+}
+
+// resolveLLMConfig overrides endpoint, host, headers, and model from the stored
+// llmConfig (if set). Since WithLLMConfig creates a new Client per call, there is
+// no need to clear llmConfig after use.
+func (c *Client) resolveLLMConfig(endpoint, host string, headers map[string]string, data types.LLMReqBody) (string, string, map[string]string, types.LLMReqBody) {
+	if c.llmConfig == nil {
+		return endpoint, host, headers, data
+	}
+	cfg := c.llmConfig
+
+	resolvedHeaders := headers
+	if len(cfg.AuthHeader) > 0 {
+		var parsed map[string]string
+		if err := json.Unmarshal([]byte(cfg.AuthHeader), &parsed); err == nil {
+			resolvedHeaders = parsed
+		} else {
+			slog.Error("failed to parse llm config auth header json, request will proceed without resolved headers",
+				slog.Any("error", err), slog.String("model_name", cfg.ModelName))
+		}
+	}
+	if cfg.ModelName != "" {
+		data.Model = cfg.ModelName
+	}
+	return cfg.ApiEndpoint, host, resolvedHeaders, data
+}
+
 func (c *Client) ChatStream(ctx context.Context, endpoint, host string, headers map[string]string, data types.LLMReqBody) (<-chan string, error) {
+	endpoint, host, headers, data = c.resolveLLMConfig(endpoint, host, headers, data)
 	slog.Debug("chat with llm", slog.Any("endpoint", endpoint), slog.Any("data", data))
 	rc, err := c.doRequest(ctx, http.MethodPost, strings.TrimSpace(endpoint), host, headers, data)
 	if err != nil {
@@ -101,6 +144,7 @@ func (c *Client) readToChannel(rc io.ReadCloser) <-chan string {
 }
 
 func (c *Client) Chat(ctx context.Context, endpoint, host string, headers map[string]string, data types.LLMReqBody) (string, error) {
+	endpoint, host, headers, data = c.resolveLLMConfig(endpoint, host, headers, data)
 	slog.Debug("chat with llm", slog.Any("endpoint", endpoint), slog.Any("data", data))
 	rc, err := c.doRequest(ctx, http.MethodPost, endpoint, host, headers, data)
 	if err != nil {
@@ -131,7 +175,8 @@ func (c *Client) Chat(ctx context.Context, endpoint, host string, headers map[st
 }
 
 func (c *Client) Tokenize(ctx context.Context, endpoint, host string, req interface{}) ([]byte, error) {
-	rc, err := c.doRequest(ctx, http.MethodPost, endpoint, host, nil, req)
+	endpoint, host, headers, _ := c.resolveLLMConfig(endpoint, host, nil, types.LLMReqBody{})
+	rc, err := c.doRequest(ctx, http.MethodPost, endpoint, host, headers, req)
 	if err != nil {
 		return nil, fmt.Errorf("do llm request, error: %w", err)
 	}
@@ -145,7 +190,8 @@ func (c *Client) Tokenize(ctx context.Context, endpoint, host string, req interf
 
 func (c *Client) EmbeddingTokenize(ctx context.Context, endpoint, host string, req interface{}) ([]byte, error) {
 	const path = "/tokenize"
-	rc, err := c.doRequest(ctx, http.MethodPost, endpoint+path, host, nil, req)
+	endpoint, host, headers, _ := c.resolveLLMConfig(endpoint, host, nil, types.LLMReqBody{})
+	rc, err := c.doRequest(ctx, http.MethodPost, endpoint+path, host, headers, req)
 	if err != nil {
 		return nil, fmt.Errorf("do llm request, error: %w", err)
 	}

--- a/builder/llm/client_test.go
+++ b/builder/llm/client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/types"
 )
 
@@ -461,5 +462,195 @@ func TestClient_readToChannel(t *testing.T) {
 			lines = append(lines, msg)
 		}
 		assert.Empty(t, lines)
+	})
+}
+
+func TestClient_WithLLMConfig(t *testing.T) {
+	t.Run("chat uses llmConfig endpoint headers and model", func(t *testing.T) {
+		mockDoer := new(mockHttpDoer)
+		c := &Client{client: mockDoer}
+
+		llmConfig := &database.LLMConfig{
+			ModelName:   "upstream-model",
+			ApiEndpoint: "http://upstream.example.com/chat",
+			AuthHeader:  `{"Authorization":"Bearer token123"}`,
+			Upstreams: []database.Upstream{
+				{
+					URL:        "http://upstream.example.com/chat",
+					Enabled:    true,
+					ModelName:  "upstream-model",
+					AuthHeader: `{"Authorization":"Bearer token123"}`,
+					Provider:   "test-provider",
+				},
+			},
+		}
+
+		chatResp := types.ChatCompletion{
+			ID: "chatcmpl-456",
+			Choices: []types.Choice{
+				{
+					Index: 0,
+					Message: types.Message{
+						Role:    "assistant",
+						Content: "Response from upstream",
+					},
+				},
+			},
+		}
+		data, _ := json.Marshal(chatResp)
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(string(data))),
+		}
+
+		var capturedReq *http.Request
+		mockDoer.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			capturedReq = req
+			return true
+		})).Return(resp, nil).Once()
+
+		result, err := c.WithLLMConfig(llmConfig).Chat(context.Background(), "http://should-be-overridden", "", nil, types.LLMReqBody{
+			Messages: []types.LLMMessage{
+				{Role: "user", Content: "hello"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Response from upstream", result)
+
+		// Verify the request used the upstream endpoint
+		assert.Equal(t, "http://upstream.example.com/chat", capturedReq.URL.String())
+		// Verify the request used the upstream auth header
+		assert.Equal(t, "Bearer token123", capturedReq.Header.Get("Authorization"))
+
+		// Verify the original client was not modified (WithLLMConfig creates a new client)
+		assert.Nil(t, c.llmConfig)
+	})
+
+	t.Run("chat without llmConfig uses explicit params", func(t *testing.T) {
+		mockDoer := new(mockHttpDoer)
+		c := &Client{client: mockDoer}
+
+		chatResp := types.ChatCompletion{
+			ID: "chatcmpl-789",
+			Choices: []types.Choice{
+				{
+					Index: 0,
+					Message: types.Message{
+						Role:    "assistant",
+						Content: "Normal response",
+					},
+				},
+			},
+		}
+		data, _ := json.Marshal(chatResp)
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(string(data))),
+		}
+
+		var capturedReq *http.Request
+		mockDoer.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			capturedReq = req
+			return true
+		})).Return(resp, nil).Once()
+
+		headers := map[string]string{"X-Custom": "val"}
+		result, err := c.Chat(context.Background(), "http://explicit.example.com", "", headers, types.LLMReqBody{
+			Model: "explicit-model",
+			Messages: []types.LLMMessage{
+				{Role: "user", Content: "hi"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Normal response", result)
+		assert.Equal(t, "http://explicit.example.com", capturedReq.URL.String())
+		assert.Equal(t, "val", capturedReq.Header.Get("X-Custom"))
+	})
+
+	t.Run("WithLLMConfig does not mutate original client", func(t *testing.T) {
+		mockDoer := new(mockHttpDoer)
+		c := &Client{client: mockDoer}
+
+		llmConfig := &database.LLMConfig{
+			ModelName:   "upstream-model",
+			ApiEndpoint: "http://upstream.example.com/chat",
+			AuthHeader:  `{"Authorization":"Bearer token"}`,
+			Upstreams: []database.Upstream{
+				{
+					URL:        "http://upstream.example.com/chat",
+					Enabled:    true,
+					ModelName:  "upstream-model",
+					AuthHeader: `{"Authorization":"Bearer token"}`,
+				},
+			},
+		}
+
+		// WithLLMConfig should return a new client, not modify the original
+		configured := c.WithLLMConfig(llmConfig)
+		assert.Nil(t, c.llmConfig, "original client should not have llmConfig set")
+
+		// First call with WithLLMConfig
+		chatResp1 := types.ChatCompletion{
+			Choices: []types.Choice{
+				{Index: 0, Message: types.Message{Role: "assistant", Content: "first"}},
+			},
+		}
+		data1, _ := json.Marshal(chatResp1)
+		resp1 := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(string(data1))),
+		}
+		mockDoer.On("Do", mock.Anything).Return(resp1, nil).Once()
+
+		_, err := configured.Chat(context.Background(), "", "", nil, types.LLMReqBody{
+			Messages: []types.LLMMessage{{Role: "user", Content: "first"}},
+		})
+		require.NoError(t, err)
+
+		// Second call without WithLLMConfig on the original client should use explicit params
+		chatResp2 := types.ChatCompletion{
+			Choices: []types.Choice{
+				{Index: 0, Message: types.Message{Role: "assistant", Content: "second"}},
+			},
+		}
+		data2, _ := json.Marshal(chatResp2)
+		resp2 := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(string(data2))),
+		}
+
+		var capturedReq *http.Request
+		mockDoer.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			capturedReq = req
+			return true
+		})).Return(resp2, nil).Once()
+
+		_, err = c.Chat(context.Background(), "http://explicit.example.com", "", nil, types.LLMReqBody{
+			Messages: []types.LLMMessage{{Role: "user", Content: "second"}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "http://explicit.example.com", capturedReq.URL.String())
+	})
+
+	t.Run("with nil llmConfig is no-op", func(t *testing.T) {
+		mockDoer := new(mockHttpDoer)
+		c := &Client{client: mockDoer}
+
+		chatResp := types.ChatCompletion{
+			Choices: []types.Choice{
+				{Index: 0, Message: types.Message{Role: "assistant", Content: "ok"}},
+			},
+		}
+		data, _ := json.Marshal(chatResp)
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(string(data))),
+		}
+		mockDoer.On("Do", mock.Anything).Return(resp, nil).Once()
+
+		_, err := c.WithLLMConfig(nil).Chat(context.Background(), "http://explicit.example.com", "", nil, types.LLMReqBody{
+			Messages: []types.LLMMessage{{Role: "user", Content: "hi"}},
+		})
+		require.NoError(t, err)
 	})
 }

--- a/builder/store/database/llm_config.go
+++ b/builder/store/database/llm_config.go
@@ -126,7 +126,6 @@ func (s *lLMConfigStoreImpl) GetOptimization(ctx context.Context) (*LLMConfig, e
 	if err != nil {
 		return nil, fmt.Errorf("select optimization llm, %w", err)
 	}
-	config.populateDerivedFields()
 	return &config, nil
 }
 
@@ -136,7 +135,6 @@ func (s *lLMConfigStoreImpl) GetModelForSummaryReadme(ctx context.Context) (*LLM
 	if err != nil {
 		return nil, fmt.Errorf("select llm for summary readme, %w", err)
 	}
-	config.populateDerivedFields()
 	return &config, nil
 }
 
@@ -146,7 +144,6 @@ func (s *lLMConfigStoreImpl) GetByType(ctx context.Context, llmType int) (*LLMCo
 	if err != nil {
 		return nil, fmt.Errorf("select llm by type %d, %w", llmType, err)
 	}
-	config.populateDerivedFields()
 	return &config, nil
 }
 
@@ -190,10 +187,6 @@ func (s *lLMConfigStoreImpl) Index(ctx context.Context, per, page int, search *t
 	if err != nil {
 		return nil, 0, err
 	}
-
-	for _, cfg := range configs {
-		cfg.populateDerivedFields()
-	}
 	return configs, total, nil
 }
 
@@ -211,10 +204,6 @@ func (s *lLMConfigStoreImpl) IndexWithRepo(ctx context.Context, per, page int, s
 	if err != nil {
 		return nil, 0, err
 	}
-
-	for _, cfg := range configs {
-		cfg.populateDerivedFields()
-	}
 	return configs, total, nil
 }
 func (s *lLMConfigStoreImpl) GetByModelName(ctx context.Context, modelName string) (*LLMConfig, error) {
@@ -223,7 +212,6 @@ func (s *lLMConfigStoreImpl) GetByModelName(ctx context.Context, modelName strin
 	if err != nil {
 		return nil, fmt.Errorf("select llm config by model_name %s: %w", modelName, err)
 	}
-	config.populateDerivedFields()
 	return &config, nil
 }
 
@@ -233,7 +221,6 @@ func (s *lLMConfigStoreImpl) GetByID(ctx context.Context, id int64) (*LLMConfig,
 	if err != nil {
 		return nil, fmt.Errorf("select llm config by id %d, %w", id, err)
 	}
-	config.populateDerivedFields()
 	return &config, nil
 }
 
@@ -281,10 +268,13 @@ func applyLLMConfigSort(q *bun.SelectQuery, sortBy, sortOrder string) {
 	q.OrderExpr(column + " " + direction)
 }
 
-// populateDerivedFields fills ApiEndpoint, AuthHeader, Provider from the best available upstream.
+// PopulateDerivedFields fills ApiEndpoint, AuthHeader, Provider, and ModelName from the best available upstream.
 // Prefers healthy enabled upstreams; falls back to the first enabled upstream.
 // If no upstream is available at all, uses upstream[0] and logs a warning.
-func (c *LLMConfig) populateDerivedFields() {
+// Callers that use the LLMConfig to make llm.NewClient() requests should call this
+// method after querying from DB to ensure the derived fields are populated from the
+// best available upstream.
+func (c *LLMConfig) PopulateDerivedFields() {
 	if len(c.Upstreams) == 0 {
 		return
 	}
@@ -294,6 +284,7 @@ func (c *LLMConfig) populateDerivedFields() {
 			c.ApiEndpoint = u.URL
 			c.AuthHeader = u.AuthHeader
 			c.Provider = u.Provider
+			c.applyUpstreamModelName(u)
 			return
 		}
 	}
@@ -303,6 +294,7 @@ func (c *LLMConfig) populateDerivedFields() {
 			c.ApiEndpoint = u.URL
 			c.AuthHeader = u.AuthHeader
 			c.Provider = u.Provider
+			c.applyUpstreamModelName(u)
 			slog.Warn("no healthy upstream available, using first enabled upstream",
 				"model_name", c.ModelName, "upstream_id", u.ID, "url", u.URL)
 			return
@@ -313,20 +305,31 @@ func (c *LLMConfig) populateDerivedFields() {
 	c.ApiEndpoint = u.URL
 	c.AuthHeader = u.AuthHeader
 	c.Provider = u.Provider
+	c.applyUpstreamModelName(u)
 	slog.Error("no enabled upstream available, using upstream[0]",
 		"model_name", c.ModelName, "upstream_id", u.ID, "url", u.URL)
 }
 
+// applyUpstreamModelName overrides the LLMConfig ModelName with the upstream's
+// ModelName when the upstream defines one. This ensures that requests are sent
+// with the model name expected by the upstream endpoint.
+func (c *LLMConfig) applyUpstreamModelName(u Upstream) {
+	if u.ModelName != "" {
+		c.ModelName = u.ModelName
+	}
+}
+
 // isHealthy checks whether this upstream has a healthy health state.
+// An upstream is considered healthy if it is not explicitly marked unhealthy.
 func (u *Upstream) isHealthy() bool {
 	if u.HealthState == nil {
 		return true // no health state yet, assume healthy
 	}
-	return u.HealthState.HealthState == "healthy"
+	return u.HealthState.HealthState != "unhealthy"
 }
 
 // PrimaryEndpoint returns the URL of the best available upstream.
-// Call populateDerivedFields() first after querying from DB.
+// Call PopulateDerivedFields() first after querying from DB.
 func (c *LLMConfig) PrimaryEndpoint() string {
 	return c.ApiEndpoint
 }

--- a/builder/store/database/llm_config_test.go
+++ b/builder/store/database/llm_config_test.go
@@ -504,3 +504,138 @@ func TestLLMConfigStore_Index_SortByModelSizeB(t *testing.T) {
 	require.Equal(t, "size-medium", cfgsDesc[1].ModelName)
 	require.Equal(t, "size-small", cfgsDesc[2].ModelName)
 }
+
+func TestLLMConfig_PopulateDerivedFields_NoUpstreams(t *testing.T) {
+	cfg := &database.LLMConfig{
+		ModelName:   "original-model",
+		ApiEndpoint: "original-endpoint",
+		AuthHeader:  "original-auth",
+		Provider:    "original-provider",
+	}
+	cfg.PopulateDerivedFields()
+	require.Equal(t, "original-model", cfg.ModelName)
+	require.Equal(t, "original-endpoint", cfg.ApiEndpoint)
+	require.Equal(t, "original-auth", cfg.AuthHeader)
+	require.Equal(t, "original-provider", cfg.Provider)
+}
+
+func TestLLMConfig_PopulateDerivedFields_HealthyUpstream(t *testing.T) {
+	cfg := &database.LLMConfig{
+		ModelName:   "original-model",
+		ApiEndpoint: "original-endpoint",
+		AuthHeader:  "original-auth",
+		Provider:    "original-provider",
+		Upstreams: []database.Upstream{
+			{
+				URL:      "http://disabled-upstream",
+				Enabled:  false,
+				ModelName: "disabled-model",
+				AuthHeader: `{"Authorization":"disabled"}`,
+				Provider: "disabled-provider",
+			},
+			{
+				URL:      "http://healthy-upstream",
+				Enabled:  true,
+				ModelName: "healthy-model",
+				AuthHeader: `{"Authorization":"healthy"}`,
+				Provider: "healthy-provider",
+				HealthState: &database.AIGatewayUpstreamHealthState{
+					HealthState: "healthy",
+				},
+			},
+		},
+	}
+	cfg.PopulateDerivedFields()
+	require.Equal(t, "http://healthy-upstream", cfg.ApiEndpoint)
+	require.Equal(t, `{"Authorization":"healthy"}`, cfg.AuthHeader)
+	require.Equal(t, "healthy-provider", cfg.Provider)
+	require.Equal(t, "healthy-model", cfg.ModelName)
+}
+
+func TestLLMConfig_PopulateDerivedFields_UnhealthyUpstream(t *testing.T) {
+	cfg := &database.LLMConfig{
+		ModelName:   "original-model",
+		ApiEndpoint: "original-endpoint",
+		Upstreams: []database.Upstream{
+			{
+				URL:      "http://unhealthy-upstream",
+				Enabled:  true,
+				ModelName: "unhealthy-model",
+				AuthHeader: `{"Authorization":"unhealthy"}`,
+				Provider: "unhealthy-provider",
+				HealthState: &database.AIGatewayUpstreamHealthState{
+					HealthState: "unhealthy",
+				},
+			},
+			{
+				URL:      "http://fallback-upstream",
+				Enabled:  true,
+				ModelName: "fallback-model",
+				AuthHeader: `{"Authorization":"fallback"}`,
+				Provider: "fallback-provider",
+			},
+		},
+	}
+	cfg.PopulateDerivedFields()
+	// Should skip unhealthy upstream and use the fallback (no health state = healthy)
+	require.Equal(t, "http://fallback-upstream", cfg.ApiEndpoint)
+	require.Equal(t, "fallback-model", cfg.ModelName)
+	require.Equal(t, "fallback-provider", cfg.Provider)
+}
+
+func TestLLMConfig_PopulateDerivedFields_DegradedIsHealthy(t *testing.T) {
+	cfg := &database.LLMConfig{
+		ModelName: "original-model",
+		Upstreams: []database.Upstream{
+			{
+				URL:      "http://degraded-upstream",
+				Enabled:  true,
+				ModelName: "degraded-model",
+				AuthHeader: `{"Authorization":"degraded"}`,
+				Provider: "degraded-provider",
+				HealthState: &database.AIGatewayUpstreamHealthState{
+					HealthState: "degraded",
+				},
+			},
+		},
+	}
+	cfg.PopulateDerivedFields()
+	// "degraded" is not "unhealthy", so it should be considered healthy
+	require.Equal(t, "http://degraded-upstream", cfg.ApiEndpoint)
+	require.Equal(t, "degraded-model", cfg.ModelName)
+}
+
+func TestLLMConfig_PopulateDerivedFields_OverridesModelName(t *testing.T) {
+	cfg := &database.LLMConfig{
+		ModelName: "config-model",
+		Upstreams: []database.Upstream{
+			{
+				URL:       "http://upstream",
+				Enabled:   true,
+				ModelName: "upstream-model",
+				AuthHeader: "{}",
+				Provider:  "upstream-provider",
+			},
+		},
+	}
+	cfg.PopulateDerivedFields()
+	require.Equal(t, "upstream-model", cfg.ModelName)
+}
+
+func TestLLMConfig_PopulateDerivedFields_EmptyUpstreamModelName(t *testing.T) {
+	cfg := &database.LLMConfig{
+		ModelName: "config-model",
+		Upstreams: []database.Upstream{
+			{
+				URL:       "http://upstream",
+				Enabled:   true,
+				ModelName: "",
+				AuthHeader: "{}",
+				Provider:  "upstream-provider",
+			},
+		},
+	}
+	cfg.PopulateDerivedFields()
+	// Should keep original ModelName when upstream ModelName is empty
+	require.Equal(t, "config-model", cfg.ModelName)
+}

--- a/component/industry_tag.go
+++ b/component/industry_tag.go
@@ -140,11 +140,6 @@ func (c *industryTagComponentImpl) IdentifyIndustryTags(ctx context.Context, req
 		return &types.IdentifyIndustryTagsResult{Reason: fmt.Sprintf("failed to load LLM config: %v", err)}, nil
 	}
 
-	var headers map[string]string
-	if err := json.Unmarshal([]byte(llmConfig.AuthHeader), &headers); err != nil {
-		return nil, fmt.Errorf("parse llm auth header: %w", err)
-	}
-
 	candidates := make([]string, 0, len(allTags))
 	for _, tag := range allTags {
 		candidates = append(candidates, tag.Name)
@@ -159,8 +154,7 @@ func (c *industryTagComponentImpl) IdentifyIndustryTags(ctx context.Context, req
 		return nil, fmt.Errorf("marshal industry identify input: %w", err)
 	}
 
-	resp, err := c.llmClient.Chat(ctx, llmConfig.ApiEndpoint, "", headers, types.LLMReqBody{
-		Model: llmConfig.ModelName,
+	resp, err := c.llmClient.WithLLMConfig(llmConfig).Chat(ctx, "", "", nil, types.LLMReqBody{
 		Messages: []types.LLMMessage{
 			{Role: SystemRole, Content: prompt.ZH},
 			{Role: UserRole, Content: string(input)},

--- a/component/industry_tag_test.go
+++ b/component/industry_tag_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	mockgitserver "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/git/gitserver"
 	mockllm "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/llm"
@@ -39,8 +40,8 @@ func TestIndustryTagComponent_IdentifyIndustryTags(t *testing.T) {
 			{URL: "http://llm", Enabled: true, AuthHeader: "{}"},
 		},
 	}, nil)
-	llmClient.EXPECT().Chat(ctx, "http://llm", "", map[string]string{}, types.LLMReqBody{
-		Model: "mock",
+	llmClient.EXPECT().WithLLMConfig(mock.Anything).Return(llmClient)
+	llmClient.EXPECT().Chat(ctx, "", "", mock.Anything, types.LLMReqBody{
 		Messages: []types.LLMMessage{
 			{Role: SystemRole, Content: "prompt"},
 			{Role: UserRole, Content: "{\"candidates\":[\"finance\",\"healthcare\"],\"description\":\"financial dataset\",\"readme\":\"dataset about banks\"}"},
@@ -101,8 +102,8 @@ func TestIndustryTagComponent_RefreshRepoAutoIndustryTags(t *testing.T) {
 			{URL: "http://llm", Enabled: true, AuthHeader: "{}"},
 		},
 	}, nil)
-	llmClient.EXPECT().Chat(ctx, "http://llm", "", map[string]string{}, types.LLMReqBody{
-		Model: "mock",
+	llmClient.EXPECT().WithLLMConfig(mock.Anything).Return(llmClient)
+	llmClient.EXPECT().Chat(ctx, "", "", mock.Anything, types.LLMReqBody{
 		Messages: []types.LLMMessage{
 			{Role: SystemRole, Content: "prompt"},
 			{Role: UserRole, Content: "{\"candidates\":[\"finance\"],\"description\":\"financial dataset\",\"readme\":\"dataset about banks\"}"},
@@ -157,8 +158,8 @@ func TestIndustryTagComponent_IdentifyIndustryTags_ModelRepo(t *testing.T) {
 			{URL: "http://llm", Enabled: true, AuthHeader: "{}"},
 		},
 	}, nil)
-	llmClient.EXPECT().Chat(ctx, "http://llm", "", map[string]string{}, types.LLMReqBody{
-		Model: "mock",
+	llmClient.EXPECT().WithLLMConfig(mock.Anything).Return(llmClient)
+	llmClient.EXPECT().Chat(ctx, "", "", mock.Anything, types.LLMReqBody{
 		Messages: []types.LLMMessage{
 			{Role: SystemRole, Content: "prompt"},
 			{Role: UserRole, Content: "{\"candidates\":[\"finance\"],\"description\":\"financial model\",\"readme\":\"model for banking risk\"}"},
@@ -213,8 +214,8 @@ func TestIndustryTagComponent_IdentifyIndustryTags_ChineseDescriptionMatchesEngl
 			{URL: "http://llm", Enabled: true, AuthHeader: "{}"},
 		},
 	}, nil)
-	llmClient.EXPECT().Chat(ctx, "http://llm", "", map[string]string{}, types.LLMReqBody{
-		Model: "mock",
+	llmClient.EXPECT().WithLLMConfig(mock.Anything).Return(llmClient)
+	llmClient.EXPECT().Chat(ctx, "", "", mock.Anything, types.LLMReqBody{
 		Messages: []types.LLMMessage{
 			{Role: SystemRole, Content: "prompt"},
 			{Role: UserRole, Content: "{\"candidates\":[\"finance\",\"healthcare\"],\"description\":\"这是一个银行风控和信贷评估数据集\",\"readme\":\"包含贷款违约预测、银行客户评分等金融场景样本\"}"},

--- a/component/mcp_scanner_plugins.go
+++ b/component/mcp_scanner_plugins.go
@@ -3,7 +3,6 @@ package component
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"opencsg.com/csghub-server/builder/llm"
 	"opencsg.com/csghub-server/builder/store/database"
@@ -17,7 +16,6 @@ type MCPScannerPlugin interface {
 
 func summaryResult(ctx context.Context, llmClient *llm.Client, llmConfig *database.LLMConfig, summaryPrompt, result string, temperature float64) ([]types.ScannerIssue, error) {
 	req := types.LLMReqBody{
-		Model: llmConfig.ModelName,
 		Messages: []types.LLMMessage{
 			{Role: SystemRole, Content: summaryPrompt},
 			{Role: UserRole, Content: result},
@@ -25,12 +23,7 @@ func summaryResult(ctx context.Context, llmClient *llm.Client, llmConfig *databa
 		Stream:      false,
 		Temperature: temperature,
 	}
-	headers := make(map[string]string)
-	err := json.Unmarshal([]byte(llmConfig.AuthHeader), &headers)
-	if err != nil {
-		return nil, fmt.Errorf("parse llm config header error: %w", err)
-	}
-	summaryResult, err := llmClient.Chat(ctx, llmConfig.ApiEndpoint, "", headers, req)
+	summaryResult, err := llmClient.WithLLMConfig(llmConfig).Chat(ctx, "", "", nil, req)
 	if err != nil {
 		return nil, err
 	}

--- a/component/mcp_scanner_tool_poison.go
+++ b/component/mcp_scanner_tool_poison.go
@@ -2,8 +2,6 @@ package component
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"strings"
 
 	"opencsg.com/csghub-server/builder/llm"
@@ -40,7 +38,6 @@ func (plugin *toolPoisoningPlugin) Check(ctx context.Context, files []*types.Fil
 		}
 		// 2. Check the code content, file by file
 		reqData := types.LLMReqBody{
-			Model: plugin.llmConfig.ModelName,
 			Messages: []types.LLMMessage{
 				{Role: SystemRole, Content: plugin.prompt.ZH},
 				{Role: UserRole, Content: file.Content},
@@ -48,12 +45,7 @@ func (plugin *toolPoisoningPlugin) Check(ctx context.Context, files []*types.Fil
 			Stream:      false,
 			Temperature: plugin.temperature,
 		}
-		var headers map[string]string
-		err := json.Unmarshal([]byte(plugin.llmConfig.AuthHeader), &headers)
-		if err != nil {
-			return nil, fmt.Errorf("parse llm config header error: %w", err)
-		}
-		resp, err := plugin.llmClient.Chat(ctx, plugin.llmConfig.ApiEndpoint, "", headers, reqData)
+		resp, err := plugin.llmClient.WithLLMConfig(plugin.llmConfig).Chat(ctx, "", "", nil, reqData)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Summary:
- Removed automatic `populateDerivedFields` calls from the database store to prevent side effects, exporting it as `PopulateDerivedFields` for explicit external invocation.
- Added `llm.Client.WithLLMConfig` to safely configure the client (parsing endpoint, headers, and model) and updated all callers to use this new pattern.
- Fixed `isHealthy` logic to treat degraded/unknown states as available, and added `applyUpstreamModelName` to ensure the upstream model name overrides the config.