### PR TITLE
Add cached price per million in model list

### DIFF
--- a/aigateway/types/openai.go
+++ b/aigateway/types/openai.go
@@ -288,8 +288,9 @@ const (
 
 // ModelTokenPrice is currency plus per-million-token rate (major units, from accounting cents + sku_unit).
 type ModelTokenPrice struct {
-	Currency        string  `json:"currency"`
-	PricePerMillion float64 `json:"price_per_million"`
+	Currency              string   `json:"currency"`
+	PricePerMillion       float64  `json:"price_per_million"`
+	CachedPricePerMillion *float64 `json:"cached_price_per_million,omitempty"`
 }
 
 // ModelModalPrice is a unit-based media generation price.


### PR DESCRIPTION
Summary:
- Added `CachedPricePerMillion` field to the `ModelTokenPrice` struct to expose cached token pricing in the `/v1/models` API, which was previously missing.
- Populated the new field in `toTokenPrice()` by calculating it from `SkuCachedPrice` (using the same conversion logic as standard prices), setting it to `nil` when unconfigured (`SkuCachedPrice < 0`) to maintain backward compatibility via `omitempty`.