### PR TITLE
feat(aigateway/metrics): extend metrics reporting to all protocol endpoints

### DIFF
--- a/_mocks/opencsg.com/csghub-server/aigateway/component/mock_OpenAIComponent.go
+++ b/_mocks/opencsg.com/csghub-server/aigateway/component/mock_OpenAIComponent.go
@@ -8,9 +8,7 @@ import (
 	context "context"
 
 	mock "github.com/stretchr/testify/mock"
-
 	token "opencsg.com/csghub-server/aigateway/token"
-
 	types "opencsg.com/csghub-server/aigateway/types"
 )
 
@@ -290,6 +288,55 @@ func (_c *MockOpenAIComponent_CommitUsageLimit_Call) Return(_a0 error) *MockOpen
 }
 
 func (_c *MockOpenAIComponent_CommitUsageLimit_Call) RunAndReturn(run func(context.Context, string, *types.Model, token.Counter) error) *MockOpenAIComponent_CommitUsageLimit_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CommitUsageLimitFromUsage provides a mock function with given fields: ctx, userUUID, model, usage
+func (_m *MockOpenAIComponent) CommitUsageLimitFromUsage(ctx context.Context, userUUID string, model *types.Model, usage *token.Usage) error {
+	ret := _m.Called(ctx, userUUID, model, usage)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CommitUsageLimitFromUsage")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *types.Model, *token.Usage) error); ok {
+		r0 = rf(ctx, userUUID, model, usage)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockOpenAIComponent_CommitUsageLimitFromUsage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CommitUsageLimitFromUsage'
+type MockOpenAIComponent_CommitUsageLimitFromUsage_Call struct {
+	*mock.Call
+}
+
+// CommitUsageLimitFromUsage is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userUUID string
+//   - model *types.Model
+//   - usage *token.Usage
+func (_e *MockOpenAIComponent_Expecter) CommitUsageLimitFromUsage(ctx interface{}, userUUID interface{}, model interface{}, usage interface{}) *MockOpenAIComponent_CommitUsageLimitFromUsage_Call {
+	return &MockOpenAIComponent_CommitUsageLimitFromUsage_Call{Call: _e.mock.On("CommitUsageLimitFromUsage", ctx, userUUID, model, usage)}
+}
+
+func (_c *MockOpenAIComponent_CommitUsageLimitFromUsage_Call) Run(run func(ctx context.Context, userUUID string, model *types.Model, usage *token.Usage)) *MockOpenAIComponent_CommitUsageLimitFromUsage_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(*types.Model), args[3].(*token.Usage))
+	})
+	return _c
+}
+
+func (_c *MockOpenAIComponent_CommitUsageLimitFromUsage_Call) Return(_a0 error) *MockOpenAIComponent_CommitUsageLimitFromUsage_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockOpenAIComponent_CommitUsageLimitFromUsage_Call) RunAndReturn(run func(context.Context, string, *types.Model, *token.Usage) error) *MockOpenAIComponent_CommitUsageLimitFromUsage_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/aigateway/component/openai.go
+++ b/aigateway/component/openai.go
@@ -40,6 +40,7 @@ type OpenAIComponent interface {
 	CheckBalance(ctx context.Context, nsUUID string) error
 	CheckUsageLimit(ctx context.Context, userUUID string, model *types.Model, endpoint string) error
 	CommitUsageLimit(ctx context.Context, userUUID string, model *types.Model, tokenCounter token.Counter) error
+	CommitUsageLimitFromUsage(ctx context.Context, userUUID string, model *types.Model, usage *token.Usage) error
 	// CanManageModel reports whether the user can manage the given model
 	// (e.g. upload or delete voices of a TTS deployment): only the deploy
 	// owner and platform admins are allowed.

--- a/aigateway/component/usage_limiter.go
+++ b/aigateway/component/usage_limiter.go
@@ -161,6 +161,16 @@ func (m *openaiComponentImpl) CommitUsageLimit(ctx context.Context, userUUID str
 	if err != nil {
 		return err
 	}
+	return m.CommitUsageLimitFromUsage(ctx, userUUID, model, usage)
+}
+
+// CommitUsageLimitFromUsage commits a pre-computed usage snapshot to the
+// usage-limiter quota window.  This avoids a redundant counter.Usage() call
+// when the caller has already computed usage on the sync metrics path.
+func (m *openaiComponentImpl) CommitUsageLimitFromUsage(ctx context.Context, userUUID string, model *types.Model, usage *token.Usage) error {
+	if usage == nil {
+		return nil
+	}
 	return m.getUsageLimiter().Commit(ctx, userUUID, model, model.Endpoint, usage)
 }
 

--- a/aigateway/handler/metrics_helpers_ce.go
+++ b/aigateway/handler/metrics_helpers_ce.go
@@ -27,12 +27,13 @@ type RecordMetricsParams struct {
 	FinalWrite     MetricsRecorderWriter
 	Counter        token.Counter
 	ProxyStartTime time.Time
+	Usage          *token.Usage
 }
 
 // Stubs for ce build — metrics helpers are no-ops when the metrics feature is
 // not compiled in.
 
-func SetMetricsModelTarget(c *gin.Context, modelName, provider string, upstreamID int64, isStream bool) {
+func SetMetricsModelTarget(p SetMetricsModelParams) {
 }
 
 func SetMetricsTTFT(c *gin.Context, ttftMs int64) {

--- a/aigateway/handler/model_target.go
+++ b/aigateway/handler/model_target.go
@@ -15,6 +15,17 @@ import (
 	"opencsg.com/csghub-server/common/utils/common"
 )
 
+// SetMetricsModelParams bundles inputs for SetMetricsModelTarget so the
+// signature stays stable as fields are added.  ModelTarget is nil when
+// model resolution fails; in that case ModelID is used as a fallback so
+// the error can still be attributed to the requested model.
+type SetMetricsModelParams struct {
+	C           *gin.Context
+	ModelID     string
+	ModelTarget *resolvedModelTarget
+	IsStream    bool
+}
+
 type resolvedModelTarget struct {
 	Model           *types.Model
 	Upstream        commonType.UpstreamConfig

--- a/aigateway/handler/openai.go
+++ b/aigateway/handler/openai.go
@@ -509,20 +509,24 @@ func (h *OpenAIHandlerImpl) Chat(c *gin.Context) {
 	modelID := chatReq.Model
 
 	modelTarget, err := h.resolveModelTarget(ctx, username, modelID, c.Request.Header)
+	// Metrics key point 1: enrich business data on the RequestMetrics object.
+	// A single call covers both paths — when err != nil, modelTarget is nil
+	// and only the requested modelID is recorded so the error is still
+	// attributed to the right model.
+	SetMetricsModelTarget(SetMetricsModelParams{
+		C:           c,
+		ModelID:     modelID,
+		ModelTarget: modelTarget,
+		IsStream:    chatReq.Stream,
+	})
 	if err != nil {
 		preflight.RecordError(err, "model_resolve")
-		// Record the requested model name even when resolution fails so
-		// the metrics middleware can attribute the error to the right model.
-		SetMetricsModelTarget(c, modelID, "", 0, chatReq.Stream)
 		handleModelTargetError(c, ctx, modelID, "failed to get model target address", err)
 		return
 	}
 	applyChatCompletionsEndpointCompatibility(ctx, modelTarget)
 	preflight.SetTargetModel(modelID, modelTarget)
 	chatReq.Model = modelTarget.ModelName
-
-	// Metrics key point 1: enrich business data on the RequestMetrics object.
-	SetMetricsModelTarget(c, modelTarget.ModelName, modelTarget.Upstream.Provider, modelTarget.Upstream.ID, chatReq.Stream)
 
 	if chatReq.Stream {
 		c.Writer.Header().Set("Content-Type", "text/event-stream")
@@ -621,12 +625,18 @@ func (h *OpenAIHandlerImpl) Chat(c *gin.Context) {
 	// Metrics middleware Finalize()es RequestMetrics as soon as the handler
 	// returns, so this MUST stay on the hot path — never move it to the
 	// async post-process goroutine or the write will race Finalize().
+	//
+	// Pre-compute usage once here and share the *Usage pointer with both
+	// RecordMetrics (sync) and runChatPostProcessAsync (async) to avoid
+	// calling counter.Usage() three times (metrics, trace, CommitUsageLimit).
+	chatUsage := preComputeUsage(ctx, chatCtx.tokenCounter)
 	RecordMetrics(RecordMetricsParams{
 		C:              c,
 		Ctx:            ctx,
 		FinalWrite:     finalWriter,
 		Counter:        chatCtx.tokenCounter,
 		ProxyStartTime: proxyStartTime,
+		Usage:          chatUsage,
 	})
 
 	h.runChatPostProcessAsync(ctx, chatPostProcessInput{
@@ -635,6 +645,7 @@ func (h *OpenAIHandlerImpl) Chat(c *gin.Context) {
 		Model:           modelTarget.Model,
 		TargetModelName: modelTarget.ModelName,
 		TokenCounter:    chatCtx.tokenCounter,
+		Usage:           chatUsage,
 		LogCapture:      chatCtx.logCapture,
 		Trace:           newChatTracePostProcessInput(generationRecorder, chatReq, finalWriter),
 		StatusCode:      retryWriterStatusCode(finalWriter),
@@ -647,6 +658,7 @@ type chatPostProcessInput struct {
 	Model           *types.Model
 	TargetModelName string
 	TokenCounter    token.Counter
+	Usage           *token.Usage
 	LogCapture      component.LLMLogRecorder
 	Trace           chatTracePostProcessInput
 	StatusCode      int
@@ -761,6 +773,24 @@ func (h *OpenAIHandlerImpl) executeChatWithFallback(
 	return retryWriter, nil
 }
 
+// preComputeUsage synchronously calls counter.Usage() with a short timeout
+// so the resulting *Usage pointer can be shared between the sync metrics path
+// and the async post-process goroutine, avoiding duplicate computation.
+// Returns nil if the counter is nil or the call fails/times out.
+func preComputeUsage(ctx context.Context, counter token.Counter) *token.Usage {
+	if counter == nil {
+		return nil
+	}
+	usageCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
+	defer cancel()
+	usage, err := counter.Usage(usageCtx)
+	if err != nil {
+		slog.DebugContext(usageCtx, "pre-compute token usage failed", slog.Any("error", err))
+		return nil
+	}
+	return usage
+}
+
 func (h *OpenAIHandlerImpl) runChatPostProcessAsync(ctx context.Context, input chatPostProcessInput) {
 	go func() {
 		defer func() {
@@ -775,8 +805,11 @@ func (h *OpenAIHandlerImpl) runChatPostProcessAsync(ctx context.Context, input c
 		usageCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 3*time.Second)
 		defer cancel()
 
-		var usage *token.Usage
-		if input.TokenCounter != nil {
+		// Use the pre-computed usage from the sync path when available;
+		// fall back to a fresh counter.Usage() call only when the sync
+		// pre-compute failed (nil).
+		usage := input.Usage
+		if usage == nil && input.TokenCounter != nil {
 			var usageErr error
 			usage, usageErr = input.TokenCounter.Usage(usageCtx)
 			if usageErr != nil {
@@ -800,7 +833,7 @@ func (h *OpenAIHandlerImpl) runChatPostProcessAsync(ctx context.Context, input c
 			input.Trace.Recorder.End()
 		}
 
-		if err := h.openaiComponent.CommitUsageLimit(usageCtx, input.NSUUID, input.Model, input.TokenCounter); err != nil {
+		if err := h.openaiComponent.CommitUsageLimitFromUsage(usageCtx, input.NSUUID, input.Model, usage); err != nil {
 			slog.ErrorContext(usageCtx, "failed to commit usage limit", slog.Any("error", err))
 		}
 
@@ -947,9 +980,14 @@ func (h *OpenAIHandlerImpl) Embedding(c *gin.Context) {
 	}
 	modelID := req.Model
 	modelTarget, err := h.resolveModelTarget(ctx, username, modelID, c.Request.Header)
+	SetMetricsModelTarget(SetMetricsModelParams{
+		C:           c,
+		ModelID:     modelID,
+		ModelTarget: modelTarget,
+		IsStream:    false,
+	})
 	if err != nil {
 		preflight.RecordError(err, "model_resolve")
-		SetMetricsModelTarget(c, modelID, "", 0, false)
 		handleModelTargetError(c, ctx, modelID, "failed to get embedding target address", err)
 		return
 	}
@@ -1002,28 +1040,45 @@ func (h *OpenAIHandlerImpl) Embedding(c *gin.Context) {
 		tokenCounter.Input(req.Input.OfString.Value)
 	}
 
+	proxyStartTime := time.Now()
 	rp.ServeHTTP(w, c.Request, proxyToAPI, modelTarget.Host)
+
+	// Synchronously record proxy-level metrics before c.Next() returns.
+	// Capture usage first so the counter has token counts available for
+	// RecordMetrics to pre-fetch synchronously.  FinalWrite is nil because
+	// embedding is non-streaming — TTFT is not applicable.
+	w.CaptureEmbeddingUsage()
+	embeddingUsage := preComputeUsage(ctx, tokenCounter)
+	RecordMetrics(RecordMetricsParams{
+		C:              c,
+		Ctx:            ctx,
+		FinalWrite:     nil,
+		Counter:        tokenCounter,
+		ProxyStartTime: proxyStartTime,
+		Usage:          embeddingUsage,
+	})
+
 	go func() {
 		usageCtx, cancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 3*time.Second)
 		defer cancel()
 
-		w.CaptureEmbeddingUsage()
-
-		if embeddingRecorder != nil {
-			var usage *token.Usage
-			if tokenCounter != nil {
-				var usageErr error
-				usage, usageErr = tokenCounter.Usage(usageCtx)
-				if usageErr != nil {
-					slog.ErrorContext(usageCtx, "failed to get embedding token usage", slog.Any("error", usageErr))
-				}
+		// Use the pre-computed usage from the sync path; fall back to a
+		// fresh counter.Usage() call only when sync pre-compute failed.
+		usage := embeddingUsage
+		if usage == nil && tokenCounter != nil {
+			var usageErr error
+			usage, usageErr = tokenCounter.Usage(usageCtx)
+			if usageErr != nil {
+				slog.ErrorContext(usageCtx, "failed to get embedding token usage", slog.Any("error", usageErr))
 			}
+		}
+		if embeddingRecorder != nil {
 			recordEmbeddingTraceCompletion(embeddingRecorder, &req, modelTarget.ModelName, usage, w.StatusCode())
 			embeddingRecorder.End()
 		}
 
-		if isSuccessfulStatus(w.StatusCode()) {
-			err := h.openaiComponent.RecordUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, tokenCounter, apikey)
+		if usage != nil && isSuccessfulStatus(w.StatusCode()) {
+			err := h.openaiComponent.RecordUsageFromTokenUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, usage, apikey)
 			if err != nil {
 				slog.ErrorContext(c, "failed to record embedding token usage", "error", err)
 			}

--- a/aigateway/handler/openai_audio.go
+++ b/aigateway/handler/openai_audio.go
@@ -121,6 +121,12 @@ func (h *OpenAIHandlerImpl) handleAudioSTT(c *gin.Context, kind string) {
 	isStream := strings.EqualFold(firstMultipartValue(form, "stream"), "true")
 
 	modelTarget, err := h.resolveModelTarget(ctx, username, modelID, c.Request.Header)
+	SetMetricsModelTarget(SetMetricsModelParams{
+		C:           c,
+		ModelID:     modelID,
+		ModelTarget: modelTarget,
+		IsStream:    isStream,
+	})
 	if err != nil {
 		preflight.RecordError(err, "model_resolve")
 		handleModelTargetError(c, ctx, modelID, fmt.Sprintf("failed to get %s target address", kind), err)

--- a/aigateway/handler/openai_image.go
+++ b/aigateway/handler/openai_image.go
@@ -64,6 +64,12 @@ func (h *OpenAIHandlerImpl) GenerateImage(c *gin.Context) {
 
 	modelID := req.Model
 	modelTarget, err := h.resolveModelTarget(ctx, username, modelID, c.Request.Header)
+	SetMetricsModelTarget(SetMetricsModelParams{
+		C:           c,
+		ModelID:     modelID,
+		ModelTarget: modelTarget,
+		IsStream:    false,
+	})
 	if err != nil {
 		preflight.RecordError(err, "model_resolve")
 		handleModelTargetError(c, ctx, modelID, "failed to get model target address", err)

--- a/aigateway/handler/openai_image_edit.go
+++ b/aigateway/handler/openai_image_edit.go
@@ -78,6 +78,12 @@ func (h *OpenAIHandlerImpl) EditImage(c *gin.Context) {
 	}
 
 	modelTarget, err := h.resolveModelTarget(ctx, username, modelID, c.Request.Header)
+	SetMetricsModelTarget(SetMetricsModelParams{
+		C:           c,
+		ModelID:     modelID,
+		ModelTarget: modelTarget,
+		IsStream:    false,
+	})
 	if err != nil {
 		preflight.RecordError(err, "model_resolve")
 		handleModelTargetError(c, ctx, modelID, "failed to get model target address", err)

--- a/aigateway/handler/openai_ocr.go
+++ b/aigateway/handler/openai_ocr.go
@@ -79,6 +79,12 @@ func (h *OpenAIHandlerImpl) OCR(c *gin.Context) {
 	modelID := ocrReq.Model
 
 	modelTarget, err := h.resolveModelTarget(ctx, username, modelID, c.Request.Header)
+	SetMetricsModelTarget(SetMetricsModelParams{
+		C:           c,
+		ModelID:     modelID,
+		ModelTarget: modelTarget,
+		IsStream:    false,
+	})
 	if err != nil {
 		preflight.RecordError(err, "model_resolve")
 		handleModelTargetError(c, ctx, modelID, "failed to get ocr target address", err)

--- a/aigateway/handler/openai_responses.go
+++ b/aigateway/handler/openai_responses.go
@@ -59,6 +59,15 @@ func (h *OpenAIHandlerImpl) Responses(c *gin.Context) {
 	}
 
 	modelTarget, ok := h.resolveResponsesModelTarget(c, username, publicModelID, previousResponse.RequiredUpstreamID)
+	// Metrics key point 1: enrich business data on the RequestMetrics object.
+	// When resolution fails (ok == false), modelTarget is nil and only the
+	// requested modelID is recorded.
+	SetMetricsModelTarget(SetMetricsModelParams{
+		C:           c,
+		ModelID:     publicModelID,
+		ModelTarget: modelTarget,
+		IsStream:    req.Stream,
+	})
 	if !ok {
 		return
 	}

--- a/aigateway/handler/openai_responses_adapter.go
+++ b/aigateway/handler/openai_responses_adapter.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/aigateway/component"
@@ -44,6 +45,7 @@ func (h *OpenAIHandlerImpl) executeAdapterResponses(c *gin.Context, req *types.R
 		return
 	}
 	setResponsesAdapterToolNamespaces(writer, toolNamespaces)
+	proxyStartTime := time.Now()
 	primaryWriter, proxyErr := h.executeChatProxyAttempt(c, writer, modelTarget, nsUUID, chatReq)
 	if proxyErr != nil {
 		finishLLMTraceWithError(generationRecorder, proxyErr, types.TraceErrUpstreamUnavailable)
@@ -61,8 +63,22 @@ func (h *OpenAIHandlerImpl) executeAdapterResponses(c *gin.Context, req *types.R
 		writeResponsesError(c, http.StatusBadGateway, "upstream_response_invalid", "api_error", err.Error())
 		return
 	}
+
+	// Synchronously record proxy-level metrics before c.Next() returns.
+	// Pre-compute usage once and share with the async post-process goroutine
+	// to avoid duplicate counter.Usage() calls.
+	responsesUsage := preComputeUsage(c.Request.Context(), responsesCounter)
+	RecordMetrics(RecordMetricsParams{
+		C:              c,
+		Ctx:            c.Request.Context(),
+		FinalWrite:     finalWriter,
+		Counter:        responsesCounter,
+		ProxyStartTime: proxyStartTime,
+		Usage:          responsesUsage,
+	})
+
 	traceInput := newResponsesTracePostProcessInput(generationRecorder, req, retryWriterStatusCode(finalWriter), finalWriter.FirstWriteAt())
-	h.recordResponsesUsageWithTrace(c, responsesCounter, nsUUID, modelTarget, apikey, logCapture, traceInput)
+	h.recordResponsesUsageWithTrace(c, responsesCounter, responsesUsage, nsUUID, modelTarget, apikey, logCapture, traceInput)
 }
 
 func decodeResponsesAdapterChatBody(bufferWriter *bufferCommonResponseWriter) ([]byte, error) {

--- a/aigateway/handler/openai_responses_adapter_test.go
+++ b/aigateway/handler/openai_responses_adapter_test.go
@@ -38,7 +38,7 @@ func TestExecuteAdapterResponsesSetsStreamHeader(t *testing.T) {
 	tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "adapter-model").Return(model, nil).Maybe()
 	tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Maybe()
 	tester.mocks.openAIComp.EXPECT().CheckUsageLimit(mock.Anything, "testuuid", model, mock.Anything).Return(nil).Maybe()
-	tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, mock.Anything, model, mock.Anything).Return(nil).Maybe()
+	tester.mocks.openAIComp.EXPECT().CommitUsageLimitFromUsage(mock.Anything, mock.Anything, model, mock.Anything).Return(nil).Maybe()
 	tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, mock.Anything, model, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	req := &types.ResponsesRequest{Model: "adapter-model", Input: json.RawMessage(`"hi"`), Stream: true}
@@ -73,7 +73,7 @@ func TestExecuteAdapterResponsesStreamPassthroughUpstreamJSONError(t *testing.T)
 		}},
 	}
 	tester.mocks.openAIComp.EXPECT().CheckUsageLimit(mock.Anything, "testuuid", model, mock.Anything).Return(nil).Once()
-	tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, mock.Anything, model, mock.Anything).Return(nil).Maybe()
+	tester.mocks.openAIComp.EXPECT().CommitUsageLimitFromUsage(mock.Anything, mock.Anything, model, mock.Anything).Return(nil).Maybe()
 	tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, mock.Anything, model, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	req := &types.ResponsesRequest{Model: "adapter-model", Input: json.RawMessage(`"hi"`), Stream: true}

--- a/aigateway/handler/openai_responses_native.go
+++ b/aigateway/handler/openai_responses_native.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"opencsg.com/csghub-server/aigateway/component"
@@ -69,12 +70,27 @@ func (h *OpenAIHandlerImpl) executeNativeResponses(c *gin.Context, req *types.Re
 	)
 	proxyPath := resolveProxyPathFromModelEndpoint(backendURL, modelTarget.ModelName)
 	writer := newResponsesNativeResponseWriter(c.Writer, req.Stream, transformer, moderation, newResponsesModerationSessionID())
+	proxyStartTime := time.Now()
 	rp.ServeHTTP(writer, c.Request, proxyPath, modelTarget.Host)
 	if err := writer.Finalize(); err != nil {
 		finishLLMTraceWithError(generationRecorder, err, types.TraceErrUpstreamError)
 		writeResponsesError(c, http.StatusBadGateway, "upstream_response_invalid", "api_error", err.Error())
 		return
 	}
+
+	// Finalize transforms non-streaming responses and captures their usage, so
+	// collect metrics only after it completes while still on the request path.
+	// Pre-compute usage once and share with the async post-process goroutine
+	// to avoid duplicate counter.Usage() calls.
+	responsesUsage := preComputeUsage(c.Request.Context(), responsesCounter)
+	RecordMetrics(RecordMetricsParams{
+		C:              c,
+		Ctx:            c.Request.Context(),
+		FinalWrite:     writer,
+		Counter:        responsesCounter,
+		ProxyStartTime: proxyStartTime,
+		Usage:          responsesUsage,
+	})
 	traceInput := newResponsesTracePostProcessInput(generationRecorder, req, writer.StatusCode(), writer.FirstWriteAt())
-	h.recordResponsesUsageWithTrace(c, responsesCounter, nsUUID, modelTarget, apikey, logCapture, traceInput)
+	h.recordResponsesUsageWithTrace(c, responsesCounter, responsesUsage, nsUUID, modelTarget, apikey, logCapture, traceInput)
 }

--- a/aigateway/handler/openai_responses_test.go
+++ b/aigateway/handler/openai_responses_test.go
@@ -58,7 +58,7 @@ func TestResponsesCSGHubHostedVLLMUsesNativeResponsesBackendURL(t *testing.T) {
 	}, nil).Once()
 	tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
 	tester.mocks.openAIComp.EXPECT().CheckUsageLimit(mock.Anything, "testuuid", mock.Anything, upstream.URL+"/v1/responses").Return(nil).Once()
-	tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	tester.mocks.openAIComp.EXPECT().CommitUsageLimitFromUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	tester.handler.Responses(c)
@@ -258,7 +258,7 @@ func TestResponsesPreRequestSensitivePromptCleanAllowsExecution(t *testing.T) {
 	}).
 		Return(&rpc.CheckResult{IsSensitive: false}, nil).Once()
 	tester.mocks.openAIComp.EXPECT().CheckUsageLimit(mock.Anything, "testuuid", model, mock.Anything).Return(nil).Maybe()
-	tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, mock.Anything, model, mock.Anything).Return(nil).Maybe()
+	tester.mocks.openAIComp.EXPECT().CommitUsageLimitFromUsage(mock.Anything, mock.Anything, model, mock.Anything).Return(nil).Maybe()
 	tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, mock.Anything, model, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	tester.handler.Responses(c)
@@ -297,7 +297,7 @@ func TestResponsesWhitelistSkipsOutputModeration(t *testing.T) {
 		[]database.RepositoryFileCheckRule{{RuleType: database.RuleTypeNamespace, Pattern: "sensitive-model"}}, nil,
 	).Once()
 	tester.mocks.openAIComp.EXPECT().CheckUsageLimit(mock.Anything, "testuuid", model, mock.Anything).Return(nil).Maybe()
-	tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, mock.Anything, model, mock.Anything).Return(nil).Maybe()
+	tester.mocks.openAIComp.EXPECT().CommitUsageLimitFromUsage(mock.Anything, mock.Anything, model, mock.Anything).Return(nil).Maybe()
 	tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, mock.Anything, model, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	tester.handler.Responses(c)

--- a/aigateway/handler/openai_responses_usage.go
+++ b/aigateway/handler/openai_responses_usage.go
@@ -32,7 +32,7 @@ func (h *OpenAIHandlerImpl) newResponsesTokenCounter(modelTarget *resolvedModelT
 	return token.NewResponsesTokenCounter(tokenizer)
 }
 
-func (h *OpenAIHandlerImpl) recordResponsesUsageWithTrace(c *gin.Context, counter token.ResponsesTokenCounter, nsUUID string, modelTarget *resolvedModelTarget, apikey string, recorder *responsespkg.LLMLogRecorder, traceInput responsesTracePostProcessInput) {
+func (h *OpenAIHandlerImpl) recordResponsesUsageWithTrace(c *gin.Context, counter token.ResponsesTokenCounter, preUsage *token.Usage, nsUUID string, modelTarget *resolvedModelTarget, apikey string, recorder *responsespkg.LLMLogRecorder, traceInput responsesTracePostProcessInput) {
 	if modelTarget == nil || modelTarget.Model == nil {
 		return
 	}
@@ -46,8 +46,11 @@ func (h *OpenAIHandlerImpl) recordResponsesUsageWithTrace(c *gin.Context, counte
 				}
 			}
 		}()
-		var tokenUsage *token.Usage
-		if counter != nil {
+		// Use the pre-computed usage from the sync path when available;
+		// fall back to a fresh counter.Usage() call only when the sync
+		// pre-compute failed (nil).
+		tokenUsage := preUsage
+		if tokenUsage == nil && counter != nil {
 			var err error
 			usageCtx, cancel := context.WithTimeout(baseCtx, 2*time.Second)
 			tokenUsage, err = counter.Usage(usageCtx)
@@ -59,17 +62,17 @@ func (h *OpenAIHandlerImpl) recordResponsesUsageWithTrace(c *gin.Context, counte
 					slog.String("provider", modelTarget.Model.Provider),
 					slog.Any("error", err))
 			}
-			if tokenUsage != nil && tokenUsage.Source != "" {
-				slog.WarnContext(baseCtx, "responses usage fallback",
-					slog.String("step", "token_usage"),
-					slog.String("usage_source", tokenUsage.Source),
-					slog.String("usage_reason", tokenUsage.SourceReason),
-					slog.String("model", modelTarget.ModelName),
-					slog.String("provider", modelTarget.Model.Provider),
-					slog.Int64("prompt_tokens", tokenUsage.PromptTokens),
-					slog.Int64("completion_tokens", tokenUsage.CompletionTokens),
-					slog.Int64("total_tokens", tokenUsage.TotalTokens))
-			}
+		}
+		if tokenUsage != nil && tokenUsage.Source != "" {
+			slog.WarnContext(baseCtx, "responses usage fallback",
+				slog.String("step", "token_usage"),
+				slog.String("usage_source", tokenUsage.Source),
+				slog.String("usage_reason", tokenUsage.SourceReason),
+				slog.String("model", modelTarget.ModelName),
+				slog.String("provider", modelTarget.Model.Provider),
+				slog.Int64("prompt_tokens", tokenUsage.PromptTokens),
+				slog.Int64("completion_tokens", tokenUsage.CompletionTokens),
+				slog.Int64("total_tokens", tokenUsage.TotalTokens))
 		}
 		if traceInput.Recorder != nil {
 			var inputMsgs, outputMsgs []types.GenerationMessage
@@ -81,9 +84,9 @@ func (h *OpenAIHandlerImpl) recordResponsesUsageWithTrace(c *gin.Context, counte
 			recordResponsesTraceCompletion(traceInput, modelTarget.Model.Provider, modelTarget.ModelName, tokenUsage, inputMsgs, outputMsgs, recorderTraceInfo(recorder))
 			traceInput.Recorder.End()
 		}
-		if counter != nil {
+		if tokenUsage != nil {
 			commitCtx, cancel := context.WithTimeout(baseCtx, time.Second)
-			if err := h.openaiComponent.CommitUsageLimit(commitCtx, nsUUID, modelTarget.Model, counter); err != nil {
+			if err := h.openaiComponent.CommitUsageLimitFromUsage(commitCtx, nsUUID, modelTarget.Model, tokenUsage); err != nil {
 				slog.ErrorContext(baseCtx, "failed to commit responses usage limit",
 					slog.String("step", "commit_usage_limit"),
 					slog.String("model", modelTarget.ModelName),

--- a/aigateway/handler/openai_responses_usage_test.go
+++ b/aigateway/handler/openai_responses_usage_test.go
@@ -114,8 +114,8 @@ func TestRecordResponsesUsageHappyPathCallsComponent(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(2)
 		var seenUsage *token.Usage
-		tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, "testuuid", model, mock.Anything).
-			RunAndReturn(func(_ context.Context, _ string, _ *types.Model, _ token.Counter) error {
+		tester.mocks.openAIComp.EXPECT().CommitUsageLimitFromUsage(mock.Anything, "testuuid", model, mock.Anything).
+			RunAndReturn(func(_ context.Context, _ string, _ *types.Model, _ *token.Usage) error {
 				wg.Done()
 				return nil
 			}).Once()
@@ -127,7 +127,7 @@ func TestRecordResponsesUsageHappyPathCallsComponent(t *testing.T) {
 			return nil
 		}).Once()
 
-		tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "apikey", nil, responsesTracePostProcessInput{StatusCode: http.StatusOK})
+		tester.handler.recordResponsesUsageWithTrace(c, counter, nil, "testuuid", modelTarget, "apikey", nil, responsesTracePostProcessInput{StatusCode: http.StatusOK})
 
 		synctest.Wait()
 		require.NotNil(t, seenUsage)
@@ -178,8 +178,8 @@ func TestRecordResponsesUsagePublishesLLMLog(t *testing.T) {
 
 		var wg sync.WaitGroup
 		wg.Add(3)
-		tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, "testuuid", model, mock.Anything).
-			RunAndReturn(func(_ context.Context, _ string, _ *types.Model, _ token.Counter) error {
+		tester.mocks.openAIComp.EXPECT().CommitUsageLimitFromUsage(mock.Anything, "testuuid", model, mock.Anything).
+			RunAndReturn(func(_ context.Context, _ string, _ *types.Model, _ *token.Usage) error {
 				wg.Done()
 				return nil
 			}).Once()
@@ -193,7 +193,7 @@ func TestRecordResponsesUsagePublishesLLMLog(t *testing.T) {
 			wg.Done()
 		}
 
-		tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "apikey", recorder, responsesTracePostProcessInput{StatusCode: http.StatusOK})
+		tester.handler.recordResponsesUsageWithTrace(c, counter, nil, "testuuid", modelTarget, "apikey", recorder, responsesTracePostProcessInput{StatusCode: http.StatusOK})
 
 		synctest.Wait()
 		require.NotNil(t, publisher.payload)
@@ -241,8 +241,8 @@ func TestRecordResponsesUsageRecordsLLMTrace(t *testing.T) {
 
 		var wg sync.WaitGroup
 		wg.Add(2)
-		tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, "testuuid", model, mock.Anything).
-			RunAndReturn(func(_ context.Context, _ string, _ *types.Model, _ token.Counter) error {
+		tester.mocks.openAIComp.EXPECT().CommitUsageLimitFromUsage(mock.Anything, "testuuid", model, mock.Anything).
+			RunAndReturn(func(_ context.Context, _ string, _ *types.Model, _ *token.Usage) error {
 				wg.Done()
 				return nil
 			}).Once()
@@ -253,7 +253,7 @@ func TestRecordResponsesUsageRecordsLLMTrace(t *testing.T) {
 			return nil
 		}).Once()
 
-		tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "apikey", recorder, traceInput)
+		tester.handler.recordResponsesUsageWithTrace(c, counter, nil, "testuuid", modelTarget, "apikey", recorder, traceInput)
 
 		synctest.Wait()
 		usage, usageEnded, usageEvents := traceRecorder.snapshot()
@@ -290,7 +290,7 @@ func TestRecordResponsesUsageSkipsBillingOnErrorStatus(t *testing.T) {
 
 		var billingCalled atomic.Bool
 		tester.mocks.openAIComp.EXPECT().
-			CommitUsageLimit(mock.Anything, "testuuid", model, mock.Anything).
+			CommitUsageLimitFromUsage(mock.Anything, "testuuid", model, mock.Anything).
 			Return(nil).
 			Once()
 		tester.mocks.openAIComp.EXPECT().
@@ -300,7 +300,7 @@ func TestRecordResponsesUsageSkipsBillingOnErrorStatus(t *testing.T) {
 			}).
 			Maybe()
 
-		tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "apikey", nil, responsesTracePostProcessInput{
+		tester.handler.recordResponsesUsageWithTrace(c, counter, nil, "testuuid", modelTarget, "apikey", nil, responsesTracePostProcessInput{
 			StatusCode: http.StatusInternalServerError,
 		})
 
@@ -326,7 +326,7 @@ func TestRecordResponsesUsageSkipsBillingOnRedirectStatus(t *testing.T) {
 
 		var billingCalled atomic.Bool
 		tester.mocks.openAIComp.EXPECT().
-			CommitUsageLimit(mock.Anything, "testuuid", model, mock.Anything).
+			CommitUsageLimitFromUsage(mock.Anything, "testuuid", model, mock.Anything).
 			Return(nil).
 			Once()
 		tester.mocks.openAIComp.EXPECT().
@@ -336,7 +336,7 @@ func TestRecordResponsesUsageSkipsBillingOnRedirectStatus(t *testing.T) {
 			}).
 			Maybe()
 
-		tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "apikey", nil, responsesTracePostProcessInput{
+		tester.handler.recordResponsesUsageWithTrace(c, counter, nil, "testuuid", modelTarget, "apikey", nil, responsesTracePostProcessInput{
 			StatusCode: http.StatusFound,
 		})
 

--- a/aigateway/handler/openai_retry_test.go
+++ b/aigateway/handler/openai_retry_test.go
@@ -663,8 +663,8 @@ func TestRetryChatWithFallback_UsesFallbackModelName(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	tester.mocks.openAIComp.EXPECT().
-		CommitUsageLimit(mock.Anything, "user-1", modelTarget.Model, tokenCounter).
-		RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, counter token.Counter) error {
+		CommitUsageLimitFromUsage(mock.Anything, "user-1", modelTarget.Model, mock.Anything).
+		RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, usage *token.Usage) error {
 			wg.Done()
 			return nil
 		}).
@@ -715,16 +715,16 @@ func TestRunChatPostProcessAsync_RecordsTraceUsageBeforeAccounting(t *testing.T)
 	var wg sync.WaitGroup
 	wg.Add(2)
 	tester.mocks.openAIComp.EXPECT().
-		CommitUsageLimit(mock.Anything, "user-1", model, tokenCounter).
-		RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, counter token.Counter) error {
-			usage, ended, events := recorder.snapshot()
+		CommitUsageLimitFromUsage(mock.Anything, "user-1", model, mock.Anything).
+		RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, usage *token.Usage) error {
+			usageSnapshot, ended, events := recorder.snapshot()
 			require.True(t, ended)
 			require.Equal(t, []string{"usage", "end"}, events)
-			require.NotNil(t, usage)
-			require.Equal(t, int64(11), usage.InputTokens)
-			require.Equal(t, int64(7), usage.OutputTokens)
-			require.Equal(t, int64(18), usage.TotalTokens)
-			require.Equal(t, int64(3), usage.ReasoningTokens)
+			require.NotNil(t, usageSnapshot)
+			require.Equal(t, int64(11), usageSnapshot.InputTokens)
+			require.Equal(t, int64(7), usageSnapshot.OutputTokens)
+			require.Equal(t, int64(18), usageSnapshot.TotalTokens)
+			require.Equal(t, int64(3), usageSnapshot.ReasoningTokens)
 			wg.Done()
 			return nil
 		}).
@@ -777,7 +777,7 @@ func TestRunChatPostProcessAsync_RecordsTraceCompletionBeforeUsage(t *testing.T)
 		recorder := &testGenerationRecorderWithMutex{}
 		firstWriteAt := time.Now()
 		tester.mocks.openAIComp.EXPECT().
-			CommitUsageLimit(mock.Anything, "user-1", model, tokenCounter).
+			CommitUsageLimitFromUsage(mock.Anything, "user-1", model, mock.Anything).
 			Return(nil).
 			Once()
 		tester.mocks.openAIComp.EXPECT().
@@ -840,7 +840,7 @@ func TestRunChatPostProcessAsync_SkipsBillingOnErrorStatus(t *testing.T) {
 
 		var billingCalled atomic.Bool
 		tester.mocks.openAIComp.EXPECT().
-			CommitUsageLimit(mock.Anything, "user-1", model, tokenCounter).
+			CommitUsageLimitFromUsage(mock.Anything, "user-1", model, mock.Anything).
 			Return(nil).
 			Once()
 		tester.mocks.openAIComp.EXPECT().
@@ -885,7 +885,7 @@ func TestRunChatPostProcessAsync_SkipsBillingOnRedirectStatus(t *testing.T) {
 
 		var billingCalled atomic.Bool
 		tester.mocks.openAIComp.EXPECT().
-			CommitUsageLimit(mock.Anything, "user-1", model, tokenCounter).
+			CommitUsageLimitFromUsage(mock.Anything, "user-1", model, mock.Anything).
 			Return(nil).
 			Once()
 		tester.mocks.openAIComp.EXPECT().

--- a/aigateway/handler/openai_speech.go
+++ b/aigateway/handler/openai_speech.go
@@ -69,6 +69,12 @@ func (h *OpenAIHandlerImpl) Speech(c *gin.Context) {
 	isSSE := req.Stream || strings.EqualFold(req.StreamFormat, "sse")
 
 	modelTarget, err := h.resolveModelTarget(ctx, username, modelID, c.Request.Header)
+	SetMetricsModelTarget(SetMetricsModelParams{
+		C:           c,
+		ModelID:     modelID,
+		ModelTarget: modelTarget,
+		IsStream:    isSSE,
+	})
 	if err != nil {
 		preflight.RecordError(err, "model_resolve")
 		handleModelTargetError(c, ctx, modelID, "failed to get speech target address", err)
@@ -274,6 +280,12 @@ func (h *OpenAIHandlerImpl) SpeechBatch(c *gin.Context) {
 	}
 
 	modelTarget, err := h.resolveModelTarget(ctx, username, modelID, c.Request.Header)
+	SetMetricsModelTarget(SetMetricsModelParams{
+		C:           c,
+		ModelID:     modelID,
+		ModelTarget: modelTarget,
+		IsStream:    false,
+	})
 	if err != nil {
 		preflight.RecordError(err, "model_resolve")
 		handleModelTargetError(c, ctx, modelID, "failed to get speech batch target address", err)

--- a/aigateway/handler/openai_test.go
+++ b/aigateway/handler/openai_test.go
@@ -129,7 +129,7 @@ func expectCheckUsageLimit(tester *testerOpenAIHandler, model *types.Model, endp
 }
 
 func expectCommitUsageLimit(tester *testerOpenAIHandler, model *types.Model, counter token.Counter) {
-	tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, "testuuid", model, counter).Return(nil).Once()
+	tester.mocks.openAIComp.EXPECT().CommitUsageLimitFromUsage(mock.Anything, "testuuid", model, mock.Anything).Return(nil).Once()
 }
 
 func expectBuildVideoMeteringEvent(t *testing.T, tester *testerOpenAIHandler) *commontypes.MeteringEvent {
@@ -1159,7 +1159,7 @@ func TestOpenAIHandler_Chat(t *testing.T) {
 			llmTokenCounter.EXPECT().AppendPrompts(expectReq.Messages).Return()
 			llmTokenCounter.EXPECT().Usage(mock.Anything).Return(&token.Usage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30}, nil).Once()
 			llmTokenCounter.EXPECT().Completion(mock.Anything).Return().Once()
-			tester.mocks.openAIComp.EXPECT().CommitUsageLimit(mock.Anything, "testuuid", model, llmTokenCounter).
+			tester.mocks.openAIComp.EXPECT().CommitUsageLimitFromUsage(mock.Anything, "testuuid", model, mock.Anything).
 				Return(nil).
 				Once()
 
@@ -1378,8 +1378,8 @@ func TestOpenAIHandler_Embedding(t *testing.T) {
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").
 			Return(model, nil)
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil)
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, "testuuid", model, mock.Anything, mock.Anything, "").RunAndReturn(
-			func(ctx context.Context, userID string, model *types.Model, targetModelName string, counter token.Counter, apikey string) error {
+		tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, mock.Anything, mock.Anything, "").RunAndReturn(
+			func(ctx context.Context, userID string, model *types.Model, targetModelName string, usage *token.Usage, apikey string) error {
 				wg.Done()
 				return nil
 			})
@@ -1433,7 +1433,7 @@ func TestOpenAIHandler_EmbeddingTrace(t *testing.T) {
 		}).Return(counter).Once()
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "embedding-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, "testuuid", model, "resolved-embedding", counter, "").Return(nil).Once()
+		tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, "resolved-embedding", mock.Anything, "").Return(nil).Once()
 
 		req := EmbeddingRequest{EmbeddingNewParams: openai.EmbeddingNewParams{
 			Model: "embedding-model",

--- a/aigateway/handler/openai_video.go
+++ b/aigateway/handler/openai_video.go
@@ -73,6 +73,12 @@ func (h *OpenAIHandlerImpl) CreateVideo(c *gin.Context) {
 	}
 
 	modelTarget, err := h.resolveModelTarget(ctx, username, input.modelID, c.Request.Header)
+	SetMetricsModelTarget(SetMetricsModelParams{
+		C:           c,
+		ModelID:     input.modelID,
+		ModelTarget: modelTarget,
+		IsStream:    false,
+	})
 	if err != nil {
 		preflight.RecordError(err, "model_resolve")
 		handleModelTargetError(c, ctx, input.modelID, "failed to get video target address", err)

--- a/aigateway/handler/rerank.go
+++ b/aigateway/handler/rerank.go
@@ -56,6 +56,12 @@ func (h *OpenAIHandlerImpl) Rerank(c *gin.Context) {
 	}
 	modelID := req.Model
 	modelTarget, err := h.resolveModelTarget(ctx, username, modelID, c.Request.Header)
+	SetMetricsModelTarget(SetMetricsModelParams{
+		C:           c,
+		ModelID:     modelID,
+		ModelTarget: modelTarget,
+		IsStream:    false,
+	})
 	if err != nil {
 		preflight.RecordError(err, "model_resolve")
 		handleModelTargetError(c, ctx, modelID, "failed to get rerank target address", err)
@@ -102,15 +108,43 @@ func (h *OpenAIHandlerImpl) Rerank(c *gin.Context) {
 	// tokenizer fallback input in case the engine returns no usage info
 	tokenCounter.Input(req.Query + "\n" + strings.Join(req.Documents, "\n"))
 
+	proxyStartTime := time.Now()
 	rp.ServeHTTP(w, c.Request, proxyToAPI, modelTarget.Host)
+
+	// Synchronously record proxy-level metrics before c.Next() returns.
+	// Capture usage first so the counter has token counts available for
+	// RecordMetrics to pre-fetch synchronously.  FinalWrite is nil because
+	// rerank is non-streaming — TTFT is not applicable.
+	// Pre-compute usage once and share with the async goroutine to avoid
+	// duplicate counter.Usage() calls.
+	w.CaptureRerankUsage()
+	rerankUsage := preComputeUsage(ctx, tokenCounter)
+	RecordMetrics(RecordMetricsParams{
+		C:              c,
+		Ctx:            ctx,
+		FinalWrite:     nil,
+		Counter:        tokenCounter,
+		ProxyStartTime: proxyStartTime,
+		Usage:          rerankUsage,
+	})
+
 	go func() {
 		usageCtx, cancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 3*time.Second)
 		defer cancel()
 
-		w.CaptureRerankUsage()
+		// Use the pre-computed usage from the sync path; fall back to a
+		// fresh counter.Usage() call only when sync pre-compute failed.
+		usage := rerankUsage
+		if usage == nil && tokenCounter != nil {
+			var usageErr error
+			usage, usageErr = tokenCounter.Usage(usageCtx)
+			if usageErr != nil {
+				slog.ErrorContext(usageCtx, "failed to get rerank token usage", slog.Any("error", usageErr))
+			}
+		}
 
-		if isSuccessfulStatus(w.StatusCode()) {
-			err := h.openaiComponent.RecordUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, tokenCounter, apikey)
+		if usage != nil && isSuccessfulStatus(w.StatusCode()) {
+			err := h.openaiComponent.RecordUsageFromTokenUsage(usageCtx, nsUUID, modelTarget.Model, modelTarget.ModelName, usage, apikey)
 			if err != nil {
 				slog.ErrorContext(c, "failed to record rerank token usage", "error", err)
 			}

--- a/aigateway/handler/rerank_test.go
+++ b/aigateway/handler/rerank_test.go
@@ -149,14 +149,15 @@ func TestOpenAIHandler_Rerank(t *testing.T) {
 		counter.EXPECT().Embedding(mock.MatchedBy(func(usage openai.CreateEmbeddingResponseUsage) bool {
 			return usage.PromptTokens == 9 && usage.TotalTokens == 9
 		})).Return().Once()
+		counter.EXPECT().Usage(mock.Anything).Return(&token.Usage{PromptTokens: 9, TotalTokens: 9}, nil).Once()
 		tester.mocks.tokenCounterFactory.EXPECT().NewEmbedding(token.CreateParam{
 			Endpoint: upstream.URL,
 			Model:    "resolved-rerank",
 		}).Return(counter).Once()
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "rerank-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, "testuuid", model, "resolved-rerank", counter, "").RunAndReturn(
-			func(ctx context.Context, userID string, model *types.Model, targetModelName string, tokenCounter token.Counter, apikey string) error {
+		tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, "resolved-rerank", mock.Anything, "").RunAndReturn(
+			func(ctx context.Context, userID string, model *types.Model, targetModelName string, usage *token.Usage, apikey string) error {
 				wg.Done()
 				return nil
 			}).Once()
@@ -199,6 +200,7 @@ func TestOpenAIHandler_Rerank(t *testing.T) {
 		counter.EXPECT().Embedding(mock.MatchedBy(func(usage openai.CreateEmbeddingResponseUsage) bool {
 			return usage.PromptTokens == 9 && usage.TotalTokens == 9
 		})).Return().Once()
+		counter.EXPECT().Usage(mock.Anything).Return(&token.Usage{PromptTokens: 9, TotalTokens: 9}, nil).Once()
 		tester.mocks.tokenCounterFactory.EXPECT().NewEmbedding(token.CreateParam{
 			Endpoint: upstream.URL,
 			Model:    "resolved-rerank",
@@ -206,8 +208,8 @@ func TestOpenAIHandler_Rerank(t *testing.T) {
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "rerank-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
 		var billingCalled atomic.Bool
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, "testuuid", model, "resolved-rerank", counter, "").
-			Run(func(context.Context, string, *types.Model, string, token.Counter, string) {
+		tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, "resolved-rerank", mock.Anything, "").
+			Run(func(context.Context, string, *types.Model, string, *token.Usage, string) {
 				billingCalled.Store(true)
 			}).Maybe()
 
@@ -255,6 +257,7 @@ func TestOpenAIHandler_Rerank(t *testing.T) {
 		counter.EXPECT().Embedding(mock.MatchedBy(func(usage openai.CreateEmbeddingResponseUsage) bool {
 			return usage.PromptTokens == 9 && usage.TotalTokens == 9
 		})).Return().Once()
+		counter.EXPECT().Usage(mock.Anything).Return(&token.Usage{PromptTokens: 9, TotalTokens: 9}, nil).Once()
 		tester.mocks.tokenCounterFactory.EXPECT().NewEmbedding(token.CreateParam{
 			Endpoint: upstream.URL,
 			Model:    "resolved-rerank",
@@ -262,8 +265,8 @@ func TestOpenAIHandler_Rerank(t *testing.T) {
 		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "rerank-model").Return(model, nil).Once()
 		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
 		var billingCalled atomic.Bool
-		tester.mocks.openAIComp.EXPECT().RecordUsage(mock.Anything, "testuuid", model, "resolved-rerank", counter, "").
-			Run(func(context.Context, string, *types.Model, string, token.Counter, string) {
+		tester.mocks.openAIComp.EXPECT().RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, "resolved-rerank", mock.Anything, "").
+			Run(func(context.Context, string, *types.Model, string, *token.Usage, string) {
 				billingCalled.Store(true)
 			}).Maybe()
 

--- a/aigateway/handler/responses_adapter_test.go
+++ b/aigateway/handler/responses_adapter_test.go
@@ -264,8 +264,8 @@ func TestResponsesNativeDisablesAcceptEncoding(t *testing.T) {
 			var wg sync.WaitGroup
 			wg.Add(2)
 			tester.mocks.openAIComp.EXPECT().
-				CommitUsageLimit(mock.Anything, "testuuid", model, mock.Anything).
-				RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, counter token.Counter) error {
+				CommitUsageLimitFromUsage(mock.Anything, "testuuid", model, mock.Anything).
+				RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, usage *token.Usage) error {
 					wg.Done()
 					return nil
 				}).
@@ -1421,8 +1421,8 @@ func TestRecordResponsesUsageFallsBackToTokenCounter(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	tester.mocks.openAIComp.EXPECT().
-		CommitUsageLimit(mock.Anything, "testuuid", model, counter).
-		RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, counter token.Counter) error {
+		CommitUsageLimitFromUsage(mock.Anything, "testuuid", model, mock.Anything).
+		RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, usage *token.Usage) error {
 			wg.Done()
 			return nil
 		}).
@@ -1440,7 +1440,7 @@ func TestRecordResponsesUsageFallsBackToTokenCounter(t *testing.T) {
 		}).
 		Once()
 
-	tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "api-key", nil, responsesTracePostProcessInput{StatusCode: http.StatusOK})
+	tester.handler.recordResponsesUsageWithTrace(c, counter, nil, "testuuid", modelTarget, "api-key", nil, responsesTracePostProcessInput{StatusCode: http.StatusOK})
 	wg.Wait()
 }
 
@@ -1457,8 +1457,8 @@ func TestRecordResponsesUsagePrefersResponsesUsage(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	tester.mocks.openAIComp.EXPECT().
-		CommitUsageLimit(mock.Anything, "testuuid", model, mock.Anything).
-		RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, counter token.Counter) error {
+		CommitUsageLimitFromUsage(mock.Anything, "testuuid", model, mock.Anything).
+		RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, usage *token.Usage) error {
 			wg.Done()
 			return nil
 		}).
@@ -1476,7 +1476,7 @@ func TestRecordResponsesUsagePrefersResponsesUsage(t *testing.T) {
 		}).
 		Once()
 
-	tester.handler.recordResponsesUsageWithTrace(c, counter, "testuuid", modelTarget, "api-key", nil, responsesTracePostProcessInput{StatusCode: http.StatusOK})
+	tester.handler.recordResponsesUsageWithTrace(c, counter, nil, "testuuid", modelTarget, "api-key", nil, responsesTracePostProcessInput{StatusCode: http.StatusOK})
 	wg.Wait()
 }
 
@@ -1956,8 +1956,8 @@ func TestResponsesAdapterEndToEndNonFunctionToolsDropped(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	tester.mocks.openAIComp.EXPECT().
-		CommitUsageLimit(mock.Anything, "testuuid", model, mock.Anything).
-		RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, counter token.Counter) error {
+		CommitUsageLimitFromUsage(mock.Anything, "testuuid", model, mock.Anything).
+		RunAndReturn(func(ctx context.Context, userUUID string, model *types.Model, usage *token.Usage) error {
 			wg.Done()
 			return nil
 		}).Once()

--- a/aigateway/task/processor/video/video_test.go
+++ b/aigateway/task/processor/video/video_test.go
@@ -59,6 +59,10 @@ func (c *fakeOpenAIComponent) CommitUsageLimit(ctx context.Context, userUUID str
 	return nil
 }
 
+func (c *fakeOpenAIComponent) CommitUsageLimitFromUsage(ctx context.Context, userUUID string, model *aigwtypes.Model, usage *token.Usage) error {
+	return nil
+}
+
 type fakeHTTPDoer struct {
 	t        *testing.T
 	wantURL  string


### PR DESCRIPTION
Summary:
- Extends metrics reporting (model target, provider, token usage, TTFT) to previously uncovered endpoints: `/responses`, `/embeddings`, `/rerank`, and all multimodal endpoints (`/ocr`, `/audio/*`, `/images/*`, `/video/*`).
- Refactors `SetMetricsModelTarget` to accept a `SetMetricsModelParams` struct, making it nil-safe and consolidating success/error path calls into one.
- Adds provider and upstream ID resolution logic, using `Upstream.Provider`/`ID` for external models and an FNV-1a hash of `Model.SvcName` for self-deployed CSGHub models.