### PR TITLE
fix(aigateway): skip billing on error responses for chat/responses/embedding/rerank

### DIFF
--- a/aigateway/handler/openai.go
+++ b/aigateway/handler/openai.go
@@ -637,6 +637,7 @@ func (h *OpenAIHandlerImpl) Chat(c *gin.Context) {
 		TokenCounter:    chatCtx.tokenCounter,
 		LogCapture:      chatCtx.logCapture,
 		Trace:           newChatTracePostProcessInput(generationRecorder, chatReq, finalWriter),
+		StatusCode:      retryWriterStatusCode(finalWriter),
 	})
 }
 
@@ -648,6 +649,7 @@ type chatPostProcessInput struct {
 	TokenCounter    token.Counter
 	LogCapture      component.LLMLogRecorder
 	Trace           chatTracePostProcessInput
+	StatusCode      int
 }
 
 type chatContext struct {
@@ -802,7 +804,7 @@ func (h *OpenAIHandlerImpl) runChatPostProcessAsync(ctx context.Context, input c
 			slog.ErrorContext(usageCtx, "failed to commit usage limit", slog.Any("error", err))
 		}
 
-		if usage != nil {
+		if usage != nil && isSuccessfulStatus(input.StatusCode) {
 			if err := h.openaiComponent.RecordUsageFromTokenUsage(usageCtx, input.NSUUID, input.Model, input.TargetModelName, usage, input.ApiKey); err != nil {
 				slog.ErrorContext(usageCtx, "failed to record token usage", slog.Any("error", err))
 			}
@@ -1020,9 +1022,11 @@ func (h *OpenAIHandlerImpl) Embedding(c *gin.Context) {
 			embeddingRecorder.End()
 		}
 
-		err := h.openaiComponent.RecordUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, tokenCounter, apikey)
-		if err != nil {
-			slog.ErrorContext(c, "failed to record embedding token usage", "error", err)
+		if isSuccessfulStatus(w.StatusCode()) {
+			err := h.openaiComponent.RecordUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, tokenCounter, apikey)
+			if err != nil {
+				slog.ErrorContext(c, "failed to record embedding token usage", "error", err)
+			}
 		}
 	}()
 }

--- a/aigateway/handler/openai_audio.go
+++ b/aigateway/handler/openai_audio.go
@@ -206,7 +206,7 @@ func (h *OpenAIHandlerImpl) handleAudioSTT(c *gin.Context, kind string) {
 		defer cancel()
 
 		var usage *token.Usage
-		if w.StatusCode() < http.StatusBadRequest {
+		if isSuccessfulStatus(w.StatusCode()) {
 			var usageErr error
 			usage, usageErr = audioCounter.Usage(usageCtx)
 			if usageErr != nil {
@@ -229,7 +229,7 @@ func (h *OpenAIHandlerImpl) handleAudioSTT(c *gin.Context, kind string) {
 			generationRecorder.End()
 		}
 
-		if w.StatusCode() < http.StatusBadRequest && usage != nil {
+		if isSuccessfulStatus(w.StatusCode()) && usage != nil {
 			if err := h.openaiComponent.RecordUsageFromTokenUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, usage, apikey); err != nil {
 				slog.ErrorContext(usageCtx, fmt.Sprintf("failed to record audio %s usage", kind), slog.Any("error", err))
 			}

--- a/aigateway/handler/openai_image.go
+++ b/aigateway/handler/openai_image.go
@@ -196,7 +196,7 @@ func (h *OpenAIHandlerImpl) GenerateImage(c *gin.Context) {
 		defer cancel()
 
 		var usage *token.Usage
-		if imageWrapper.StatusCode() < http.StatusBadRequest && imageCounter != nil {
+		if isSuccessfulStatus(imageWrapper.StatusCode()) && imageCounter != nil {
 			var usageErr error
 			usage, usageErr = imageCounter.Usage(usageCtx)
 			if usageErr != nil {
@@ -218,7 +218,7 @@ func (h *OpenAIHandlerImpl) GenerateImage(c *gin.Context) {
 			})
 			generationRecorder.End()
 		}
-		if imageWrapper.StatusCode() < http.StatusBadRequest && usage != nil {
+		if isSuccessfulStatus(imageWrapper.StatusCode()) && usage != nil {
 			if err := h.openaiComponent.RecordUsageFromTokenUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, usage, apikey); err != nil {
 				slog.ErrorContext(usageCtx, "failed to record image usage", slog.Any("error", err))
 			}

--- a/aigateway/handler/openai_image_edit.go
+++ b/aigateway/handler/openai_image_edit.go
@@ -190,7 +190,7 @@ func (h *OpenAIHandlerImpl) EditImage(c *gin.Context) {
 		defer cancel()
 
 		var usage *token.Usage
-		if imageWrapper.StatusCode() < http.StatusBadRequest && imageCounter != nil {
+		if isSuccessfulStatus(imageWrapper.StatusCode()) && imageCounter != nil {
 			var usageErr error
 			usage, usageErr = imageCounter.Usage(usageCtx)
 			if usageErr != nil {
@@ -212,7 +212,7 @@ func (h *OpenAIHandlerImpl) EditImage(c *gin.Context) {
 			})
 			generationRecorder.End()
 		}
-		if imageWrapper.StatusCode() < http.StatusBadRequest && usage != nil {
+		if isSuccessfulStatus(imageWrapper.StatusCode()) && usage != nil {
 			if err := h.openaiComponent.RecordUsageFromTokenUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, usage, apikey); err != nil {
 				slog.ErrorContext(usageCtx, "failed to record image edit usage", slog.Any("error", err))
 			}

--- a/aigateway/handler/openai_ocr.go
+++ b/aigateway/handler/openai_ocr.go
@@ -208,7 +208,7 @@ func (h *OpenAIHandlerImpl) OCR(c *gin.Context) {
 		defer cancel()
 
 		var usage *token.Usage
-		if w.StatusCode() < http.StatusBadRequest {
+		if isSuccessfulStatus(w.StatusCode()) {
 			var usageErr error
 			usage, usageErr = ocrCounter.Usage(usageCtx)
 			if usageErr != nil {
@@ -232,7 +232,7 @@ func (h *OpenAIHandlerImpl) OCR(c *gin.Context) {
 			generationRecorder.End()
 		}
 
-		if w.StatusCode() < http.StatusBadRequest && usage != nil {
+		if isSuccessfulStatus(w.StatusCode()) && usage != nil {
 			if err := h.openaiComponent.RecordUsageFromTokenUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, usage, apikey); err != nil {
 				slog.ErrorContext(usageCtx, "failed to record ocr usage", slog.Any("error", err))
 			}

--- a/aigateway/handler/openai_responses_usage.go
+++ b/aigateway/handler/openai_responses_usage.go
@@ -92,7 +92,7 @@ func (h *OpenAIHandlerImpl) recordResponsesUsageWithTrace(c *gin.Context, counte
 			}
 			cancel()
 		}
-		if tokenUsage != nil {
+		if tokenUsage != nil && isSuccessfulStatus(traceInput.StatusCode) {
 			recordCtx, cancel := context.WithTimeout(baseCtx, time.Second)
 			if err := h.openaiComponent.RecordUsageFromTokenUsage(recordCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, tokenUsage, apikey); err != nil {
 				slog.ErrorContext(baseCtx, "failed to record responses usage",

--- a/aigateway/handler/openai_responses_usage_test.go
+++ b/aigateway/handler/openai_responses_usage_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 
@@ -126,7 +127,7 @@ func TestRecordResponsesUsageHappyPathCallsComponent(t *testing.T) {
 			return nil
 		}).Once()
 
-		tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "apikey", nil, responsesTracePostProcessInput{})
+		tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "apikey", nil, responsesTracePostProcessInput{StatusCode: http.StatusOK})
 
 		synctest.Wait()
 		require.NotNil(t, seenUsage)
@@ -192,7 +193,7 @@ func TestRecordResponsesUsagePublishesLLMLog(t *testing.T) {
 			wg.Done()
 		}
 
-		tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "apikey", recorder, responsesTracePostProcessInput{})
+		tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "apikey", recorder, responsesTracePostProcessInput{StatusCode: http.StatusOK})
 
 		synctest.Wait()
 		require.NotNil(t, publisher.payload)
@@ -271,6 +272,78 @@ func TestRecordResponsesUsageRecordsLLMTrace(t *testing.T) {
 		require.Contains(t, events, "response")
 		require.Contains(t, events, "end")
 		require.Contains(t, usageEvents, "usage")
+	})
+}
+
+func TestRecordResponsesUsageSkipsBillingOnErrorStatus(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		tester, c, _ := setupTest(t)
+		tester.mocks.openAIComp.ExpectedCalls = nil
+		c.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+
+		model := &types.Model{BaseModel: types.BaseModel{ID: "m"}}
+		modelTarget := &resolvedModelTarget{Model: model, ModelName: "upstream"}
+
+		counter := token.NewResponsesTokenCounter(&token.DumyTokenizer{})
+		counter.Request(&types.ResponsesRequest{Model: "m", Input: json.RawMessage(`"hi"`)})
+		counter.Response(&types.ResponsesResponse{OutputText: "world"})
+
+		var billingCalled atomic.Bool
+		tester.mocks.openAIComp.EXPECT().
+			CommitUsageLimit(mock.Anything, "testuuid", model, mock.Anything).
+			Return(nil).
+			Once()
+		tester.mocks.openAIComp.EXPECT().
+			RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, "upstream", mock.Anything, "apikey").
+			Run(func(context.Context, string, *types.Model, string, *token.Usage, string) {
+				billingCalled.Store(true)
+			}).
+			Maybe()
+
+		tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "apikey", nil, responsesTracePostProcessInput{
+			StatusCode: http.StatusInternalServerError,
+		})
+
+		// synctest.Wait blocks until the async post-processing goroutine has
+		// fully completed, so the billing flag is settled.
+		synctest.Wait()
+		require.False(t, billingCalled.Load())
+	})
+}
+
+func TestRecordResponsesUsageSkipsBillingOnRedirectStatus(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		tester, c, _ := setupTest(t)
+		tester.mocks.openAIComp.ExpectedCalls = nil
+		c.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+
+		model := &types.Model{BaseModel: types.BaseModel{ID: "m"}}
+		modelTarget := &resolvedModelTarget{Model: model, ModelName: "upstream"}
+
+		counter := token.NewResponsesTokenCounter(&token.DumyTokenizer{})
+		counter.Request(&types.ResponsesRequest{Model: "m", Input: json.RawMessage(`"hi"`)})
+		counter.Response(&types.ResponsesResponse{OutputText: "world"})
+
+		var billingCalled atomic.Bool
+		tester.mocks.openAIComp.EXPECT().
+			CommitUsageLimit(mock.Anything, "testuuid", model, mock.Anything).
+			Return(nil).
+			Once()
+		tester.mocks.openAIComp.EXPECT().
+			RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, "upstream", mock.Anything, "apikey").
+			Run(func(context.Context, string, *types.Model, string, *token.Usage, string) {
+				billingCalled.Store(true)
+			}).
+			Maybe()
+
+		tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "apikey", nil, responsesTracePostProcessInput{
+			StatusCode: http.StatusFound,
+		})
+
+		// synctest.Wait blocks until the async post-processing goroutine has
+		// fully completed, so the billing flag is settled.
+		synctest.Wait()
+		require.False(t, billingCalled.Load())
 	})
 }
 

--- a/aigateway/handler/openai_retry_test.go
+++ b/aigateway/handler/openai_retry_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -682,6 +683,7 @@ func TestRetryChatWithFallback_UsesFallbackModelName(t *testing.T) {
 		Model:           modelTarget.Model,
 		TargetModelName: modelTarget.ModelName,
 		TokenCounter:    tokenCounter,
+		StatusCode:      http.StatusOK,
 	})
 	wg.Wait()
 }
@@ -741,6 +743,7 @@ func TestRunChatPostProcessAsync_RecordsTraceUsageBeforeAccounting(t *testing.T)
 		Model:           model,
 		TargetModelName: "target-model",
 		TokenCounter:    tokenCounter,
+		StatusCode:      http.StatusOK,
 		Trace: chatTracePostProcessInput{
 			Recorder: recorder,
 		},
@@ -788,6 +791,7 @@ func TestRunChatPostProcessAsync_RecordsTraceCompletionBeforeUsage(t *testing.T)
 			Model:           model,
 			TargetModelName: "target-model",
 			TokenCounter:    tokenCounter,
+			StatusCode:      http.StatusOK,
 			Trace: chatTracePostProcessInput{
 				Recorder:     recorder,
 				Completion:   true,
@@ -814,6 +818,96 @@ func TestRunChatPostProcessAsync_RecordsTraceCompletionBeforeUsage(t *testing.T)
 		require.NotNil(t, firstChunk)
 		require.Equal(t, firstWriteAt, firstChunk.At)
 		require.Equal(t, types.TraceErrUpstreamError, errorCode)
+	})
+}
+
+func TestRunChatPostProcessAsync_SkipsBillingOnErrorStatus(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		tester, c, _ := setupTest(t)
+		tester.mocks.openAIComp.ExpectedCalls = nil
+		c.Request = httptest.NewRequest("POST", "/v1/chat/completions", nil)
+
+		model := &types.Model{BaseModel: types.BaseModel{ID: "model-1"}}
+		tokenCounter := mocktoken.NewMockCounter(t)
+		tokenCounter.EXPECT().
+			Usage(mock.Anything).
+			Return(&token.Usage{
+				PromptTokens:     5,
+				CompletionTokens: 8,
+				TotalTokens:      13,
+			}, nil).
+			Once()
+
+		var billingCalled atomic.Bool
+		tester.mocks.openAIComp.EXPECT().
+			CommitUsageLimit(mock.Anything, "user-1", model, tokenCounter).
+			Return(nil).
+			Once()
+		tester.mocks.openAIComp.EXPECT().
+			RecordUsageFromTokenUsage(mock.Anything, "user-1", model, "target-model", mock.Anything, "api-key").
+			Run(func(context.Context, string, *types.Model, string, *token.Usage, string) {
+				billingCalled.Store(true)
+			}).
+			Maybe()
+
+		tester.handler.runChatPostProcessAsync(c.Request.Context(), chatPostProcessInput{
+			NSUUID:          "user-1",
+			ApiKey:          "api-key",
+			Model:           model,
+			TargetModelName: "target-model",
+			TokenCounter:    tokenCounter,
+			StatusCode:      http.StatusBadGateway,
+		})
+
+		// synctest.Wait blocks until the async post-processing goroutine has
+		// fully completed, so the billing flag is settled.
+		synctest.Wait()
+		require.False(t, billingCalled.Load())
+	})
+}
+
+func TestRunChatPostProcessAsync_SkipsBillingOnRedirectStatus(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		tester, c, _ := setupTest(t)
+		tester.mocks.openAIComp.ExpectedCalls = nil
+		c.Request = httptest.NewRequest("POST", "/v1/chat/completions", nil)
+
+		model := &types.Model{BaseModel: types.BaseModel{ID: "model-1"}}
+		tokenCounter := mocktoken.NewMockCounter(t)
+		tokenCounter.EXPECT().
+			Usage(mock.Anything).
+			Return(&token.Usage{
+				PromptTokens:     5,
+				CompletionTokens: 8,
+				TotalTokens:      13,
+			}, nil).
+			Once()
+
+		var billingCalled atomic.Bool
+		tester.mocks.openAIComp.EXPECT().
+			CommitUsageLimit(mock.Anything, "user-1", model, tokenCounter).
+			Return(nil).
+			Once()
+		tester.mocks.openAIComp.EXPECT().
+			RecordUsageFromTokenUsage(mock.Anything, "user-1", model, "target-model", mock.Anything, "api-key").
+			Run(func(context.Context, string, *types.Model, string, *token.Usage, string) {
+				billingCalled.Store(true)
+			}).
+			Maybe()
+
+		tester.handler.runChatPostProcessAsync(c.Request.Context(), chatPostProcessInput{
+			NSUUID:          "user-1",
+			ApiKey:          "api-key",
+			Model:           model,
+			TargetModelName: "target-model",
+			TokenCounter:    tokenCounter,
+			StatusCode:      http.StatusFound,
+		})
+
+		// synctest.Wait blocks until the async post-processing goroutine has
+		// fully completed, so the billing flag is settled.
+		synctest.Wait()
+		require.False(t, billingCalled.Load())
 	})
 }
 

--- a/aigateway/handler/openai_speech.go
+++ b/aigateway/handler/openai_speech.go
@@ -176,7 +176,7 @@ func (h *OpenAIHandlerImpl) Speech(c *gin.Context) {
 		defer cancel()
 
 		var usage *token.Usage
-		if w.StatusCode() < http.StatusBadRequest {
+		if isSuccessfulStatus(w.StatusCode()) {
 			var usageErr error
 			usage, usageErr = speechCounter.Usage(usageCtx)
 			if usageErr != nil {
@@ -194,7 +194,7 @@ func (h *OpenAIHandlerImpl) Speech(c *gin.Context) {
 			generationRecorder.End()
 		}
 
-		if w.StatusCode() < http.StatusBadRequest && usage != nil {
+		if isSuccessfulStatus(w.StatusCode()) && usage != nil {
 			if err := h.openaiComponent.RecordUsageFromTokenUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, usage, apikey); err != nil {
 				slog.ErrorContext(usageCtx, "failed to record audio speech usage", slog.Any("error", err))
 			}
@@ -368,7 +368,7 @@ func (h *OpenAIHandlerImpl) SpeechBatch(c *gin.Context) {
 		defer cancel()
 
 		var usage *token.Usage
-		if w.StatusCode() < http.StatusBadRequest {
+		if isSuccessfulStatus(w.StatusCode()) {
 			var usageErr error
 			usage, usageErr = speechCounter.Usage(usageCtx)
 			if usageErr != nil {
@@ -386,7 +386,7 @@ func (h *OpenAIHandlerImpl) SpeechBatch(c *gin.Context) {
 			generationRecorder.End()
 		}
 
-		if w.StatusCode() < http.StatusBadRequest && usage != nil {
+		if isSuccessfulStatus(w.StatusCode()) && usage != nil {
 			if err := h.openaiComponent.RecordUsageFromTokenUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, usage, apikey); err != nil {
 				slog.ErrorContext(usageCtx, "failed to record audio speech batch usage", slog.Any("error", err))
 			}

--- a/aigateway/handler/openai_test.go
+++ b/aigateway/handler/openai_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -115,11 +116,20 @@ func setupTest(t *testing.T) (*testerOpenAIHandler, *gin.Context, *httptest.Resp
 	tester.mocks.whitelistRule = mockWhitelistRule
 	tester.mocks.aiGenerationStore = mockAIGenerationStore
 
-	tester.mocks.whitelistRule.EXPECT().ListBySensitiveCheckTargets(mock.Anything, mock.Anything, mock.Anything).Return([]database.RepositoryFileCheckRule{}, nil).Maybe()
-	tester.mocks.openAIComp.EXPECT().CheckUsageLimit(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-	tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-
 	return tester, c, w
+}
+
+func expectNoSensitiveCheckWhitelist(tester *testerOpenAIHandler) {
+	tester.mocks.whitelistRule.EXPECT().ListBySensitiveCheckTargets(mock.Anything, mock.Anything, mock.Anything).
+		Return([]database.RepositoryFileCheckRule{}, nil).Once()
+}
+
+func expectCheckUsageLimit(tester *testerOpenAIHandler, model *types.Model, endpoint string) {
+	tester.mocks.openAIComp.EXPECT().CheckUsageLimit(mock.Anything, "testuuid", model, endpoint).Return(nil).Once()
+}
+
+func expectCommitUsageLimit(tester *testerOpenAIHandler, model *types.Model, counter token.Counter) {
+	tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, "testuuid", model, counter).Return(nil).Once()
 }
 
 func expectBuildVideoMeteringEvent(t *testing.T, tester *testerOpenAIHandler) *commontypes.MeteringEvent {
@@ -675,6 +685,7 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 		}, nil)
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1:svc1").Return(model, nil)
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil)
+		expectNoSensitiveCheckWhitelist(tester)
 		expectReq := ChatCompletionRequest{}
 		_ = json.Unmarshal(body, &expectReq)
 		tester.mocks.moderationComp.EXPECT().CheckChatPrompts(mock.Anything, expectReq.Messages, "testuuid:"+model.ID, false).
@@ -724,6 +735,8 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 		}, nil)
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1:svc1").Return(model, nil)
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil)
+		expectNoSensitiveCheckWhitelist(tester)
+		expectCheckUsageLimit(tester, model, testServer.URL)
 		expectReq := ChatCompletionRequest{}
 		_ = json.Unmarshal(body, &expectReq)
 		tester.mocks.moderationComp.EXPECT().CheckChatPrompts(mock.Anything, expectReq.Messages, "testuuid:"+model.ID, false).
@@ -738,12 +751,14 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 				Provider: model.Provider,
 			}).
 			Return(llmTokenCounter)
+		expectCommitUsageLimit(tester, model, llmTokenCounter)
 		llmTokenCounter.EXPECT().AppendPrompts(expectReq.Messages).Return()
-		llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{}, nil).Maybe()
+		llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, nil).Once()
 		var wg sync.WaitGroup
 		wg.Add(1)
 		tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, mock.Anything, mock.Anything, "").
 			RunAndReturn(func(ctx context.Context, uuid string, model *types.Model, targetModelName string, usage *token.Usage, apikey string) error {
+				require.Equal(t, &token.Usage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, usage)
 				wg.Done()
 				return nil
 			})
@@ -798,7 +813,6 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 			}).
 			Return(llmTokenCounter)
 		llmTokenCounter.EXPECT().AppendPrompts(expectReq.Messages).Return()
-		llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{}, nil).Maybe()
 
 		tester.handler.Chat(c)
 
@@ -845,6 +859,8 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 		}, nil)
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1:svc1").Return(model, nil)
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil)
+		expectNoSensitiveCheckWhitelist(tester)
+		expectCheckUsageLimit(tester, model, testServer.URL)
 		expectReq := ChatCompletionRequest{}
 		_ = json.Unmarshal(body, &expectReq)
 		tester.mocks.moderationComp.EXPECT().CheckChatPrompts(mock.Anything, expectReq.Messages, "testuuid:"+model.ID, false).
@@ -859,8 +875,9 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 				Provider: model.Provider,
 			}).
 			Return(llmTokenCounter)
+		expectCommitUsageLimit(tester, model, llmTokenCounter)
 		llmTokenCounter.EXPECT().AppendPrompts(expectReq.Messages).Return()
-		llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{}, nil).Maybe()
+		llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, nil).Once()
 		var wg sync.WaitGroup
 		wg.Add(1)
 		tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, mock.Anything, mock.Anything, "").
@@ -912,6 +929,8 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 		}, nil)
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1:svc1").Return(model, nil)
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil)
+		expectNoSensitiveCheckWhitelist(tester)
+		expectCheckUsageLimit(tester, model, testServer.URL)
 		expectReq := ChatCompletionRequest{}
 		_ = json.Unmarshal(body, &expectReq)
 		tester.mocks.moderationComp.EXPECT().CheckChatPrompts(mock.Anything, expectReq.Messages, "testuuid:"+model.ID, false).
@@ -926,8 +945,9 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 				Provider: model.Provider,
 			}).
 			Return(llmTokenCounter)
+		expectCommitUsageLimit(tester, model, llmTokenCounter)
 		llmTokenCounter.EXPECT().AppendPrompts(expectReq.Messages).Return()
-		llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{}, nil).Maybe()
+		llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, nil).Once()
 		var wg sync.WaitGroup
 		wg.Add(1)
 		tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, mock.Anything, mock.Anything, "").
@@ -975,6 +995,8 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "external-model-id").Return(model, nil)
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil)
+		expectNoSensitiveCheckWhitelist(tester)
+		expectCheckUsageLimit(tester, model, testServer.URL)
 		expectReq := ChatCompletionRequest{}
 		_ = json.Unmarshal(body, &expectReq)
 		tester.mocks.moderationComp.EXPECT().CheckChatPrompts(mock.Anything, expectReq.Messages, "testuuid:"+model.ID, false).
@@ -988,8 +1010,9 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 				ImageID:  model.ImageID,
 			}).
 			Return(llmTokenCounter)
+		expectCommitUsageLimit(tester, model, llmTokenCounter)
 		llmTokenCounter.EXPECT().AppendPrompts(expectReq.Messages).Return()
-		llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{}, nil).Maybe()
+		llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, nil).Once()
 
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -1046,6 +1069,8 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "test-model-1(OpenAI)").Return(model, nil)
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil)
+		expectNoSensitiveCheckWhitelist(tester)
+		expectCheckUsageLimit(tester, model, testServer.URL)
 		expectReq := ChatCompletionRequest{}
 		_ = json.Unmarshal(body, &expectReq)
 		tester.mocks.moderationComp.EXPECT().CheckChatPrompts(mock.Anything, expectReq.Messages, "testuuid:"+model.ID, false).
@@ -1059,8 +1084,9 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 				ImageID:  model.ImageID,
 			}).
 			Return(llmTokenCounter)
+		expectCommitUsageLimit(tester, model, llmTokenCounter)
 		llmTokenCounter.EXPECT().AppendPrompts(expectReq.Messages).Return()
-		llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{}, nil).Maybe()
+		llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, nil).Once()
 
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -1076,87 +1102,93 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 		assert.Equal(t, "test-model-1", forwardedModel)
 	})
 	t.Run("report primary upstream http status failure for downstream processing", func(t *testing.T) {
-		tester, c, w := setupTest(t)
-		tester.mocks.openAIComp.ExpectedCalls = nil
-		reporter := &testChatAttemptFailureReporterWithMutex{doneCh: make(chan struct{}, 10)}
-		tester.handler.SetChatAttemptFailureReporter(reporter)
+		synctest.Test(t, func(t *testing.T) {
+			tester, c, w := setupTest(t)
+			tester.mocks.openAIComp.ExpectedCalls = nil
+			reporter := &testChatAttemptFailureReporterWithMutex{doneCh: make(chan struct{}, 10)}
+			tester.handler.SetChatAttemptFailureReporter(reporter)
 
-		chatReq := ChatCompletionRequest{
-			Model: "external-model-id",
-			Messages: []openai.ChatCompletionMessageParamUnion{
-				openai.UserMessage("Hello"),
-			},
-		}
-		body, _ := json.Marshal(chatReq)
-		c.Request.Method = http.MethodPost
-		c.Request.Body = io.NopCloser(bytes.NewReader(body))
+			chatReq := ChatCompletionRequest{
+				Model: "external-model-id",
+				Messages: []openai.ChatCompletionMessageParamUnion{
+					openai.UserMessage("Hello"),
+				},
+			}
+			body, _ := json.Marshal(chatReq)
+			c.Request.Method = http.MethodPost
+			c.Request.Body = io.NopCloser(bytes.NewReader(body))
 
-		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-			_, err := w.Write([]byte(`{"error":"not found"}`))
-			require.NoError(t, err)
-		}))
-		defer testServer.Close()
+			testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, err := w.Write([]byte(`{"error":"not found"}`))
+				require.NoError(t, err)
+			}))
 
-		model := &types.Model{
-			BaseModel: types.BaseModel{
-				ID:      "external-model-id",
-				Object:  "model",
-				OwnedBy: "testuser",
-			},
-			ExternalModelInfo: types.ExternalModelInfo{
-				NeedSensitiveCheck: true,
-			},
-			Endpoint: testServer.URL,
-			Upstreams: []commontypes.UpstreamConfig{
-				{URL: testServer.URL, Enabled: true, ModelName: "external-model-id"},
-			},
-		}
-		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "external-model-id").Return(model, nil).Once()
-		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().CheckUsageLimit(mock.Anything, "testuuid", model, testServer.URL).Return(nil).Once()
-		expectReq := ChatCompletionRequest{}
-		_ = json.Unmarshal(body, &expectReq)
-		tester.mocks.moderationComp.EXPECT().CheckChatPrompts(mock.Anything, expectReq.Messages, "testuuid:"+model.ID, false).
-			Return(&rpc.CheckResult{IsSensitive: false}, nil)
-		llmTokenCounter := mocktoken.NewMockChatTokenCounter(t)
-		tester.mocks.tokenCounterFactory.EXPECT().NewChat(
-			token.CreateParam{
-				Endpoint: model.Endpoint,
-				Host:     "",
-				Model:    model.ID,
-				ImageID:  model.ImageID,
-				Provider: model.Provider,
-			},
-		).Return(llmTokenCounter)
-		llmTokenCounter.EXPECT().AppendPrompts(expectReq.Messages).Return()
-		llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{}, nil).Maybe()
-		llmTokenCounter.EXPECT().Completion(mock.Anything).Return().Maybe()
-		var wg sync.WaitGroup
-		wg.Add(2)
-		tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, "testuuid", model, llmTokenCounter).
-			RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, counter token.Counter) error {
-				wg.Done()
-				return nil
-			})
-		tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, mock.Anything, mock.Anything, mock.Anything).
-			RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, targetModelName string, usage *token.Usage, apikey string) error {
-				wg.Done()
-				return nil
-			})
+			model := &types.Model{
+				BaseModel: types.BaseModel{
+					ID:      "external-model-id",
+					Object:  "model",
+					OwnedBy: "testuser",
+				},
+				ExternalModelInfo: types.ExternalModelInfo{
+					NeedSensitiveCheck: true,
+				},
+				Endpoint: testServer.URL,
+				Upstreams: []commontypes.UpstreamConfig{
+					{URL: testServer.URL, Enabled: true, ModelName: "external-model-id"},
+				},
+			}
+			tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "external-model-id").Return(model, nil).Once()
+			tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+			tester.mocks.openAIComp.EXPECT().CheckUsageLimit(mock.Anything, "testuuid", model, testServer.URL).Return(nil).Once()
+			expectNoSensitiveCheckWhitelist(tester)
+			expectReq := ChatCompletionRequest{}
+			_ = json.Unmarshal(body, &expectReq)
+			tester.mocks.moderationComp.EXPECT().CheckChatPrompts(mock.Anything, expectReq.Messages, "testuuid:"+model.ID, false).
+				Return(&rpc.CheckResult{IsSensitive: false}, nil)
+			llmTokenCounter := mocktoken.NewMockChatTokenCounter(t)
+			tester.mocks.tokenCounterFactory.EXPECT().NewChat(
+				token.CreateParam{
+					Endpoint: model.Endpoint,
+					Host:     "",
+					Model:    model.ID,
+					ImageID:  model.ImageID,
+					Provider: model.Provider,
+				},
+			).Return(llmTokenCounter)
+			llmTokenCounter.EXPECT().AppendPrompts(expectReq.Messages).Return()
+			llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, nil).Once()
+			llmTokenCounter.EXPECT().Completion(mock.Anything).Return().Once()
+			tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, "testuuid", model, llmTokenCounter).
+				Return(nil).
+				Once()
 
-		tester.handler.Chat(c)
-		wg.Wait()
+			tester.handler.Chat(c)
 
-		assert.Equal(t, http.StatusNotFound, w.Code)
-		reporter.Wait()
-		events := reporter.Events()
-		require.Len(t, events, 1)
-		assert.Equal(t, chatAttemptPhasePrimary, events[0].Phase)
-		assert.Equal(t, "external-model-id", events[0].ModelID)
-		assert.Equal(t, testServer.URL, events[0].Target)
-		assert.Equal(t, http.StatusNotFound, events[0].StatusCode)
-		assert.True(t, events[0].Retryable)
+			// The proxy has already consumed the 404 by now, so shut the test
+			// server down before synctest.Wait: a live listener's accept-loop
+			// goroutine is blocked on a network syscall, which synctest does not
+			// count as idle and would otherwise keep Wait spinning until timeout.
+			testServer.Close()
+
+			// synctest.Wait blocks until the async post-process goroutine has
+			// fully completed (usage capture, CommitUsageLimit, billing gate), so
+			// the billing assertion below is settled.
+			synctest.Wait()
+
+			// upstream returned 404, so billing must be skipped
+			tester.mocks.openAIComp.AssertNotCalled(t, "RecordUsageFromTokenUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+
+			assert.Equal(t, http.StatusNotFound, w.Code)
+			reporter.Wait()
+			events := reporter.Events()
+			require.Len(t, events, 1)
+			assert.Equal(t, chatAttemptPhasePrimary, events[0].Phase)
+			assert.Equal(t, "external-model-id", events[0].ModelID)
+			assert.Equal(t, testServer.URL, events[0].Target)
+			assert.Equal(t, http.StatusNotFound, events[0].StatusCode)
+			assert.True(t, events[0].Retryable)
+		})
 	})
 }
 
@@ -1297,6 +1329,13 @@ func TestOpenAIHandler_Embedding(t *testing.T) {
 
 	t.Run("model without svc name", func(t *testing.T) {
 		tester, c, _ := setupTest(t)
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{"object":"list","data":[],"model":"model1","usage":{"prompt_tokens":2,"total_tokens":2}}`))
+			require.NoError(t, err)
+		}))
+		defer upstream.Close()
+
 		embeddingReq := EmbeddingRequest{
 			EmbeddingNewParams: openai.EmbeddingNewParams{
 				Model: "model1",
@@ -1318,9 +1357,9 @@ func TestOpenAIHandler_Embedding(t *testing.T) {
 			InternalModelInfo: types.InternalModelInfo{
 				SvcName: "",
 			},
-			Endpoint: "https://api.example.com/embeddings",
+			Endpoint: upstream.URL,
 			Upstreams: []commontypes.UpstreamConfig{
-				{URL: "https://api.example.com/embeddings", Enabled: true, ModelName: "model1"},
+				{URL: upstream.URL, Enabled: true, ModelName: "model1"},
 			},
 		}
 		var wg sync.WaitGroup
@@ -1505,7 +1544,6 @@ func TestOpenAIHandler_EmbeddingTrace(t *testing.T) {
 		}).Return(counter).Once()
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "embedding-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, "testuuid", model, "resolved-embedding", counter, "").Return(nil).Once()
 
 		req := EmbeddingRequest{EmbeddingNewParams: openai.EmbeddingNewParams{
 			Model: "embedding-model",
@@ -1523,12 +1561,74 @@ func TestOpenAIHandler_EmbeddingTrace(t *testing.T) {
 			_, _, ended, _ := recorder.snapshot()
 			return ended
 		}, time.Second, 10*time.Millisecond)
+		tester.mocks.openAIComp.AssertNotCalled(t, "RecordUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 		result, errorCode, ended, events := recorder.snapshot()
 		require.True(t, ended)
 		require.NotNil(t, result)
 		require.Equal(t, int64(3), result.InputTokens)
 		require.Equal(t, types.TraceErrUpstreamError, errorCode)
 		require.Equal(t, []string{"error", "result", "end"}, events)
+	})
+
+	t.Run("upstream redirect status skips billing", func(t *testing.T) {
+		tester, c, _ := setupTest(t)
+		tester.mocks.openAIComp.ExpectedCalls = nil
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusFound)
+			_, err := w.Write([]byte(`{"object":"list","data":[],"model":"resolved-embedding","usage":{"prompt_tokens":3,"total_tokens":3}}`))
+			require.NoError(t, err)
+		}))
+		defer upstream.Close()
+
+		recorder := &testEmbeddingRecorderWithMutex{}
+		tester.handler.llmTracer = &testLLMTracerWithMutex{embeddingRecorder: recorder}
+
+		model := &types.Model{
+			BaseModel: types.BaseModel{ID: "embedding-model", Object: "model", OwnedBy: "testuser"},
+			ExternalModelInfo: types.ExternalModelInfo{
+				Provider: "openai",
+			},
+			Upstreams: []commontypes.UpstreamConfig{
+				{URL: upstream.URL, Enabled: true, ModelName: "resolved-embedding", Provider: "openai"},
+			},
+		}
+		counter := mocktoken.NewMockEmbeddingTokenCounter(t)
+		counter.EXPECT().Embedding(mock.MatchedBy(func(usage openai.CreateEmbeddingResponseUsage) bool {
+			return usage.PromptTokens == 3 && usage.TotalTokens == 3
+		})).Return().Once()
+		counter.EXPECT().Usage(mock.Anything).Return(&token.Usage{PromptTokens: 3, TotalTokens: 3}, nil).Once()
+		tester.mocks.tokenCounterFactory.EXPECT().NewEmbedding(token.CreateParam{
+			Endpoint: upstream.URL,
+			Model:    "resolved-embedding",
+			Provider: "openai",
+		}).Return(counter).Once()
+		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "embedding-model").Return(model, nil).Once()
+		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+
+		req := EmbeddingRequest{EmbeddingNewParams: openai.EmbeddingNewParams{
+			Model: "embedding-model",
+			Input: openai.EmbeddingNewParamsInputUnion{OfArrayOfStrings: []string{"test input"}},
+		}}
+		body, err := json.Marshal(req)
+		require.NoError(t, err)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/embeddings", bytes.NewReader(body))
+		httpbase.SetCurrentUser(c, "testuser")
+		httpbase.SetCurrentNamespaceUUID(c, "testuuid")
+
+		tester.handler.Embedding(c)
+
+		require.Eventually(t, func() bool {
+			_, _, ended, _ := recorder.snapshot()
+			return ended
+		}, time.Second, 10*time.Millisecond)
+		tester.mocks.openAIComp.AssertNotCalled(t, "RecordUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		result, errorCode, ended, events := recorder.snapshot()
+		require.True(t, ended)
+		require.NotNil(t, result)
+		require.Equal(t, int64(3), result.InputTokens)
+		require.Empty(t, errorCode)
+		require.Equal(t, []string{"result", "end"}, events)
 	})
 }
 
@@ -2367,7 +2467,6 @@ func TestOpenAIHandler_CreateVideo(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "image-video-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tester.mocks.moderationComp.EXPECT().CheckImagePrompts(mock.Anything, "animate this image", "testuuid").Return(&rpc.CheckResult{IsSensitive: false}, nil).Once()
 		expectBuildVideoMeteringEvent(t, tester)
 		tester.mocks.aiGenerationStore.EXPECT().Create(mock.Anything, mock.Anything).
@@ -2406,7 +2505,6 @@ func TestOpenAIHandler_CreateVideo(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "video-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tester.mocks.moderationComp.EXPECT().CheckImagePrompts(mock.Anything, "animate this asset", "testuuid").Return(&rpc.CheckResult{IsSensitive: false}, nil).Once()
 		expectBuildVideoMeteringEvent(t, tester)
 		tester.mocks.aiGenerationStore.EXPECT().Create(mock.Anything, mock.Anything).
@@ -2459,7 +2557,6 @@ func TestOpenAIHandler_CreateVideo(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "video-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tester.mocks.moderationComp.EXPECT().CheckImagePrompts(mock.Anything, "make a boat", "testuuid").Return(&rpc.CheckResult{IsSensitive: false}, nil).Once()
 		expectBuildVideoMeteringEvent(t, tester)
 		tester.mocks.aiGenerationStore.EXPECT().Create(mock.Anything, mock.MatchedBy(func(generation database.AIGeneration) bool {
@@ -2510,7 +2607,6 @@ func TestOpenAIHandler_CreateVideo(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "video-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tester.mocks.moderationComp.EXPECT().CheckImagePrompts(mock.Anything, "make a boat", "testuuid").Return(&rpc.CheckResult{IsSensitive: false}, nil).Once()
 		expectBuildVideoMeteringEvent(t, tester)
 		tester.mocks.aiGenerationStore.EXPECT().Create(mock.Anything, mock.MatchedBy(func(generation database.AIGeneration) bool {
@@ -2553,7 +2649,6 @@ func TestOpenAIHandler_CreateVideo(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "video-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tester.mocks.moderationComp.EXPECT().CheckImagePrompts(mock.Anything, "make a boat", "testuuid").Return(&rpc.CheckResult{IsSensitive: false}, nil).Once()
 
 		body := `{"model":"video-model","prompt":"make a boat","size":"1024x1792"}`
@@ -2595,7 +2690,6 @@ func TestOpenAIHandler_CreateVideo(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "video-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tester.mocks.moderationComp.EXPECT().CheckImagePrompts(mock.Anything, "make a boat", "testuuid").Return(&rpc.CheckResult{IsSensitive: false}, nil).Once()
 
 		body := `{"model":"video-model","prompt":"make a boat","size":"1280x720"}`
@@ -2633,7 +2727,6 @@ func TestOpenAIHandler_CreateVideo(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "video-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tester.mocks.moderationComp.EXPECT().CheckImagePrompts(mock.Anything, "make a boat", "testuuid").Return(&rpc.CheckResult{IsSensitive: false}, nil).Once()
 
 		body := `{"model":"video-model","prompt":"make a boat"}`
@@ -2664,7 +2757,6 @@ func TestOpenAIHandler_CreateVideo(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "video-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tester.mocks.moderationComp.EXPECT().CheckImagePrompts(mock.Anything, "make a boat", "testuuid").Return(&rpc.CheckResult{IsSensitive: false}, nil).Once()
 
 		body := `{"model":"video-model","prompt":"make a boat","size":"1024x1792"}`
@@ -2711,7 +2803,6 @@ func TestOpenAIHandler_CreateVideo(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "video-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tester.mocks.moderationComp.EXPECT().CheckImagePrompts(mock.Anything, "make a boat", "testuuid").Return(&rpc.CheckResult{IsSensitive: false}, nil).Once()
 		expectBuildVideoMeteringEvent(t, tester)
 		tester.mocks.aiGenerationStore.EXPECT().Create(mock.Anything, mock.MatchedBy(func(generation database.AIGeneration) bool {
@@ -2786,7 +2877,6 @@ func TestOpenAIHandler_CreateVideo(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "video-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tester.mocks.moderationComp.EXPECT().CheckImagePrompts(mock.Anything, "make a boat", "testuuid").Return(&rpc.CheckResult{IsSensitive: false}, nil).Once()
 		expectBuildVideoMeteringEvent(t, tester)
 		tester.mocks.aiGenerationStore.EXPECT().Create(mock.Anything, mock.MatchedBy(func(generation database.AIGeneration) bool {
@@ -2841,7 +2931,6 @@ func TestOpenAIHandler_CreateVideo(t *testing.T) {
 		}
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "longcat-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 		tester.mocks.moderationComp.EXPECT().CheckImagePrompts(mock.Anything, "two presenters talking", "testuuid").Return(&rpc.CheckResult{IsSensitive: false}, nil).Once()
 		expectBuildVideoMeteringEvent(t, tester)
 		tester.mocks.aiGenerationStore.EXPECT().Create(mock.Anything, mock.MatchedBy(func(generation database.AIGeneration) bool {

--- a/aigateway/handler/openai_video.go
+++ b/aigateway/handler/openai_video.go
@@ -123,7 +123,7 @@ func (h *OpenAIHandlerImpl) CreateVideo(c *gin.Context) {
 	}
 	body := capture.Body()
 	var videoResp *types.VideoObject
-	if capture.StatusCode() < http.StatusBadRequest {
+	if isSuccessfulStatus(capture.StatusCode()) {
 		var videoProviderResp *text2video.ProviderResponse
 		videoProviderResp, ok = parseCreateVideoProviderResponse(c, ctx, adapter, body, generationRecorder)
 		if !ok {

--- a/aigateway/handler/rerank.go
+++ b/aigateway/handler/rerank.go
@@ -109,9 +109,11 @@ func (h *OpenAIHandlerImpl) Rerank(c *gin.Context) {
 
 		w.CaptureRerankUsage()
 
-		err := h.openaiComponent.RecordUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, tokenCounter, apikey)
-		if err != nil {
-			slog.ErrorContext(c, "failed to record rerank token usage", "error", err)
+		if isSuccessfulStatus(w.StatusCode()) {
+			err := h.openaiComponent.RecordUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, tokenCounter, apikey)
+			if err != nil {
+				slog.ErrorContext(c, "failed to record rerank token usage", "error", err)
+			}
 		}
 	}()
 }

--- a/aigateway/handler/rerank_test.go
+++ b/aigateway/handler/rerank_test.go
@@ -9,7 +9,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/assert"
@@ -169,6 +171,118 @@ func TestOpenAIHandler_Rerank(t *testing.T) {
 
 		tester.handler.Rerank(c)
 		wg.Wait()
+	})
+
+	t.Run("upstream error status skips billing", func(t *testing.T) {
+		tester, c, _ := setupTest(t)
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, err := w.Write([]byte(`{"id":"rerank-1","model":"resolved-rerank","usage":{"total_tokens":9},"results":[]}`))
+			require.NoError(t, err)
+		}))
+		defer upstream.Close()
+
+		model := &types.Model{
+			BaseModel: types.BaseModel{ID: "rerank-model", Object: "model", OwnedBy: "testuser"},
+			Upstreams: []commontypes.UpstreamConfig{
+				{
+					URL:       upstream.URL,
+					Enabled:   true,
+					ModelName: "resolved-rerank",
+				},
+			},
+		}
+
+		counter := mocktoken.NewMockEmbeddingTokenCounter(t)
+		counter.EXPECT().Input("what is a panda?\npandas are bears\nparis is a city").Return().Once()
+		counter.EXPECT().Embedding(mock.MatchedBy(func(usage openai.CreateEmbeddingResponseUsage) bool {
+			return usage.PromptTokens == 9 && usage.TotalTokens == 9
+		})).Return().Once()
+		tester.mocks.tokenCounterFactory.EXPECT().NewEmbedding(token.CreateParam{
+			Endpoint: upstream.URL,
+			Model:    "resolved-rerank",
+		}).Return(counter).Once()
+		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "rerank-model").Return(model, nil).Once()
+		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+		var billingCalled atomic.Bool
+		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, "testuuid", model, "resolved-rerank", counter, "").
+			Run(func(context.Context, string, *types.Model, string, token.Counter, string) {
+				billingCalled.Store(true)
+			}).Maybe()
+
+		body, _ := json.Marshal(RerankRequest{
+			Model:     "rerank-model",
+			Query:     "what is a panda?",
+			Documents: []string{"pandas are bears", "paris is a city"},
+		})
+		c.Request.Method = http.MethodPost
+		c.Request.Body = io.NopCloser(bytes.NewReader(body))
+
+		tester.handler.Rerank(c)
+
+		// the async goroutine finishes well within this window; if billing were
+		// published on error status it would flip the flag and fail the test
+		require.Never(t, func() bool {
+			return billingCalled.Load()
+		}, 100*time.Millisecond, 10*time.Millisecond)
+		require.False(t, billingCalled.Load())
+	})
+
+	t.Run("upstream redirect status skips billing", func(t *testing.T) {
+		tester, c, _ := setupTest(t)
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusFound)
+			_, err := w.Write([]byte(`{"id":"rerank-1","model":"resolved-rerank","usage":{"total_tokens":9},"results":[]}`))
+			require.NoError(t, err)
+		}))
+		defer upstream.Close()
+
+		model := &types.Model{
+			BaseModel: types.BaseModel{ID: "rerank-model", Object: "model", OwnedBy: "testuser"},
+			Upstreams: []commontypes.UpstreamConfig{
+				{
+					URL:       upstream.URL,
+					Enabled:   true,
+					ModelName: "resolved-rerank",
+				},
+			},
+		}
+
+		counter := mocktoken.NewMockEmbeddingTokenCounter(t)
+		counter.EXPECT().Input("what is a panda?\npandas are bears\nparis is a city").Return().Once()
+		counter.EXPECT().Embedding(mock.MatchedBy(func(usage openai.CreateEmbeddingResponseUsage) bool {
+			return usage.PromptTokens == 9 && usage.TotalTokens == 9
+		})).Return().Once()
+		tester.mocks.tokenCounterFactory.EXPECT().NewEmbedding(token.CreateParam{
+			Endpoint: upstream.URL,
+			Model:    "resolved-rerank",
+		}).Return(counter).Once()
+		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "rerank-model").Return(model, nil).Once()
+		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+		var billingCalled atomic.Bool
+		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, "testuuid", model, "resolved-rerank", counter, "").
+			Run(func(context.Context, string, *types.Model, string, token.Counter, string) {
+				billingCalled.Store(true)
+			}).Maybe()
+
+		body, _ := json.Marshal(RerankRequest{
+			Model:     "rerank-model",
+			Query:     "what is a panda?",
+			Documents: []string{"pandas are bears", "paris is a city"},
+		})
+		c.Request.Method = http.MethodPost
+		c.Request.Body = io.NopCloser(bytes.NewReader(body))
+
+		tester.handler.Rerank(c)
+
+		// the async goroutine finishes well within this window; if billing were
+		// published on redirect status it would flip the flag and fail the test
+		require.Never(t, func() bool {
+			return billingCalled.Load()
+		}, 100*time.Millisecond, 10*time.Millisecond)
+		require.False(t, billingCalled.Load())
 	})
 }
 

--- a/aigateway/handler/responses_adapter_test.go
+++ b/aigateway/handler/responses_adapter_test.go
@@ -1440,7 +1440,7 @@ func TestRecordResponsesUsageFallsBackToTokenCounter(t *testing.T) {
 		}).
 		Once()
 
-	tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "api-key", nil, responsesTracePostProcessInput{})
+	tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "api-key", nil, responsesTracePostProcessInput{StatusCode: http.StatusOK})
 	wg.Wait()
 }
 
@@ -1476,7 +1476,7 @@ func TestRecordResponsesUsagePrefersResponsesUsage(t *testing.T) {
 		}).
 		Once()
 
-	tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "api-key", nil, responsesTracePostProcessInput{})
+	tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "api-key", nil, responsesTracePostProcessInput{StatusCode: http.StatusOK})
 	wg.Wait()
 }
 

--- a/aigateway/handler/stream_upstream_passthrough.go
+++ b/aigateway/handler/stream_upstream_passthrough.go
@@ -6,6 +6,10 @@ func isUpstreamHTTPError(statusCode int) bool {
 	return statusCode >= http.StatusBadRequest
 }
 
+func isSuccessfulStatus(statusCode int) bool {
+	return statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices
+}
+
 func shouldPassthroughUpstreamError(statusCode int, sseStarted bool) bool {
 	return isUpstreamHTTPError(statusCode) && !sseStarted
 }


### PR DESCRIPTION
Summary:
- Skips billing (`RecordUsage`) for Chat, Responses, Embedding, and Rerank endpoints when upstream returns error status codes, aligning them with existing multimodal endpoint behavior.
- Restricts billing to successful responses (status >= 200 and < 300) to prevent charging for failed requests, while keeping trace and usage limit tracking unaffected.