### PR TITLE
Use I18n message for serverless update

### DIFF
--- a/common/errorx/error_deploy.go
+++ b/common/errorx/error_deploy.go
@@ -4,6 +4,7 @@ const errDeployPrefix = "DEPLOY-ERR"
 
 const (
 	codeDeployNameAlreadyExistsErr = iota
+	codeDeployStopFirstErr
 )
 
 var (
@@ -17,4 +18,15 @@ var (
 	//
 	// zh-HK: 同類型下已存在同名部署
 	ErrDeployNameAlreadyExists error = CustomError{prefix: errDeployPrefix, code: codeDeployNameAlreadyExistsErr}
+
+	// Description: The deploy is still running, please stop it first before updating.
+	//
+	// Description_ZH: 部署实例仍在运行中，请先停止后再更新
+	//
+	// en-US: The deploy is still running, please stop it first before updating.
+	//
+	// zh-CN: 部署实例仍在运行中，请先停止后再更新
+	//
+	// zh-HK: 部署實例仍在運行中，請先停止後再更新
+	ErrDeployStopFirst error = CustomError{prefix: errDeployPrefix, code: codeDeployStopFirstErr}
 )

--- a/common/i18n/en-US/err_deploy.json
+++ b/common/i18n/en-US/err_deploy.json
@@ -1,5 +1,8 @@
 {
     "error.DEPLOY-ERR-0": {
         "other": "Deploy name already exists for this deploy type."
+    },
+    "error.DEPLOY-ERR-1": {
+        "other": "The deploy is still running, please stop it first before updating."
     }
 }

--- a/common/i18n/zh-CN/err_deploy.json
+++ b/common/i18n/zh-CN/err_deploy.json
@@ -1,5 +1,8 @@
 {
     "error.DEPLOY-ERR-0": {
         "other": "同类型下已存在同名部署"
+    },
+    "error.DEPLOY-ERR-1": {
+        "other": "部署实例仍在运行中，请先停止后再更新"
     }
 }

--- a/common/i18n/zh-HK/err_deploy.json
+++ b/common/i18n/zh-HK/err_deploy.json
@@ -1,5 +1,8 @@
 {
     "error.DEPLOY-ERR-0": {
         "other": "同類型下已存在同名部署"
+    },
+    "error.DEPLOY-ERR-1": {
+        "other": "部署實例仍在運行中，請先停止後再更新"
     }
 }

--- a/component/notebook.go
+++ b/component/notebook.go
@@ -292,8 +292,7 @@ func (c *notebookComponentImpl) UpdateNotebook(ctx context.Context, req *types.U
 		return fmt.Errorf("check deploy exists, err: %w", err)
 	}
 	if exist {
-		// deploy instance is running
-		return errors.New("stop deploy first")
+		return errorx.ErrDeployStopFirst
 	}
 
 	resource, err := c.spaceResourceStore.FindByID(ctx, req.ResourceID)

--- a/component/notebook_test.go
+++ b/component/notebook_test.go
@@ -9,6 +9,7 @@ import (
 	deployer "opencsg.com/csghub-server/builder/deploy"
 	"opencsg.com/csghub-server/builder/git/membership"
 	"opencsg.com/csghub-server/builder/store/database"
+	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 
 	corev1 "k8s.io/api/core/v1"
@@ -450,7 +451,7 @@ func TestNotebookComponentImpl_UpdateNotebook_DeployRunning(t *testing.T) {
 		ResourceID:  2,
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "stop deploy first")
+	require.ErrorIs(t, err, errorx.ErrDeployStopFirst)
 }
 
 func TestNotebookComponentImpl_UpdateNotebook_ResourceNotFound(t *testing.T) {

--- a/component/repo_ce_test.go
+++ b/component/repo_ce_test.go
@@ -110,7 +110,7 @@ func TestRepoComponent_DeployUpdate_RunningDeploy_StopFirst(t *testing.T) {
 		InstanceName: "i1",
 	}, req)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "stop deploy first")
+	require.ErrorIs(t, err, errorx.ErrDeployStopFirst)
 }
 
 func TestRepoComponent_DeployUpdate_StoppedDeploy(t *testing.T) {
@@ -404,7 +404,7 @@ func TestRepoComponent_DeployStart_ExistAndRunning(t *testing.T) {
 		InstanceName: "i1",
 	})
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "stop deploy first")
+	require.ErrorIs(t, err, errorx.ErrDeployStopFirst)
 }
 
 func TestRepoComponent_DeployStart_ExistButNotRunning(t *testing.T) {

--- a/component/repo_deploy.go
+++ b/component/repo_deploy.go
@@ -1038,8 +1038,7 @@ func (c *repoComponentImpl) DeployUpdate(ctx context.Context, updateReq types.De
 	exist := deploy.Status != deployStatus.Stopped && deploy.Status != deployStatus.Deleted
 
 	if needRestartDeploy(req) && exist {
-		// deploy instance is running
-		return errors.New("stop deploy first")
+		return errorx.ErrDeployStopFirst
 	}
 
 	if req.EngineArgs != nil {
@@ -1148,7 +1147,7 @@ func (c *repoComponentImpl) DeployStart(ctx context.Context, startReq types.Depl
 		// if deploy is in running status, return error
 		const deployStatusRunning = 4
 		if status == deployStatusRunning {
-			return errors.New("stop deploy first")
+			return errorx.ErrDeployStopFirst
 		}
 
 		// if deploy exists but not running, stop it first


### PR DESCRIPTION
Summary:
- Replaced hardcoded `errors.New("stop deploy first")` with a new `ErrDeployStopFirst` custom error (`DEPLOY-ERR-1`) in `DeployUpdate`, `DeployStart`, and `UpdateNotebook` methods.
- Added i18n translations for `DEPLOY-ERR-1` in en-US, zh-CN, and zh-HK to ensure the error message respects the `Accept-Language` header.