### PR TITLE
Support multiple status query

### DIFF
--- a/api/handler/user.go
+++ b/api/handler/user.go
@@ -818,11 +818,15 @@ func (h *UserHandler) GetRunServerless(ctx *gin.Context) {
 
 	statusQuery := ctx.Query("status")
 	if len(statusQuery) > 0 {
-		code, err := strconv.Atoi(strings.TrimSpace(statusQuery))
-		if err == nil {
-			req.Status = append(req.Status, code)
-		} else {
-			httpbase.BadRequestWithExt(ctx, err)
+		statusCodes := strings.Split(strings.TrimSpace(statusQuery), ",")
+		for _, status := range statusCodes {
+			code, err := strconv.Atoi(status)
+			if err == nil {
+				req.Status = append(req.Status, code)
+			} else {
+				httpbase.BadRequestWithExt(ctx, errorx.ReqParamInvalid(err, errorx.Ctx().Set("invalid", "status")))
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
Summary:
- Updated the `status` query parameter in `GetRunServerless` to accept comma-separated values (e.g., `?status=2,3`) to allow filtering by multiple deployment statuses
- Changed error handling for invalid values to return an explicit parameter validation error instead of silently ignoring them