### PR TITLE
refactor: move TimeZone from Database config to top-level Config

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -48,6 +48,10 @@ type Config struct {
 	UniqueServiceName        string            `env:"STARHUB_SERVER_UNIQUE_SERVICE_NAME" default:""`
 	ServerFailureRedirectURL string            `env:"STARHUB_SERVER_FAIL_REDIRECT_URL" default:"http://localhost:3000/errors/server-error"`
 	NeedPhoneVerify          bool              `env:"STARHUB_SERVER_NEED_PHONE_VERIFY" default:"false"`
+	// TimeZone is the application-wide timezone used for formatting
+	// timestamps (e.g. Loki log timestamps). It is not used by the
+	// database connection layer.
+	TimeZone string `env:"STARHUB_SERVER_TIMEZONE" default:"Asia/Shanghai"`
 
 	APIServer struct {
 		Port         int    `env:"STARHUB_SERVER_SERVER_PORT" default:"8080"`
@@ -76,7 +80,6 @@ type Config struct {
 	Database struct {
 		Driver              string `env:"STARHUB_DATABASE_DRIVER" default:"pg"`
 		DSN                 string `env:"STARHUB_DATABASE_DSN" default:"postgresql://postgres:postgres@localhost:5432/starhub_server?sslmode=disable"`
-		TimeZone            string `env:"STARHUB_DATABASE_TIMEZONE" default:"Asia/Shanghai"`
 		SearchConfiguration string `env:"STARHUB_DATABASE_SEARCH_CONFIGURATION" default:"opencsgchinese"`
 	}
 

--- a/common/config/config.toml.example
+++ b/common/config/config.toml.example
@@ -7,6 +7,7 @@ api_token = "f3a7b9c1d6e5f8e2a1b5d4f9e6a2b8d7c3a4e2b1d9f6e7a8d2c5a7b4c1e3f5b8a1d
 lbs_service_key = "123456"
 city_to_cdn_domain = {}
 docs_host = "http://localhost:6636"
+timezone = "Asia/Shanghai"
 
 [api_server]
 port = 8080
@@ -31,7 +32,6 @@ lfs_concurrency = 5
 [database]
 driver = "pg"
 dsn = "postgresql://postgres:postgres@localhost:5433/starhub_server?sslmode=disable"
-timezone = "Asia/Shanghai"
 
 [redis]
 endpoint = "localhost:6379"

--- a/component/reporter/sender/loki_client.go
+++ b/component/reporter/sender/loki_client.go
@@ -31,7 +31,7 @@ func NewLokiClient(url string, clientID types.ClientType, config *config.Config)
 	if err != nil {
 		slog.Error("failed to create loki client", slog.Any("error", err))
 	}
-	timeLoc, err := time.LoadLocation(config.Database.TimeZone)
+	timeLoc, err := time.LoadLocation(config.TimeZone)
 	if err != nil {
 		slog.Error("failed to create loki client by TimeZone error", slog.Any("error", err))
 	}

--- a/component/reporter/sender/loki_client_test.go
+++ b/component/reporter/sender/loki_client_test.go
@@ -594,7 +594,7 @@ func TestNewLokiClient_ReturnsLogSender(t *testing.T) {
 	cfg.LogCollector.AcceptLabelPrefix = "csghub_"
 	cfg.LogCollector.LineSeparator = "\\n"
 	cfg.LogCollector.MaxStoreTimeDay = 7
-	cfg.Database.TimeZone = "UTC"
+	cfg.TimeZone = "UTC"
 
 	sender, err := NewLokiClient(server.URL, types.ClientType("test-client"), cfg)
 	require.NoError(t, err)

--- a/docker-compose-gitaly.yml
+++ b/docker-compose-gitaly.yml
@@ -314,7 +314,7 @@ services:
           memory: 2048M
     environment:
       STARHUB_DATABASE_DSN: postgresql://postgres:postgres@postgres:5432/starhub_server?sslmode=disable
-      STARHUB_DATABASE_TIMEZONE: Asia/Shanghai
+      STARHUB_SERVER_TIMEZONE: Asia/Shanghai
       STARHUB_SERVER_REDIS_ENDPOINT: redis:6379
       STARHUB_SERVER_GITSERVER_TYPE: gitaly
       STARHUB_SERVER_GITALY_SERVER_SOCKET: tcp://gitaly:8075
@@ -336,7 +336,7 @@ services:
       - postgres
     environment:
       STARHUB_DATABASE_DSN: postgresql://postgres:postgres@postgres:5432/starhub_server?sslmode=disable
-      STARHUB_DATABASE_TIMEZONE: Asia/Shanghai
+      STARHUB_SERVER_TIMEZONE: Asia/Shanghai
       STARHUB_SERVER_REDIS_ENDPOINT: redis:6379
       STARHUB_SERVER_MIRROR_REMOTE: false
       STARHUB_SERVER_S3_ACCESS_KEY_ID: admin

--- a/docs/en/config.md
+++ b/docs/en/config.md
@@ -1,240 +1,30 @@
-# Environment Variable Configuration Document
+# Project Configuration
 
-## Global Configuration
-
-| Environment Variable                    | Default Value                   | Description                                                                 |
-|-----------------------------------------|---------------------------------|---------------------------------------------------------------------------|
-| `STARHUB_SERVER_SAAS`                   | `false`                         | Whether to enable SaaS mode.                                               |
-| `STARHUB_SERVER_INSTANCE_ID`            |                                 | Instance ID used to uniquely identify the current instance.               |
-| `STARHUB_SERVER_ENABLE_SWAGGER`         | `false`                         | Whether to enable Swagger documentation.                                  |
-| `STARHUB_SERVER_API_TOKEN`              | `0c11e6e4f2054444374ba3f0b70de4145935a7312289d404814cd5907c6aa93cc65cd35dbf94e04c13a3dedbf51f1694de84240c8acb7238b54a2c3ac8e87c59`                   | API authentication token used for identity verification.                  |
-| `STARHUB_SERVER_ENABLE_HTTPS`           | `false`                         | Whether to enable HTTPS, mainly for reverse proxy usage.                  |
-| `STARHUB_SERVER_SERVER_DOCS_HOST`       | `http://localhost:6636`         | Documentation service host address.                                       |
-
-## API Server Configuration
-
-| Environment Variable                    | Default Value                   | Description                                                                 |
-|-----------------------------------------|---------------------------------|---------------------------------------------------------------------------|
-| `STARHUB_SERVER_SERVER_PORT`            | `8080`                          | The port on which the API server listens.                                 |
-| `STARHUB_SERVER_PUBLIC_DOMAIN`          | `http://localhost:8080`         | The public domain exposed externally.                                     |
-| `STARHUB_SERVER_SSH_DOMAIN`             | `git@localhost:2222`            | SSH domain configuration.                                                 |
-
-## Mirror Service Configuration
-
-| Environment Variable                    | Default Value                   | Description                                                                 |
-|-----------------------------------------|---------------------------------|---------------------------------------------------------------------------|
-| `STARHUB_SERVER_MIRROR_URL`             | `http://localhost:8085`         | The URL address for the mirror service.                                   |
-| `STARHUB_SERVER_MIRROR_Token`           |                                 | The authentication token for the mirror service.                          |
-| `STARHUB_SERVER_MIRROR_PORT`            | `8085`                          | The port on which the mirror service listens.                              |
-| `STARHUB_SERVER_MIRROR_SESSION_SECRET_KEY` | `mirror`                     | The session key for the mirror service.                                   |
-| `STARHUB_SERVER_MIRROR_WORKER_NUMBER`   | `5`                             | The number of worker threads for the mirror service.                       |
-
-## Database Configuration
-
-| Environment Variable                    | Default Value                   | Description                                                                 |
-|-----------------------------------------|---------------------------------|---------------------------------------------------------------------------|
-| `STARHUB_DATABASE_DRIVER`               | `pg`                            | The database driver type (e.g., PostgreSQL).                               |
-| `STARHUB_DATABASE_DSN`                  | `postgresql://postgres:postgres@localhost:5432/starhub_server?sslmode=disable`     | Database connection string.                                                |
-| `STARHUB_DATABASE_TIMEZONE`             | `Asia/Shanghai`                 | The timezone used by the database.                                         |
-
-## Redis Configuration
-
-| Environment Variable                    | Default Value                   | Description                                                                 |
-|-----------------------------------------|---------------------------------|---------------------------------------------------------------------------|
-| `STARHUB_SERVER_REDIS_ENDPOINT`         | `localhost:6379`                | Redis server address.                                                     |
-| `STARHUB_SERVER_REDIS_MAX_RETRIES`      | `3`                             | Maximum retries for Redis operations.                                      |
-| `STARHUB_SERVER_REDIS_MIN_IDLE_CONNECTIONS` | `0`                          | Minimum idle Redis connections.                                            |
-| `STARHUB_SERVER_REDIS_USER`             |                                 | Redis username.                                                           |
-| `STARHUB_SERVER_REDIS_PASSWORD`         |                                 | Redis password.                                                           |
-| `STARHUB_SERVER_REDIS_USE_SENTINEL`     | `false`                         | Whether to use Redis Sentinel mode.                                        |
-| `STARHUB_SERVER_REDIS_SENTINEL_MASTER`  |                                 | The name of the Sentinel master node.                                     |
-| `STARHUB_SERVER_REDIS_SENTINEL_ENDPOINT`|                                 | The address of the Sentinel node.                                          |
-
-## Git Server Configuration
-
-| Environment Variable                    | Default Value                   | Description                                                                 |
-|-----------------------------------------|---------------------------------|---------------------------------------------------------------------------|
-| `STARHUB_SERVER_GITSERVER_URL`          | `http://localhost:3000`         | Git server URL address.                                                    |
-| `STARHUB_SERVER_GITSERVER_TYPE`         | `gitea`                         | The type of the Git server (e.g., Gitea).                                  |
-| `STARHUB_SERVER_GITSERVER_HOST`         | `http://localhost:3000`         | Git server host address.                                                   |
-| `STARHUB_SERVER_GITSERVER_SECRET_KEY`   | `619c849c49e03754454ccd4cda79a209ce0b30b3`                   | Authentication key for the Git server.                                    |
-| `STARHUB_SERVER_GITSERVER_USERNAME`     | `root`                          | Git server username.                                                       |
-| `STARHUB_SERVER_GITSERVER_PASSWORD`     | `password123`                   | Git server password.                                                       |
-| `STARHUB_SERVER_GITSERVER_TIMEOUT_SEC`  | `5`                             | Git server request timeout (in seconds).                                   |
-
-## Gitaly Configuration
-
-| Environment Variable                    | Default Value                   | Type     | Description                                                                |
-|-----------------------------------------|---------------------------------|----------|----------------------------------------------------------------------------|
-| `STARHUB_SERVER_GITALY_SERVER_SOCKET`   | `tcp://localhost:9999`          | `string` | The Gitaly server address.                                                 |
-| `STARHUB_SERVER_GITALY_STORGE`          | `default`                       | `string` | The Gitaly storage type.                                                   |
-| `STARHUB_SERVER_GITALY_TOKEN`           | `abc123secret`                  | `string` | The Gitaly token.                                                          |
-| `STARHUB_SERVER_GITALY_JWT_SECRET`      | `signing-key`                   | `string` | The Gitaly JWT signing key.                                                |
-
-## Mirror Server Configuration
-
-| Environment Variable                    | Default Value                   | Type     | Description                                                                |
-|-----------------------------------------|---------------------------------|----------|----------------------------------------------------------------------------|
-| `STARHUB_SERVER_MIRRORSERVER_ENABLE`    | `false`                         | `bool`   | Whether to enable the mirror server.                                       |
-| `STARHUB_SERVER_MIRRORSERVER_URL`       | `http://localhost:3001`         | `string` | The URL address for the mirror server.                                     |
-| `STARHUB_SERVER_MIRRORSERVER_TYPE`      | `gitea`                         | `string` | The type of the mirror server.                                             |
-| `STARHUB_SERVER_MIRRORSERVER_HOST`      | `http://localhost:3001`         | `string` | The host address for the mirror server.                                    |
-| `STARHUB_SERVER_MIRRORSERVER_SECRET_KEY`| `619c849c49e03754454ccd4cda79a209ce0b30b3` | `string` | The authentication key for the mirror server.                              |
-| `STARHUB_SERVER_MIRRORSERVER_USERNAME`  | `root`                          | `string` | The username for the mirror server.                                        |
-| `STARHUB_SERVER_MIRRORSERVER_PASSWORD`  | `password123`                   | `string` | The password for the mirror server.                                        |
-
-## Frontend Configuration
-
-| Environment Variable                    | Default Value                   | Type     | Description                                                                |
-|-----------------------------------------|---------------------------------|----------|----------------------------------------------------------------------------|
-| `STARHUB_SERVER_FRONTEND_URL`           | `https://opencsg.com`           | `string` | The frontend service URL address.                                          |
-
-## S3 Configuration
-
-| Environment Variable                    | Default Value                   | Description                                                                 |
-|-----------------------------------------|---------------------------------|---------------------------------------------------------------------------|
-| `STARHUB_SERVER_S3_SSL`                 | `false`                         | Whether to enable SSL for S3.                                              |
-| `STARHUB_SERVER_S3_ACCESS_KEY_ID`       |                                 | S3 access key ID.                                                          |
-| `STARHUB_SERVER_S3_ACCESS_KEY_SECRET`   |                                 | S3 access key secret.                                                      |
-| `STARHUB_SERVER_S3_REGION`              |                                 | S3 region configuration.                                                   |
-| `STARHUB_SERVER_S3_ENDPOINT`            | `localhost:9000`                | The S3 server address.                                                     |
-| `STARHUB_SERVER_S3_INTERNAL_ENDPOINT`   |                                 | The internal S3 server address.                                            |
-| `STARHUB_SERVER_S3_BUCKET`              | `opencsg-test`                  | The S3 bucket name.                                                        |
-| `STARHUB_SERVER_S3_ENABLE_SSL`          | `false`                         | Whether to enable SSL.                                                     |
-
-## Sensitive Word Detection Configuration
-
-| Environment Variable                              | Default Value                 | Type   | Description                                                                |
-|---------------------------------------------------|-------------------------------|--------|----------------------------------------------------------------------------|
-| `STARHUB_SERVER_SENSITIVE_CHECK_ENABLE`           | `false`                       | `bool` | Whether to enable sensitive word detection.                                |
-| `STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_ID`    |                               | `string` | OSS access key ID.                                                        |
-| `STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_SECRET`|                               | `string` | OSS access key secret.                                                    |
-| `STARHUB_SERVER_SENSITIVE_CHECK_REGION`           |                               | `string` | OSS region name.                                                          |
-| `STARHUB_SERVER_SENSITIVE_CHECK_ENDPOINT`         | `oss-cn-beijing.aliyuncs.com` | `string` | OSS endpoint.                                                            |
-| `STARHUB_SERVER_S3_ENABLE_SSH`                    | `true`                        | `bool`  | Whether to enable SSH.                                                    |
-
-## JWT Configuration
-
-| Environment Variable                    | Default Value                   | Type     | Description                                                                |
-|-----------------------------------------|---------------------------------|----------|----------------------------------------------------------------------------|
-| `STARHUB_SERVER_JWT_SIGNING_KEY`         | `secret-key`                    | `string` | JWT signing key.                                                          |
-| `STARHUB_SERVER_JWT_EXPIRES_IN`          | `24h`                           | `string` | JWT expiration time.                                                       |
-
-## Space Configuration
-
-| Environment Variable                                | Default Value                                       | Type      | Description                             |
-|-----------------------------------------------------|----------------------------------------------------|-----------|-----------------------------------------|
-| `STARHUB_SERVER_SPACE_BUILDER_ENDPOINT`             | `http://localhost:8081`                            | `string`  | Builder service address.               |
-| `STARHUB_SERVER_SPACE_RUNNER_ENDPOINT`              | `http://localhost:8082`                            | `string`  | Runner service address.                |
-| `STARHUB_SERVER_SPACE_RUNNER_SERVER_PORT`           | `8082`                                            | `int`     | Runner service port.                   |
-| `STARHUB_SERVER_INTERNAL_ROOT_DOMAIN`               | `internal.example.com`                             | `string`  | Internal root domain (for internal access). |
-| `STARHUB_SERVER_PUBLIC_ROOT_DOMAIN`                 | `public.example.com`                               | `string`  | Public root domain.                    |
-| `STARHUB_SERVER_DOCKER_REG_BASE`                    | `registry.cn-beijing.aliyuncs.com/opencsg_public/` | `string`  | Base address for Docker image repository. |
-| `STARHUB_SERVER_DOCKER_IMAGE_PULL_SECRET`           | `opencsg-pull-secret`                              | `string`  | Secret name for pulling images.        |
-| `STARHUB_SERVER_SPACE_RPROXY_SERVER_PORT`           | `8083`                                            | `int`     | Reverse proxy service port.            |
-| `STARHUB_SERVER_SPACE_SESSION_SECRET_KEY`           | `secret`                                          | `string`  | Session encryption key.                |
-| `STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES`    | `30`                                              | `int`     | Deployment timeout in minutes.         |
-| `STARHUB_SERVER_GPU_MODEL_LABEL`                    | `aliyun.accelerator/nvidia_name`                   | `string`  | GPU model label.                       |
-| `STARHUB_SERVER_READNESS_DELAY_SECONDS`             | `120`                                             | `int`     | Readiness check delay time in seconds. |
-| `STARHUB_SERVER_READNESS_PERIOD_SECONDS`            | `10`                                              | `int`     | Readiness check interval time in seconds. |
-| `STARHUB_SERVER_READNESS_FAILURE_THRESHOLD`         | `3`                                               | `int`     | Readiness check failure threshold.     |
-                                    |
-
-## Model Configuration
-
-| Environment Variable                                | Default Value                                        | Type      | Description                           |
-|-----------------------------------------------------|-----------------------------------------------------|-----------|---------------------------------------|
-| `STARHUB_SERVER_MODEL_DEPLOY_TIMEOUT_IN_MINUTES`    | `60`                                                 | `int`     | Model deployment timeout in minutes. |
-| `STARHUB_SERVER_MODEL_DOWNLOAD_ENDPOINT`            | `https://hub.opencsg.com`                            | `string`  | Model download address.              |
-| `STARHUB_SERVER_MODEL_DOCKER_REG_BASE`              | `opencsg-registry.cn-beijing.cr.aliyuncs.com/public/` | `string`  | Base address for model Docker image repository. |
-| `STARHUB_SERVER_MODEL_NIM_DOCKER_SECRET_NAME`       | `ngc-secret`                                         | `string`  | NGC Docker image secret name.        |
-| `STARHUB_SERVER_MODEL_NIM_NGC_SECRET_NAME`          | `nvidia-nim-secrets`                                 | `string`  | NGC Secret name.                     |
-
-
-## Event Configuration
-
-| Environment Variable                    | Default Value | Type  | Description                        |
-|-----------------------------------------|---------------|-------|------------------------------------|
-| `STARHUB_SERVER_SYNC_IN_MINUTES`       | `1`           | `int` | Interval time for event synchronization (in minutes). |
-
-
-## Casdoor Configuration
-
-| Environment Variable                      | Default Value                     | Type    | Description                       |
-|-------------------------------------------|-----------------------------------|---------|-----------------------------------|
-| `STARHUB_SERVER_CASDOOR_CLIENT_ID`        | `client_id`                       | `string`| Casdoor client ID.                |
-| `STARHUB_SERVER_CASDOOR_CLIENT_SECRET`    | `client_secret`                   | `string`| Casdoor client secret.            |
-| `STARHUB_SERVER_CASDOOR_ENDPOINT`         | `http://localhost:80`             | `string`| Casdoor server endpoint address.  |
-| `STARHUB_SERVER_CASDOOR_CERTIFICATE`      | `/etc/casdoor/certificate.pem`    | `string`| Casdoor certificate path.         |
-| `STARHUB_SERVER_CASDOOR_ORGANIZATION_NAME`| `opencsg`                         | `string`| Casdoor organization name.        |
-| `STARHUB_SERVER_CASDOOR_APPLICATION_NAME` | `opencsg`                         | `string`| Casdoor application name.         |
-
-
-## Nats Configuration
-
-| Environment Variable                          | Default Value                                                   | Type    | Description                          |
-|-----------------------------------------------|-----------------------------------------------------------------|---------|--------------------------------------|
-| `OPENCSG_ACCOUNTING_NATS_URL`                 | `nats://account:g98dc5FA8v4J7ck90w@natsmaster:4222`             | `string`| NATS service URL.                   |
-| `OPENCSG_ACCOUNTING_MSG_FETCH_TIMEOUTINSEC`   | `5`                                                             | `int`   | Message fetch timeout (seconds).    |
-| `OPENCSG_ACCOUNTING_METER_EVENT_SUBJECT`      | `accounting.metering.>`                                         | `string`| Message subject for metering events. |
-| `STARHUB_SERVER_METER_DURATION_SEND_SUBJECT`  | `accounting.metering.duration`                                  | `string`| Message subject for sending duration data. |
-| `STARHUB_SERVER_METER_TOKEN_SEND_SUBJECT`     | `accounting.metering.token`                                     | `string`| Message subject for sending token data. |
-| `STARHUB_SERVER_METER_QUOTA_SEND_SUBJECT`     | `accounting.metering.quota`                                     | `string`| Message subject for sending quota data. |
-
-
-## User Configuration
-
-| Environment Variable                                      | Default Value                             | Type    | Description                          |
-|-----------------------------------------------------------|-------------------------------------------|---------|--------------------------------------|
-| `OPENCSG_USER_SERVER_HOST`                                | `http://localhost`                        | `string`| User service host address.          |
-| `OPENCSG_USER_SERVER_PORT`                                | `8088`                                    | `int`   | User service port number.           |
-| `OPENCSG_USER_SERVER_SIGNIN_SUCCESS_REDIRECT_URL`         | `http://localhost:3000/server/callback`   | `string`| Redirect URL after successful login. |
-
-## Multi-source Synchronization Configuration
-
-| Environment Variable                                      | Default Value                             | Type    | Description                          |
-|-----------------------------------------------------------|-------------------------------------------|---------|--------------------------------------|
-| `OPENCSG_SAAS_API_DOMAIN`                                 | `https://hub.opencsg.com`                 | `string`| SaaS API domain.                    |
-| `OPENCSG_SAAS_SYNC_DOMAIN`                                | `https://sync.opencsg.com`                | `string`| SaaS synchronization domain.        |
-| `STARHUB_SERVER_MULTI_SYNC_ENABLED`                       | `true`                                    | `bool`  | Whether multi-sync functionality is enabled. |
-                          |
-
-## Telemetry Configuration
-
-| Environment Variable                        | Default Value                             | Type    | Description                          |
-|---------------------------------------------|-------------------------------------------|---------|--------------------------------------|
-| `STARHUB_SERVER_TELEMETRY_ENABLE`           | `true`                                    | `bool`  | Whether telemetry is enabled.        |
-| `STARHUB_SERVER_TELEMETRY_URL`              | `http://hub.opencsg.com/api/v1/telemetry` | `string`| Telemetry report URL.               |
-
-## Auto Cleanup Configuration
-
-| Environment Variable                        | Default Value                             | Type    | Description                          |
-|---------------------------------------------|-------------------------------------------|---------|--------------------------------------|
-| `OPENCSG_AUTO_CLEANUP_INSTANCE_ENABLE`      | `false`                                   | `bool`  | Whether automatic instance cleanup is enabled. |
-
-## Dataset Configuration
-
-| Environment Variable                        | Default Value                             | Type      | Description                          |
-|---------------------------------------------|-------------------------------------------|-----------|--------------------------------------|
-| `OPENCSG_PROMPT_MAX_JSONL_FILESIZE_BYTES`   | `1048576` (1MB)                           | `int64`   | Maximum dataset file size (bytes).  |
-
-## Data Flow Configuration
-
-| Environment Variable                        | Default Value                             | Type    | Description                          |
-|---------------------------------------------|-------------------------------------------|---------|--------------------------------------|
-| `OPENCSG_DATAFLOW_SERVER_HOST`              | `http://127.0.0.1`                       | `string`| Data flow service host address.     |
-| `OPENCSG_DATAFLOW_SERVER_PORT`              | `8000`                                    | `int`    | Data flow service port number.      |
-
-## Moderation Configuration
-
-| Environment Variable                        | Default Value                             | Type    | Description                          |
-|---------------------------------------------|-------------------------------------------|---------|--------------------------------------|
-| `OPENCSG_MODERATION_SERVER_HOST`            | `http://localhost`                        | `string`| Moderation service host address.    |
-| `OPENCSG_MODERATION_SERVER_PORT`            | `8089`                                    | `int`    | Moderation service port number.     |
-| `OPENCSG_MODERATION_SERVER_ENCODED_SENSITIVE_WORDS` | `5Lmg6L+R5bmzLHhpamlucGluZw==`   | `string`| Encoded sensitive words list.       |
-
-## Workflow Configuration
-
-| Environment Variable                        | Default Value                             | Type    | Description                          |
-|---------------------------------------------|-------------------------------------------|---------|--------------------------------------|
-| `OPENCSG_WORKFLOW_SERVER_ENDPOINT`          | `localhost:7233`                          | `string`| Workflow service endpoint.           |
+| Environment Variable | Default Value | Description |
+| --- | --- | --- |
+| STARHUB_SERVER_INSTANCE_ID | none | A unique instance ID used to identify multiple instances during deployment |
+| STARHUB_SERVER_ENABLE_SWAGGER | false | Whether to enable Swagger documentation service |
+| STARHUB_SERVER_API_TOKEN | none | API token for identity verification with the frontend, it needs to be 128 characters long |
+| STARHUB_SERVER_SERVER_PORT | 8080 | Port on which CSGhub Server listens after startup |
+| STARHUB_SERVER_SERVER_EXTERNAL_HOST | localhost | Host after CSGhub Server startup |
+| STARHUB_SERVER_SERVER_DOCS_HOST | `http://localhost:6636` | Host after Swagger startup |
+| STARHUB_DATABASE_DRIVER | pg | Database type |
+| STARHUB_DATABASE_DSN | postgresql://postgres:postgres@localhost:5432/STARHUB_SERVER?sslmode=disable | Database DSN |
+| STARHUB_SERVER_TIMEZONE | Asia/Shanghai | Application-wide timezone (used for formatting Loki log timestamps) |
+| STARHUB_SERVER_GITSERVER_URL | http://localhost:3000 | Git server address |
+| STARHUB_SERVER_GITSERVER_TYPE | gitea | Git server type, currently only supports gitea |
+| STARHUB_SERVER_GITSERVER_HOST | http://localhost:3000 | Git server host |
+| STARHUB_SERVER_GITSERVER_SECRET_KEY | 619c849c49e03754454ccd4cda79a209ce0b30b3 | Access token for Git server administrator user |
+| STARHUB_SERVER_GITSERVER_USERNAME | root | Account of the Git server administrator user |
+| STARHUB_SERVER_GITSERVER_PASSWORD | password123 | Password of the Git server administrator user |
+| STARHUB_SERVER_FRONTEND_URL | https://portal-stg.opencsg.com | URL after CSGhub frontend project startup |
+| STARHUB_SERVER_S3_ACCESS_KEY_ID | none | S3 storage Access key ID |
+| STARHUB_SERVER_S3_ACCESS_KEY_SECRET | none | S3 storage Access key Secret |
+| STARHUB_SERVER_S3_REGION | none | S3 storage region |
+| STARHUB_SERVER_S3_ENDPOINT | none | S3 storage address |
+| STARHUB_SERVER_S3_BUCKET | none | S3 storage bucket |
+| STARHUB_SERVER_SENSITIVE_CHECK_ENABLE | false | Whether to enable text review (currently only supports Alibaba Cloud content review service) |
+| STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_ID | none | Alibaba Cloud content review Access key ID |
+| STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_SECRET | none | Alibaba Cloud content review Access key secret |
+| STARHUB_SERVER_SENSITIVE_CHECK_REGION | none | Alibaba Cloud content review region |
+| STARHUB_SERVER_SENSITIVE_CHECK_ENDPOINT | none | Alibaba Cloud content review service address |

--- a/docs/en/migration.md
+++ b/docs/en/migration.md
@@ -14,7 +14,7 @@ Before using Starhub Server locally, it is necessary to manually create the data
 | --- | --- | --- |
 | STARHUB_DATABASE_DRIVER | Database driver, e.g., pg | pg |
 | STARHUB_DATABASE_DSN | Database connection DSN | postgresql://postgres:postgres@localhost:5432/starhub_server?sslmode=disable |
-| STARHUB_DATABASE_TIMEZONE | Database timezone | Asia/Shanghai |
+| STARHUB_SERVER_TIMEZONE | Application-wide timezone (used for formatting Loki log timestamps) | Asia/Shanghai |
 
 ## Initializing Database Migrations
 

--- a/docs/zh-CN/config.md
+++ b/docs/zh-CN/config.md
@@ -1,221 +1,30 @@
-# 环境变量配置文档
+# 项目配置
 
-## 全局配置
-
-| 环境变量                        | 默认值                         | 描述                                                                                     |
-|--------------------------------|-------------------------------|----------------------------------------------------------------------------------------|
-| `STARHUB_SERVER_SAAS`          | `false`                       | 是否启用 SaaS 模式。                                                                   |
-| `STARHUB_SERVER_INSTANCE_ID`   |                               | 实例 ID，用于唯一标识当前实例。                                                        |
-| `STARHUB_SERVER_ENABLE_SWAGGER`| `false`                       | 是否启用 Swagger 文档。                                                                |
-| `STARHUB_SERVER_API_TOKEN`     | `0c11e6e4f2054444374ba3f0b70de4145935a7312289d404814cd5907c6aa93cc65cd35dbf94e04c13a3dedbf51f1694de84240c8acb7238b54a2c3ac8e87c59`                 | API 鉴权令牌，用于身份验证。                                                           |
-| `STARHUB_SERVER_ENABLE_HTTPS`  | `false`                       | 是否启用 HTTPS，主要用于反向代理。                                                     |
-| `STARHUB_SERVER_SERVER_DOCS_HOST` | `http://localhost:6636`     | 文档服务的主机地址。                                                                   |
-
-## API 服务器配置
-
-| 环境变量                          | 默认值                         | 描述                                                                                     |
-|----------------------------------|-------------------------------|----------------------------------------------------------------------------------------|
-| `STARHUB_SERVER_SERVER_PORT`     | `8080`                        | API 服务器监听的端口。                                                                  |
-| `STARHUB_SERVER_PUBLIC_DOMAIN`   | `http://localhost:8080`       | 对外暴露的公共域名。                                                                   |
-| `STARHUB_SERVER_SSH_DOMAIN`      | `git@localhost:2222`          | SSH 域名配置。                                                                          |
-
-## 镜像服务配置
-
-| 环境变量                          | 默认值                         | 描述                                                                                     |
-|----------------------------------|-------------------------------|----------------------------------------------------------------------------------------|
-| `STARHUB_SERVER_MIRROR_URL`      | `http://localhost:8085`       | 镜像服务的 URL 地址。                                                                  |
-| `STARHUB_SERVER_MIRROR_Token`    |                               | 镜像服务的鉴权令牌。                                                                   |
-| `STARHUB_SERVER_MIRROR_PORT`     | `8085`                        | 镜像服务监听的端口。                                                                   |
-| `STARHUB_SERVER_MIRROR_SESSION_SECRET_KEY` | `mirror`          | 镜像服务会话的密钥。                                                                   |
-| `STARHUB_SERVER_MIRROR_WORKER_NUMBER` | `5`                       | 镜像服务的工作线程数。                                                                 |
-
-## 数据库配置
-
-| 环境变量                          | 默认值                         | 描述                                                                                     |
-|----------------------------------|-------------------------------|----------------------------------------------------------------------------------------|
-| `STARHUB_DATABASE_DRIVER`        | `pg`                          | 数据库驱动类型（如 PostgreSQL）。                                                       |
-| `STARHUB_DATABASE_DSN`           | `postgresql://postgres:postgres@localhost:5432/starhub_server?sslmode=disable`   | 数据库连接字符串。                                                                      |
-| `STARHUB_DATABASE_TIMEZONE`      | `Asia/Shanghai`               | 数据库使用的时区。                                                                      |
-
-## Redis 配置
-
-| 环境变量                              | 默认值                         | 描述                                                                                     |
-|--------------------------------------|-------------------------------|----------------------------------------------------------------------------------------|
-| `STARHUB_SERVER_REDIS_ENDPOINT`      | `localhost:6379`              | Redis 服务器的地址。                                                                    |
-| `STARHUB_SERVER_REDIS_MAX_RETRIES`   | `3`                           | Redis 操作的最大重试次数。                                                              |
-| `STARHUB_SERVER_REDIS_MIN_IDLE_CONNECTIONS` | `0`                        | Redis 最小空闲连接数。                                                                  |
-| `STARHUB_SERVER_REDIS_USER`          |                               | Redis 用户名。                                                                          |
-| `STARHUB_SERVER_REDIS_PASSWORD`      |                               | Redis 密码。                                                                            |
-| `STARHUB_SERVER_REDIS_USE_SENTINEL`  | `false`                       | 是否使用 Redis Sentinel 模式。                                                          |
-| `STARHUB_SERVER_REDIS_SENTINEL_MASTER` |                              | Sentinel 主节点名称。                                                                  |
-| `STARHUB_SERVER_REDIS_SENTINEL_ENDPOINT` |                           | Sentinel 节点的地址。                                                                  |
-
-## Git 服务器配置
-
-| 环境变量                           | 默认值                         | 描述                                                                                     |
-|-----------------------------------|-------------------------------|----------------------------------------------------------------------------------------|
-| `STARHUB_SERVER_GITSERVER_URL`    | `http://localhost:3000`       | Git 服务器的 URL 地址。                                                                 |
-| `STARHUB_SERVER_GITSERVER_TYPE`   | `gitea`                       | Git 服务器类型（如 Gitea）。                                                            |
-| `STARHUB_SERVER_GITSERVER_HOST`   | `http://localhost:3000`       | Git 服务器主机地址。                                                                    |
-| `STARHUB_SERVER_GITSERVER_SECRET_KEY` | `619c849c49e03754454ccd4cda79a209ce0b30b3`              | Git 服务器鉴权密钥。                                                                    |
-| `STARHUB_SERVER_GITSERVER_USERNAME` | `root`                      | Git 服务器用户名。                                                                      |
-| `STARHUB_SERVER_GITSERVER_PASSWORD` | `password123`               | Git 服务器密码。                                                                        |
-| `STARHUB_SERVER_GITSERVER_TIMEOUT_SEC` | `5`                       | Git 服务器请求超时时间（秒）。                                                          |
-
-## Gitaly 配置
-| 环境变量                                | 默认值                              | 类型      | 说明                          |
-|-----------------------------------------|-------------------------------------|-----------|-------------------------------|
-| `STARHUB_SERVER_GITALY_SERVER_SOCKET`   | `tcp://localhost:9999`              | `string`  | Gitaly 服务器地址。           |
-| `STARHUB_SERVER_GITALY_STORGE`          | `default`                           | `string`  | Gitaly 存储类型。             |
-| `STARHUB_SERVER_GITALY_TOKEN`           | `abc123secret`                      | `string`  | Gitaly Token。                |
-| `STARHUB_SERVER_GITALY_JWT_SECRET`      | `signing-key`                       | `string`  | Gitaly JWT 签名密钥。         |
-
-## 镜像服务配置
-| 环境变量                                | 默认值                              | 类型      | 说明                          |
-|-----------------------------------------|-------------------------------------|-----------|-------------------------------|
-| `STARHUB_SERVER_MIRRORSERVER_ENABLE`    | `false`                             | `bool`    | 是否启用镜像服务器。          |
-| `STARHUB_SERVER_MIRRORSERVER_URL`       | `http://localhost:3001`             | `string`  | 镜像服务器 URL。              |
-| `STARHUB_SERVER_MIRRORSERVER_TYPE`      | `gitea`                             | `string`  | 镜像服务器类型。              |
-| `STARHUB_SERVER_MIRRORSERVER_HOST`      | `http://localhost:3001`             | `string`  | 镜像服务器主机地址。          |
-| `STARHUB_SERVER_MIRRORSERVER_SECRET_KEY`| `619c849c49e03754454ccd4cda79a209ce0b30b3` | `string`  | 镜像服务器密钥。              |
-| `STARHUB_SERVER_MIRRORSERVER_USERNAME`  | `root`                              | `string`  | 镜像服务器用户名。            |
-| `STARHUB_SERVER_MIRRORSERVER_PASSWORD`  | `password123`                       | `string`  | 镜像服务器密码。              |
-
-## 前端配置
-| 环境变量                                | 默认值                              | 类型      | 说明                          |
-|-----------------------------------------|-------------------------------------|-----------|-------------------------------|
-| `STARHUB_SERVER_FRONTEND_URL`           | `https://opencsg.com`               | `string`  | 前端服务的 URL 地址。         |
-
-
-## S3 配置
-
-| 环境变量                            | 默认值                         | 描述                                                                                     |
-|------------------------------------|-------------------------------|----------------------------------------------------------------------------------------|
-| `STARHUB_SERVER_S3_SSL`            | `false`                       | 是否启用 S3 的 SSL。                                                                    |
-| `STARHUB_SERVER_S3_ACCESS_KEY_ID`  |                               | S3 的访问密钥 ID。                                                                      |
-| `STARHUB_SERVER_S3_ACCESS_KEY_SECRET` |                            | S3 的访问密钥 Secret。                                                                  |
-| `STARHUB_SERVER_S3_REGION`         |                               | S3 的区域配置。                                                                          |
-| `STARHUB_SERVER_S3_ENDPOINT`       | `localhost:9000`              | S3 的服务端地址。                                                                          |
-| `STARHUB_SERVER_S3_INTERNAL_ENDPOINT`         |                    | S3 内部服务端地址。                                                                       |
-| `STARHUB_SERVER_S3_BUCKET`         | `opencsg-test`                | S3 的存储桶名称。                                                                       |
-| `STARHUB_SERVER_S3_ENABLE_SSL`         | false                     | 是否启用 SSL。                                                                       |
-
-
-## 敏感词检测配置
-| 环境变量                                | 默认值                              | 类型  | 说明                          |
-|-----------------------------------------|-------------------------------------|-------|-------------------------------|
-| `STARHUB_SERVER_SENSITIVE_CHECK_ENABLE` | `false`                             | `bool`| 是否启用敏感信息检查功能。      |
-| `STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_ID` | -                             | `string` | OSS 的访问密钥 ID。           |
-| `STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_SECRET` | -                          | `string` | OSS 的访问密钥 Secret。       |
-| `STARHUB_SERVER_SENSITIVE_CHECK_REGION` | -                                   | `string` | OSS 的区域名称。              |
-| `STARHUB_SERVER_SENSITIVE_CHECK_ENDPOINT` | `oss-cn-beijing.aliyuncs.com`     | `string` | OSS 的访问终端。              |
-| `STARHUB_SERVER_S3_ENABLE_SSH`         | `true`                              | `bool` | 是否启用 SSL。                |
-
-## JWT 配置
-| 环境变量                      | 默认值           | 类型      | 说明                          |
-|-------------------------------|------------------|-----------|-------------------------------|
-| `STARHUB_JWT_SIGNING_KEY`     | `signing-key`    | `string`  | JWT 签名密钥。                |
-| `STARHUB_JWT_VALIDATE_HOUR`   | `24`             | `int`     | JWT 的有效时间（小时）。       |
-
-
-## 应用配置
-| 环境变量                                | 默认值                                       | 类型      | 说明                          |
-|-----------------------------------------|----------------------------------------------|-----------|-------------------------------|
-| `STARHUB_SERVER_SPACE_BUILDER_ENDPOINT` | `http://localhost:8081`                      | `string`  | 构建器服务地址。              |
-| `STARHUB_SERVER_SPACE_RUNNER_ENDPOINT`  | `http://localhost:8082`                      | `string`  | 运行器服务地址。              |
-| `STARHUB_SERVER_SPACE_RUNNER_SERVER_PORT`| `8082`                                      | `int`     | 运行器服务端口。              |
-| `STARHUB_SERVER_INTERNAL_ROOT_DOMAIN`   | `internal.example.com`                       | `string`  | 内部根域名（仅内部访问）。    |
-| `STARHUB_SERVER_PUBLIC_ROOT_DOMAIN`     | `public.example.com`                         | `string`  | 公共根域名。                  |
-| `STARHUB_SERVER_DOCKER_REG_BASE`        | `registry.cn-beijing.aliyuncs.com/opencsg_public/` | `string`  | Docker 镜像仓库基地址。       |
-| `STARHUB_SERVER_DOCKER_IMAGE_PULL_SECRET`| `opencsg-pull-secret`                        | `string`  | 拉取镜像的秘密名称。          |
-| `STARHUB_SERVER_SPACE_RPROXY_SERVER_PORT`| `8083`                                      | `int`     | 反向代理服务端口。            |
-| `STARHUB_SERVER_SPACE_SESSION_SECRET_KEY`| `secret`                                    | `string`  | 会话加密密钥。                |
-| `STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES` | `30`                                 | `int`     | 部署超时时间（分钟）。        |
-| `STARHUB_SERVER_GPU_MODEL_LABEL`        | `aliyun.accelerator/nvidia_name`             | `string`  | GPU 模型标签。                |
-| `STARHUB_SERVER_READNESS_DELAY_SECONDS` | `120`                                       | `int`     | 健康检查延迟时间（秒）。      |
-| `STARHUB_SERVER_READNESS_PERIOD_SECONDS`| `10`                                        | `int`     | 健康检查间隔时间（秒）。      |
-| `STARHUB_SERVER_READNESS_FAILURE_THRESHOLD` | `3`                                    | `int`     | 健康检查失败阈值。            |
-
-## 模型配置
-| 环境变量                                | 默认值                                       | 类型      | 说明                          |
-|-----------------------------------------|----------------------------------------------|-----------|-------------------------------|
-| `STARHUB_SERVER_MODEL_DEPLOY_TIMEOUT_IN_MINUTES` | `60`                                 | `int`     | 模型部署超时时间（分钟）。    |
-| `STARHUB_SERVER_MODEL_DOWNLOAD_ENDPOINT`| `https://hub.opencsg.com`                   | `string`  | 模型下载地址。                |
-| `STARHUB_SERVER_MODEL_DOCKER_REG_BASE`  | `opencsg-registry.cn-beijing.cr.aliyuncs.com/public/` | `string`  | 模型 Docker 镜像仓库基地址。  |
-| `STARHUB_SERVER_MODEL_NIM_DOCKER_SECRET_NAME` | `ngc-secret`                          | `string`  | NGC Docker 镜像秘密名称。     |
-| `STARHUB_SERVER_MODEL_NIM_NGC_SECRET_NAME` | `nvidia-nim-secrets`                  | `string`  | NGC Secret 名称。             |
-
-
-## 事件配置
-| 环境变量                                | 默认值                              | 类型  | 说明                          |
-|-----------------------------------------|-------------------------------------|-------|-------------------------------|
-| `STARHUB_SERVER_SYNC_IN_MINUTES`       | `1`                                 | `int`  | 同步事件的间隔时间（分钟）。   |
-
-## Casdoor 配置
-| 环境变量                                | 默认值                              | 类型  | 说明                          |
-|-----------------------------------------|-------------------------------------|-------|-------------------------------|
-| `STARHUB_SERVER_CASDOOR_CLIENT_ID`      | `client_id`                         | `string` | Casdoor 客户端 ID。           |
-| `STARHUB_SERVER_CASDOOR_CLIENT_SECRET`  | `client_secret`                     | `string` | Casdoor 客户端密钥。          |
-| `STARHUB_SERVER_CASDOOR_ENDPOINT`       | `http://localhost:80`               | `string` | Casdoor 服务端点地址。        |
-| `STARHUB_SERVER_CASDOOR_CERTIFICATE`    | `/etc/casdoor/certificate.pem`      | `string` | Casdoor 证书路径。            |
-| `STARHUB_SERVER_CASDOOR_ORGANIZATION_NAME` | `opencsg`                        | `string` | Casdoor 组织名称。            |
-| `STARHUB_SERVER_CASDOOR_APPLICATION_NAME` | `opencsg`                         | `string` | Casdoor 应用名称。            |
-
-## Nats 配置
-| 环境变量                                  | 默认值                                       | 类型      | 说明                          |
-|-------------------------------------------|----------------------------------------------|-----------|-------------------------------|
-| `OPENCSG_ACCOUNTING_NATS_URL`             | `nats://account:g98dc5FA8v4J7ck90w@natsmaster:4222` | `string`  | NATS 服务 URL。               |
-| `OPENCSG_ACCOUNTING_MSG_FETCH_TIMEOUTINSEC` | `5`                                     | `int`     | 消息获取超时（秒）。          |
-| `OPENCSG_ACCOUNTING_METER_EVENT_SUBJECT`  | `accounting.metering.>`                     | `string`  | 用于计费事件的消息主题。      |
-| `STARHUB_SERVER_METER_DURATION_SEND_SUBJECT` | `accounting.metering.duration`          | `string`  | 用于发送时长数据的消息主题。  |
-| `STARHUB_SERVER_METER_TOKEN_SEND_SUBJECT` | `accounting.metering.token`                | `string`  | 用于发送 token 数据的消息主题。 |
-| `STARHUB_SERVER_METER_QUOTA_SEND_SUBJECT` | `accounting.metering.quota`                | `string`  | 用于发送配额数据的消息主题。  |
-
-## 用户配置
-| 环境变量                                      | 默认值                              | 类型      | 说明                          |
-|-----------------------------------------------|-------------------------------------|-----------|-------------------------------|
-| `OPENCSG_USER_SERVER_HOST`                    | `http://localhost`                  | `string`  | 用户服务的主机地址。          |
-| `OPENCSG_USER_SERVER_PORT`                    | `8088`                              | `int`     | 用户服务的端口号。            |
-| `OPENCSG_USER_SERVER_SIGNIN_SUCCESS_REDIRECT_URL` | `http://localhost:3000/server/callback` | `string`  | 登录成功后的重定向 URL。      |
-
-## 多源同步配置
-| 环境变量                                | 默认值                                       | 类型      | 说明                          |
-|-----------------------------------------|----------------------------------------------|-----------|-------------------------------|
-| `OPENCSG_SAAS_API_DOMAIN`               | `https://hub.opencsg.com`                   | `string`  | SaaS API 域名。               |
-| `OPENCSG_SAAS_SYNC_DOMAIN`              | `https://sync.opencsg.com`                  | `string`  | SaaS 同步域名。               |
-| `STARHUB_SERVER_MULTI_SYNC_ENABLED`     | `true`                                      | `bool`    | 是否启用多同步功能。          |
-
-## 遥测配置
-| 环境变量                                | 默认值                              | 类型  | 说明                          |
-|-----------------------------------------|-------------------------------------|-------|-------------------------------|
-| `STARHUB_SERVER_TELEMETRY_ENABLE`       | `true`                              | `bool` | 是否启用遥测功能。            |
-| `STARHUB_SERVER_TELEMETRY_URL`          | `http://hub.opencsg.com/api/v1/telemetry` | `string` | 遥测报告 URL 地址。           |
-
-## 自动清理配置
-| 环境变量                                | 默认值                              | 类型  | 说明                          |
-|-----------------------------------------|-------------------------------------|-------|-------------------------------|
-| `OPENCSG_AUTO_CLEANUP_INSTANCE_ENABLE`  | `false`                             | `bool` | 是否启用自动清理实例功能。    |
-
-## 数据集配置
-| 环境变量                                | 默认值                              | 类型      | 说明                          |
-|-----------------------------------------|-------------------------------------|-----------|-------------------------------|
-| `OPENCSG_PROMPT_MAX_JSONL_FILESIZE_BYTES` | `1048576` (1MB)                    | `int64`   | 数据集文件最大大小（字节）。  |
-
-## 数据流配置
-| 环境变量                                | 默认值                              | 类型  | 说明                          |
-|-----------------------------------------|-------------------------------------|-------|-------------------------------|
-| `OPENCSG_DATAFLOW_SERVER_HOST`          | `http://127.0.0.1`                 | `string` | 数据流服务的主机地址。        |
-| `OPENCSG_DATAFLOW_SERVER_PORT`          | `8000`                              | `int`    | 数据流服务的端口号。          |
-
-## 审核配置
-| 环境变量                                | 默认值                              | 类型  | 说明                          |
-|-----------------------------------------|-------------------------------------|-------|-------------------------------|
-| `OPENCSG_MODERATION_SERVER_HOST`        | `http://localhost`                  | `string` | 审核服务的主机地址。          |
-| `OPENCSG_MODERATION_SERVER_PORT`        | `8089`                              | `int`    | 审核服务的端口号。            |
-| `OPENCSG_MODERATION_SERVER_ENCODED_SENSITIVE_WORDS` | `5Lmg6L+R5bmzLHhpamlucGluZw==` | `string` | 编码的敏感词列表。            |
-
-## 工作流配置
-| 环境变量                                | 默认值                              | 类型      | 说明                          |
-|-----------------------------------------|-------------------------------------|-----------|-------------------------------|
-| `OPENCSG_WORKFLOW_SERVER_ENDPOINT`      | `localhost:7233`                    | `string`  | 工作流服务端点。              |
-
+| 环境变量名 | 默认值 | 描述 |
+| --- | --- | --- |
+| STARHUB_SERVER_INSTANCE_ID | none | 一个唯一的实例 ID，用于部署多个实例时做标识 |
+| STARHUB_SERVER_ENABLE_SWAGGER | false | 是否开启 Swagger 文档服务 |
+| STARHUB_SERVER_API_TOKEN | f3a7b9c1d6e5f8e2a1b5d4f9e6a2b8d7c3a4e2b1d9f6e7a8d2c5a7b4c1e3f5b8a1d4f9b7d6e2f8a5d3b1e7f9c6a8b2d1e4f7d5b6e9f2a4b3c8e1d7f995hd82hf | 用于和前端做身份校验的 API token |
+| STARHUB_SERVER_SERVER_PORT | 8080 | Starhub Sever 启动后监听的端口 |
+| STARHUB_SERVER_SERVER_EXTERNAL_HOST | localhost | Starhub Server 启动后的 Host |
+| STARHUB_SERVER_SERVER_DOCS_HOST | `http://localhost:6636` | Swagger 启动后的 Host|
+| STARHUB_DATABASE_DRIVER | pg | 数据库的类别 |
+| STARHUB_DATABASE_DSN | postgresql://postgres:postgres@localhost:5432/STARHUB_SERVER?sslmode=disable | 数据库的 DSN |
+| STARHUB_SERVER_TIMEZONE | Asia/Shanghai | 应用全局时区（用于格式化 Loki 日志时间戳） |
+| STARHUB_SERVER_GITSERVER_URL | http://localhost:3000 | Git server 的地址 |
+| STARHUB_SERVER_GITSERVER_TYPE | gitea | Git server 的类别，目前只支持 gitea |
+| STARHUB_SERVER_GITSERVER_HOST | http://localhost:3000 | Git server 的 Host |
+| STARHUB_SERVER_GITSERVER_SECRET_KEY | 619c849c49e03754454ccd4cda79a209ce0b30b3 | Git server 管理员用户的 access token |
+| STARHUB_SERVER_GITSERVER_USERNAME | root | Git server 管理员用户的账号 |
+| STARHUB_SERVER_GITSERVER_PASSWORD | password123 | Git server 管理员用户的密码 |
+| STARHUB_SERVER_FRONTEND_URL | https://portal-stg.opencsg.com | Starhub 前端项目启动后的 URL |
+| STARHUB_SERVER_S3_ACCESS_KEY_ID | none | S3 存储的 Access key ID |
+| STARHUB_SERVER_S3_ACCESS_KEY_SECRET | none | S3 存储的 Access key Secret |
+| STARHUB_SERVER_S3_REGION | none | S3 存储的 region |
+| STARHUB_SERVER_S3_ENDPOINT | none | S3 存储的地址 |
+| STARHUB_SERVER_S3_BUCKET | none | S3 存储的 bucket |
+| STARHUB_SERVER_SENSITIVE_CHECK_ENABLE | false | 是否开启文本审核(目前只支持阿里云内容审核服务)|
+| STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_ID | none | 阿里云内容审核的 Access key ID |
+| STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_SECRET | none | 阿里云内容审核的 Access key secret |
+| STARHUB_SERVER_SENSITIVE_CHECK_REGION | none | 阿里云内容审核的 region |
+| STARHUB_SERVER_SENSITIVE_CHECK_ENDPOINT | none | 阿里云内容审核的服务地址 |

--- a/docs/zh-CN/migration.md
+++ b/docs/zh-CN/migration.md
@@ -14,7 +14,7 @@ Migration 文件的名字有两个部分，时间戳和迁移名（也就是这�
 | --- | --- | --- |
 | STARHUB_DATABASE_DRIVER | 数据库的 dirver，例如 pg | pg |
 | STARHUB_DATABASE_DSN | 数据库的连接 DSN | postgresql://postgres:postgres@localhost:5432/starhub_server?sslmode=disable |
-| STARHUB_DATABASE_TIMEZONE | 数据库的时区 | Asia/Shanghai |
+| STARHUB_SERVER_TIMEZONE | 应用全局时区（用于格式化 Loki 日志时间戳） | Asia/Shanghai |
 
 ## 初始化数据库迁移
 


### PR DESCRIPTION
Summary:
- Moved `TimeZone` from `Config.Database` to the top-level `Config` struct, as it is only used by the Loki client for log formatting, not by the database layer.
- Renamed the environment variable from `STARHUB_DATABASE_TIMEZONE` to `STARHUB_SERVER_TIMEZONE` and updated all related code, Docker Compose, and TOML configurations accordingly.
- Updated relevant documentation and migration guides to reflect the configuration relocation.