### PR TITLE
Fix AI gateway insufficient balance responses

### DIFF
--- a/aigateway/handler/openai.go
+++ b/aigateway/handler/openai.go
@@ -195,9 +195,10 @@ func (h *OpenAIHandlerImpl) Shutdown(ctx context.Context) error {
 	return h.llmTracer.Shutdown(ctx)
 }
 
-// handleInsufficientBalance handles the insufficient balance error response
-// for both stream and non-stream requests
-func (h *OpenAIHandlerImpl) handleInsufficientBalance(c *gin.Context, isStream bool, nsUUID, modelID string, err error) {
+// handleInsufficientBalance returns an HTTP error before any upstream response
+// stream starts. Streaming requests must also receive a non-2xx status so
+// clients can distinguish this preflight failure from a successful SSE stream.
+func (h *OpenAIHandlerImpl) handleInsufficientBalance(c *gin.Context, _ bool, nsUUID, modelID string, err error) {
 	// Check if the error is the standard insufficient balance error
 	if !errors.Is(err, errorx.ErrInsufficientBalance) {
 		// If it's a different error, log and return generic error
@@ -210,18 +211,22 @@ func (h *OpenAIHandlerImpl) handleInsufficientBalance(c *gin.Context, isStream b
 	slog.WarnContext(c.Request.Context(), "insufficient balance for request",
 		slog.Any("ns_uuid", nsUUID), slog.Any("model", modelID))
 
-	if isStream {
-		// For stream requests, write error chunk
-		errorChunk := generateInsufficientBalanceResp(h.config.Frontend.URL)
-		errorChunkJson, _ := json.Marshal(errorChunk)
-		_, writeErr := c.Writer.Write([]byte("data: " + string(errorChunkJson) + "\n\ndata: [DONE]\n\n"))
-		if writeErr != nil {
-			slog.Error("failed to write insufficient balance error to stream", "error", writeErr)
-		}
-		c.Writer.Flush()
-	} else {
-		httpbase.ForbiddenError(c, err)
-	}
+	c.Header("Content-Type", "application/json; charset=utf-8")
+	c.JSON(http.StatusPaymentRequired, gin.H{
+		"error": gin.H{
+			"code":    "insufficient_balance",
+			"message": insufficientBalanceMessage(h.config.Frontend.URL),
+			"type":    "insufficient_balance",
+		},
+	})
+}
+
+func insufficientBalanceMessage(frontendURL string) string {
+	rechargeURL := strings.TrimRight(frontendURL, "/") + "/settings/recharge-payment"
+	return fmt.Sprintf(
+		"**Insufficient balance**\n\n👉 [Recharge your account](%s) to continue.",
+		rechargeURL,
+	)
 }
 
 func (h *OpenAIHandlerImpl) handleUsageLimitExceeded(c *gin.Context, isStream bool, username, modelID string, err error) {

--- a/aigateway/handler/openai_audio.go
+++ b/aigateway/handler/openai_audio.go
@@ -155,9 +155,6 @@ func (h *OpenAIHandlerImpl) handleAudioSTT(c *gin.Context, kind string) {
 	if !modelTarget.Model.SkipBalance() {
 		if err := h.openaiComponent.CheckBalance(ctx, nsUUID); err != nil {
 			finishModalGenerationTraceWithError(generationRecorder, err, types.TraceErrInsufficientBalance)
-			if isStream {
-				c.Writer.Header().Set("Content-Type", "text/event-stream")
-			}
 			h.handleInsufficientBalance(c, isStream, nsUUID, modelID, err)
 			return
 		}

--- a/aigateway/handler/openai_image_edit_test.go
+++ b/aigateway/handler/openai_image_edit_test.go
@@ -120,8 +120,8 @@ func TestOpenAIHandler_EditImagePreProxyErrors(t *testing.T) {
 
 		tester.handler.EditImage(c)
 
-		require.Equal(t, http.StatusForbidden, w.Code)
-		require.Contains(t, w.Body.String(), "ACT-ERR-0")
+		require.Equal(t, http.StatusPaymentRequired, w.Code)
+		require.Contains(t, w.Body.String(), `"code":"insufficient_balance"`)
 	})
 
 	t.Run("sensitive prompt", func(t *testing.T) {

--- a/aigateway/handler/openai_ocr_test.go
+++ b/aigateway/handler/openai_ocr_test.go
@@ -244,7 +244,8 @@ func TestOpenAIHandler_OCRPreProxyErrors(t *testing.T) {
 
 		tester.handler.OCR(c)
 
-		require.Equal(t, http.StatusForbidden, w.Code)
+		require.Equal(t, http.StatusPaymentRequired, w.Code)
+		require.Contains(t, w.Body.String(), `"code":"insufficient_balance"`)
 	})
 }
 

--- a/aigateway/handler/openai_speech.go
+++ b/aigateway/handler/openai_speech.go
@@ -105,9 +105,6 @@ func (h *OpenAIHandlerImpl) Speech(c *gin.Context) {
 	if !modelTarget.Model.SkipBalance() {
 		if err := h.openaiComponent.CheckBalance(ctx, nsUUID); err != nil {
 			finishModalGenerationTraceWithError(generationRecorder, err, types.TraceErrInsufficientBalance)
-			if isSSE {
-				c.Writer.Header().Set("Content-Type", "text/event-stream")
-			}
 			h.handleInsufficientBalance(c, isSSE, nsUUID, modelID, err)
 			return
 		}

--- a/aigateway/handler/openai_test.go
+++ b/aigateway/handler/openai_test.go
@@ -1433,7 +1433,7 @@ func TestOpenAIHandler_EmbeddingTrace(t *testing.T) {
 	})
 
 	t.Run("balance failure records trace error", func(t *testing.T) {
-		tester, c, _ := setupTest(t)
+		tester, c, w := setupTest(t)
 		tester.mocks.openAIComp.ExpectedCalls = nil
 
 		recorder := &testEmbeddingRecorderWithMutex{}
@@ -1463,6 +1463,8 @@ func TestOpenAIHandler_EmbeddingTrace(t *testing.T) {
 
 		tester.handler.Embedding(c)
 
+		require.Equal(t, http.StatusPaymentRequired, w.Code)
+		require.Contains(t, w.Body.String(), `"code":"insufficient_balance"`)
 		_, errorCode, ended, _ := recorder.snapshot()
 		require.True(t, ended)
 		require.Equal(t, types.TraceErrInsufficientBalance, errorCode)
@@ -1717,8 +1719,9 @@ func TestOpenAIHandler_Transcription(t *testing.T) {
 		require.Contains(t, w.Body.String(), "model_not_found")
 	})
 
-	t.Run("stream insufficient balance uses chat completion stream error", func(t *testing.T) {
+	t.Run("stream insufficient balance returns payment required before SSE starts", func(t *testing.T) {
 		tester, c, w := setupTest(t)
+		tester.handler.config.Frontend.URL = "https://hub.example.com/"
 		c.Request = newMultipartTranscriptionRequest(t, "model1", "audio-bytes", map[string]string{
 			"stream": "true",
 		})
@@ -1741,11 +1744,15 @@ func TestOpenAIHandler_Transcription(t *testing.T) {
 		tester.handler.Transcription(c)
 
 		body := w.Body.String()
-		require.Equal(t, http.StatusOK, w.Code)
-		require.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
-		require.Contains(t, body, "data: ")
-		require.Contains(t, body, `"finish_reason":"insufficient_balance"`)
-		require.Contains(t, body, "data: [DONE]\n\n")
+		require.Equal(t, http.StatusPaymentRequired, w.Code)
+		require.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+		require.JSONEq(t, `{
+			"error": {
+				"code": "insufficient_balance",
+				"message": "**Insufficient balance**\n\n👉 [Recharge your account](https://hub.example.com/settings/recharge-payment) to continue.",
+				"type": "insufficient_balance"
+			}
+		}`, body)
 	})
 
 	t.Run("upstream error status ends trace without billing", func(t *testing.T) {

--- a/aigateway/handler/response_writer_wrapper.go
+++ b/aigateway/handler/response_writer_wrapper.go
@@ -266,26 +266,6 @@ func writeSensitiveJSONResponse(c *gin.Context, resp any) {
 	c.JSON(http.StatusOK, resp)
 }
 
-func generateInsufficientBalanceResp(frontendURL string) types.ChatCompletionChunk {
-	rechargeURL := fmt.Sprintf("%s/settings/recharge-payment", frontendURL)
-	message := fmt.Sprintf(
-		"**Insufficient balance**\n\n👉 [Recharge your account](%s) to continue.",
-		rechargeURL,
-	)
-	newChunk := types.ChatCompletionChunk{
-		Choices: []types.ChatCompletionChunkChoice{
-			{
-				Delta: types.ChatCompletionChunkChoiceDelta{
-					Content: message,
-				},
-				FinishReason: "insufficient_balance",
-				Index:        0,
-			},
-		},
-	}
-	return newChunk
-}
-
 func (rw *ResponseWriterWrapper) Flush() {
 	rw.internalWritter.Flush()
 }

--- a/aigateway/handler/response_writer_wrapper_test.go
+++ b/aigateway/handler/response_writer_wrapper_test.go
@@ -61,15 +61,6 @@ func TestResponseWriterWrapper_StreamWrite(t *testing.T) {
 	}
 }
 
-func TestGenerateInsufficientBalanceResp(t *testing.T) {
-	frontendURL := "http://localhost:8080"
-	chunk := generateInsufficientBalanceResp(frontendURL)
-	assert.Len(t, chunk.Choices, 1)
-	assert.Equal(t, "insufficient_balance", chunk.Choices[0].FinishReason)
-	assert.Contains(t, chunk.Choices[0].Delta.Content, "**Insufficient balance**")
-	assert.Contains(t, chunk.Choices[0].Delta.Content, frontendURL+"/settings/recharge-payment")
-}
-
 func TestWriteSensitiveStreamResponse(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(w)


### PR DESCRIPTION
Summary:
- Changed insufficient balance errors to return HTTP 402 for both streaming and non-streaming requests, enabling the Provider Pool to properly trigger fallback models instead of misinterpreting the response as successful.
- Replaced the logic that wrapped insufficient balance errors as standard SSE chunks with a unified standard JSON error structure using the `insufficient_balance` error code.
- Included top-up instructions and a link to the recharge page within the error message to guide users.