### PR TITLE
Use global timezone for admin query

### DIFF
--- a/api/handler/cluster.go
+++ b/api/handler/cluster.go
@@ -23,12 +23,14 @@ func NewClusterHandler(config *config.Config) (*ClusterHandler, error) {
 		return nil, err
 	}
 	return &ClusterHandler{
-		c: ncc,
+		c:      ncc,
+		config: config,
 	}, nil
 }
 
 type ClusterHandler struct {
-	c component.ClusterComponent
+	c      component.ClusterComponent
+	config *config.Config
 }
 
 const (
@@ -208,7 +210,7 @@ func (h *ClusterHandler) GetDeploysReport(ctx *gin.Context) {
 		req.Status = []int{code.DeployFailed}
 	}
 	req.Query = ctx.Query("search")
-	if err := bindDeployDateRange(ctx, &req); err != nil {
+	if err := h.bindDeployDateRange(ctx, &req); err != nil {
 		slog.ErrorContext(ctx.Request.Context(), "Invalid date range for deploy report", slog.Any("error", err))
 		httpbase.BadRequest(ctx, err.Error())
 		return
@@ -294,7 +296,7 @@ func (h *ClusterHandler) Update(ctx *gin.Context) {
 	httpbase.OK(ctx, result)
 }
 
-func bindDeployDateRange(ctx *gin.Context, req *types.DeployReq) error {
+func (h *ClusterHandler) bindDeployDateRange(ctx *gin.Context, req *types.DeployReq) error {
 	startTime := ctx.Query("start_time")
 	endTime := ctx.Query("end_time")
 	if startTime == "" && endTime == "" {
@@ -303,11 +305,11 @@ func bindDeployDateRange(ctx *gin.Context, req *types.DeployReq) error {
 	if startTime == "" || endTime == "" {
 		return fmt.Errorf("start_time and end_time must be provided together")
 	}
-	parsedStart, err := parseDeployQueryTime(startTime, false)
+	parsedStart, err := h.parseDeployQueryTime(startTime, false)
 	if err != nil {
 		return err
 	}
-	parsedEnd, err := parseDeployQueryTime(endTime, true)
+	parsedEnd, err := h.parseDeployQueryTime(endTime, true)
 	if err != nil {
 		return err
 	}
@@ -316,10 +318,15 @@ func bindDeployDateRange(ctx *gin.Context, req *types.DeployReq) error {
 	return nil
 }
 
-func parseDeployQueryTime(value string, isEnd bool) (time.Time, error) {
+func (h *ClusterHandler) parseDeployQueryTime(value string, isEnd bool) (time.Time, error) {
+	loc, err := time.LoadLocation(h.config.TimeZone)
+	if err != nil {
+		slog.Warn("failed to load timezone, falling back to UTC", "timezone", h.config.TimeZone, "error", err)
+		loc = time.UTC
+	}
 	layouts := []string{deployTimeLayout, deployDateOnlyLayout}
 	for _, layout := range layouts {
-		parsed, err := time.ParseInLocation(layout, value, time.UTC)
+		parsed, err := time.ParseInLocation(layout, value, loc)
 		if err != nil {
 			continue
 		}

--- a/api/handler/cluster_test.go
+++ b/api/handler/cluster_test.go
@@ -7,11 +7,13 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/mcuadros/go-defaults"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	mockcomponent "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/component"
 	"opencsg.com/csghub-server/api/httpbase"
 	"opencsg.com/csghub-server/builder/testutil"
+	"opencsg.com/csghub-server/common/config"
 	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
 )
@@ -27,8 +29,11 @@ type clusterTester struct {
 func newClusterTester(t *testing.T) *clusterTester {
 	tester := &clusterTester{GinTester: testutil.NewGinTester()}
 	tester.mocks.clusterComponent = mockcomponent.NewMockClusterComponent(t)
+	cfg := &config.Config{}
+	defaults.SetDefaults(cfg)
 	tester.handler = &ClusterHandler{
-		c: tester.mocks.clusterComponent,
+		c:      tester.mocks.clusterComponent,
+		config: cfg,
 	}
 	return tester
 }
@@ -101,9 +106,11 @@ func Test_GetDeploysReport(t *testing.T) {
 
 	start := "2024-01-01 00:00:00"
 	end := "2024-01-31"
-	expectedStart, err := time.ParseInLocation(time.DateTime, start, time.UTC)
+	loc, err := time.LoadLocation("Asia/Shanghai")
 	require.NoError(t, err)
-	endDate, err := time.ParseInLocation("2006-01-02", end, time.UTC)
+	expectedStart, err := time.ParseInLocation(time.DateTime, start, loc)
+	require.NoError(t, err)
+	endDate, err := time.ParseInLocation("2006-01-02", end, loc)
 	require.NoError(t, err)
 	expectedEnd := endDate.Add(24*time.Hour - time.Nanosecond)
 	tester.mocks.clusterComponent.EXPECT().


### PR DESCRIPTION
Summary:
- Fixed incorrect admin data export queries caused by `parseDeployQueryTime` hardcoding `time.UTC` instead of using the frontend's actual timezone (UTC+8), which shifted query ranges by 8 hours.
- Refactored `parseDeployQueryTime` and related functions into `ClusterHandler` methods to access the global timezone config (`STARHUB_SERVER_TIMEZONE`, defaulting to `Asia/Shanghai`), with a UTC fallback on load failure.