### PR TITLE
Return hardware mode for space resource list

### DIFF
--- a/common/types/space_resource.go
+++ b/common/types/space_resource.go
@@ -266,6 +266,15 @@ var ResourceTypeValidator validator.Func = func(fl validator.FieldLevel) bool {
 	return ResourceTypeValid(ResourceType(fl.Field().String()))
 }
 
+type HardwareModel string
+
+const (
+	HardwareModelCPU  HardwareModel = "CPU"
+	HardwareModelXPU  HardwareModel = "XPU"
+	HardwareModelVXPU HardwareModel = "VXPU"
+	HardwareModelMIG  HardwareModel = "MIG"
+)
+
 type SpaceResource struct {
 	ID                  int64                     `json:"id"`
 	Name                string                    `json:"name"`
@@ -283,6 +292,7 @@ type SpaceResource struct {
 	AvailableStatusList []ResourceAvailableStatus `json:"available_status_list"`
 	PriceUndefined      bool                      `json:"price_undefined"`
 	Scenarios           []string                  `json:"scenarios"`
+	HardwareModel       HardwareModel             `json:"hardware_model"` // CPU, or XPU, VXPU, MIG
 }
 
 type CreateSpaceResourceReq struct {

--- a/component/space_resource.go
+++ b/component/space_resource.go
@@ -165,6 +165,7 @@ func (c *spaceResourceComponentImpl) Index(ctx context.Context, req *types.Space
 				Type:                resourceType,
 				Scenarios:           scenarios,
 				AvailableStatusList: availableStatusList,
+				HardwareModel:       c.getHardwareModel(hardware),
 			})
 		}
 
@@ -211,6 +212,46 @@ func (c *spaceResourceComponentImpl) replicaSatisfiesConstraint(constraint *data
 		return true
 	}
 	return types.ReplicaSatisfiesConstraint(constraint.MaxReplica, replicas)
+}
+
+func (c *spaceResourceComponentImpl) getHardwareModel(hardware types.HardWare) types.HardwareModel {
+	// Determine the XPU processor (first non-empty Num field), same order as
+	// common.ResourceType / types.GetResXPUMode.
+	var xpuProc *types.Processor
+	switch {
+	case strings.TrimSpace(hardware.Gpu.Num) != "":
+		xpuProc = &hardware.Gpu
+	case strings.TrimSpace(hardware.Npu.Num) != "":
+		xpuProc = &hardware.Npu
+	case strings.TrimSpace(hardware.Gcu.Num) != "":
+		xpuProc = &hardware.Gcu
+	case strings.TrimSpace(hardware.Mlu.Num) != "":
+		xpuProc = &hardware.Mlu
+	case strings.TrimSpace(hardware.Dcu.Num) != "":
+		xpuProc = &hardware.Dcu
+	case strings.TrimSpace(hardware.GPGpu.Num) != "":
+		xpuProc = &hardware.GPGpu
+	case strings.TrimSpace(hardware.Tpu.Num) != "":
+		xpuProc = &hardware.Tpu
+	}
+
+	// No XPU configured → pure CPU.
+	if xpuProc == nil {
+		return types.HardwareModelCPU
+	}
+
+	// VXPU: virtual XPU has a ResourceMemName (e.g. volcano.sh/vgpu-memory).
+	if len(strings.TrimSpace(xpuProc.ResourceMemName)) > 0 {
+		return types.HardwareModelVXPU
+	}
+
+	// MIG: resource name starts with nvidia.com/mig- prefix.
+	if strings.HasPrefix(xpuProc.ResourceName, common.MIGResourcePrefix) {
+		return types.HardwareModelMIG
+	}
+
+	// Any other physical XPU.
+	return types.HardwareModelXPU
 }
 
 func (c *spaceResourceComponentImpl) Update(ctx context.Context, req *types.UpdateSpaceResourceReq) (*types.SpaceResource, error) {

--- a/component/space_resource_ce_test.go
+++ b/component/space_resource_ce_test.go
@@ -43,7 +43,7 @@ func TestSpaceResourceComponent_Index(t *testing.T) {
 	require.Equal(t, []types.SpaceResource{
 		{
 			ID: 1, Name: "sr", Resources: `{"memory": "1000", "gpu": {"num": "5"}}`,
-			IsAvailable: false, Type: "gpu", Scenarios: []string{"finetune"},
+			IsAvailable: false, Type: "gpu", Scenarios: []string{"finetune"}, HardwareModel: types.HardwareModelXPU,
 		},
 	}, data)
 
@@ -149,6 +149,6 @@ func TestSpaceResourceComponent_Index_Sandbox_ExcludeHardware(t *testing.T) {
 	require.Nil(t, err)
 	// only the pure-CPU resource survives; the CPU+GPU one is filtered out
 	require.Equal(t, []types.SpaceResource{
-		{ID: 1, Name: "cpu-only", Resources: `{"memory": "1000"}`, IsAvailable: false, Type: "cpu", Scenarios: []string{"sandbox"}},
+		{ID: 1, Name: "cpu-only", Resources: `{"memory": "1000"}`, IsAvailable: false, Type: "cpu", Scenarios: []string{"sandbox"}, HardwareModel: types.HardwareModelCPU},
 	}, data)
 }

--- a/component/space_resource_test.go
+++ b/component/space_resource_test.go
@@ -48,6 +48,79 @@ func TestValidateResources(t *testing.T) {
 	})
 }
 
+func TestGetHardwareModel(t *testing.T) {
+	c := &spaceResourceComponentImpl{}
+
+	t.Run("CPU when no XPU configured", func(t *testing.T) {
+		hw := types.HardWare{
+			Cpu:    types.CPU{Type: "intel", Num: "2"},
+			Memory: "8G",
+		}
+		require.Equal(t, types.HardwareModelCPU, c.getHardwareModel(hw))
+	})
+
+	t.Run("MIG when ResourceName has nvidia.com/mig- prefix", func(t *testing.T) {
+		hw := types.HardWare{
+			Cpu: types.CPU{Type: "intel", Num: "2"},
+			Gpu: types.Processor{Type: "A100", Num: "1", ResourceName: "nvidia.com/mig-1g.10gb"},
+		}
+		require.Equal(t, types.HardwareModelMIG, c.getHardwareModel(hw))
+	})
+
+	t.Run("VXPU when ResourceMemName is set", func(t *testing.T) {
+		hw := types.HardWare{
+			Cpu: types.CPU{Type: "intel", Num: "2"},
+			Gpu: types.Processor{Type: "A100", Num: "1", ResourceMemName: "volcano.sh/vgpu-memory"},
+		}
+		require.Equal(t, types.HardwareModelVXPU, c.getHardwareModel(hw))
+	})
+
+	t.Run("XPU for physical GPU without MIG or VXPU", func(t *testing.T) {
+		hw := types.HardWare{
+			Cpu: types.CPU{Type: "intel", Num: "2"},
+			Gpu: types.Processor{Type: "A100", Num: "1", ResourceName: "nvidia.com/gpu"},
+		}
+		require.Equal(t, types.HardwareModelXPU, c.getHardwareModel(hw))
+	})
+
+	t.Run("VXPU takes priority over MIG", func(t *testing.T) {
+		hw := types.HardWare{
+			Cpu: types.CPU{Type: "intel", Num: "2"},
+			Gpu: types.Processor{
+				Type:            "A100",
+				Num:             "1",
+				ResourceName:    "nvidia.com/mig-1g.10gb",
+				ResourceMemName: "volcano.sh/vgpu-memory",
+			},
+		}
+		require.Equal(t, types.HardwareModelVXPU, c.getHardwareModel(hw))
+	})
+
+	t.Run("XPU for NPU", func(t *testing.T) {
+		hw := types.HardWare{
+			Cpu: types.CPU{Type: "intel", Num: "2"},
+			Npu: types.Processor{Type: "ascend910", Num: "1", ResourceName: "huawei.com/npu"},
+		}
+		require.Equal(t, types.HardwareModelXPU, c.getHardwareModel(hw))
+	})
+
+	t.Run("VXPU for DCU with ResourceMemName", func(t *testing.T) {
+		hw := types.HardWare{
+			Cpu: types.CPU{Type: "intel", Num: "2"},
+			Dcu: types.Processor{Type: "hygon", Num: "1", ResourceMemName: "volcano.sh/vgpu-memory"},
+		}
+		require.Equal(t, types.HardwareModelVXPU, c.getHardwareModel(hw))
+	})
+
+	t.Run("XPU for TPU", func(t *testing.T) {
+		hw := types.HardWare{
+			Cpu: types.CPU{Type: "intel", Num: "2"},
+			Tpu: types.Processor{Type: "chipltech", Num: "1"},
+		}
+		require.Equal(t, types.HardwareModelXPU, c.getHardwareModel(hw))
+	})
+}
+
 func TestSpaceResourceComponent_Update(t *testing.T) {
 	ctx := context.TODO()
 	sc := initializeTestSpaceResourceComponent(ctx, t)


### PR DESCRIPTION
Summary:
- Added `HardwareModel` field to the `SpaceResource` struct and API response to allow the frontend to distinguish between physical accelerators, virtual accelerators, and MIG slices.
- Implemented `getHardwareModel` method to classify resources into CPU, XPU, VXPU, or MIG based on configuration priorities (e.g., MIG prefix, virtual memory names, or physical XPU types).