### PR TITLE
fix: optimize repository list queries

### DIFF
--- a/api/router/api.go
+++ b/api/router/api.go
@@ -637,7 +637,7 @@ func createModelRoutes(config *config.Config,
 		modelsGroup.POST("", middlewareCollection.Auth.NeedPhoneVerified, modelHandler.Create)
 		modelsGroup.GET("", cache.Cache(memoryStore, time.Minute, middleware.CacheStrategyTrendingRepos()), modelHandler.Index)
 		// V2 API for faster model list loading
-		modelsGroup.GET("/v2", modelHandler.IndexV2)
+		modelsGroup.GET("/v2", cache.Cache(memoryStore, time.Minute, middleware.CacheStrategyTrendingRepos()), modelHandler.IndexV2)
 		modelsGroup.PUT("/:namespace/:name", middlewareCollection.Auth.NeedLogin, modelHandler.Update)
 		modelsGroup.DELETE("/:namespace/:name", middlewareCollection.Auth.NeedLogin, modelHandler.Delete)
 		modelsGroup.GET("/:namespace/:name", cache.Cache(memoryStore, time.Minute*2, middleware.CacheRepoInfo()), modelHandler.Show)

--- a/builder/store/database/migrations/20260814033032_add_public_repository_list_index.down.sql
+++ b/builder/store/database/migrations/20260814033032_add_public_repository_list_index.down.sql
@@ -1,0 +1,21 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_recom_total_score_repository;
+
+--bun:split
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_repositories_active_type_stars;
+
+--bun:split
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_repositories_active_type_likes;
+
+--bun:split
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_repositories_active_type_downloads;
+
+--bun:split
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_repositories_active_type_updated;

--- a/builder/store/database/migrations/20260814033032_add_public_repository_list_index.up.sql
+++ b/builder/store/database/migrations/20260814033032_add_public_repository_list_index.up.sql
@@ -1,0 +1,31 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_repositories_active_type_updated
+ON repositories (repository_type, updated_at DESC NULLS LAST, id DESC)
+WHERE deleted_at IS NULL;
+
+--bun:split
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_repositories_active_type_downloads
+ON repositories (repository_type, download_count DESC NULLS LAST, id DESC)
+WHERE deleted_at IS NULL;
+
+--bun:split
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_repositories_active_type_likes
+ON repositories (repository_type, likes DESC NULLS LAST, id DESC)
+WHERE deleted_at IS NULL;
+
+--bun:split
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_repositories_active_type_stars
+ON repositories (repository_type, star_count DESC NULLS LAST, id DESC)
+WHERE deleted_at IS NULL;
+
+--bun:split
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_recom_total_score_repository
+ON recom_repo_scores (score DESC NULLS LAST, repository_id DESC)
+WHERE weight_name = 'total';

--- a/builder/store/database/repository.go
+++ b/builder/store/database/repository.go
@@ -890,7 +890,7 @@ func (s *repoStoreImpl) PublicToUser(ctx context.Context, repoType types.Reposit
 		return
 	}
 
-	q.Order(sortBy[filter.Sort])
+	applyRepositorySort(q, filter.Sort)
 
 	count, err = q.Count(ctx)
 	err = errorx.HandleDBError(err, errorx.Ctx().
@@ -1050,7 +1050,7 @@ func (s *repoStoreImpl) publicToUserTrending(ctx context.Context, repoType types
 		return
 	}
 
-	err = q.OrderExpr("rrs.score DESC NULLS LAST").
+	err = q.OrderExpr("rrs.score DESC NULLS LAST, r.id DESC").
 		Limit(per).
 		Offset((page-1)*per).
 		Scan(ctx, &repos)
@@ -1238,7 +1238,7 @@ func (s *repoStoreImpl) PublicToUserV2(ctx context.Context, repoType types.Repos
 		return
 	}
 
-	q.Order(sortBy[filter.Sort])
+	applyRepositorySort(q, filter.Sort)
 
 	count, err = q.Count(ctx)
 	err = errorx.HandleDBError(err, errorx.Ctx().
@@ -1252,6 +1252,20 @@ func (s *repoStoreImpl) PublicToUserV2(ctx context.Context, repoType types.Repos
 	err = q.Limit(per).Offset((page - 1) * per).Scan(ctx)
 
 	return
+}
+
+// applyRepositorySort applies stable, repository-qualified ordering to list queries.
+func applyRepositorySort(q *bun.SelectQuery, sort string) {
+	switch sort {
+	case "recently_update":
+		q.OrderExpr("repository.updated_at DESC NULLS LAST, repository.id DESC")
+	case "most_download":
+		q.OrderExpr("repository.download_count DESC NULLS LAST, repository.id DESC")
+	case "most_favorite":
+		q.OrderExpr("repository.likes DESC NULLS LAST, repository.id DESC")
+	case "most_star":
+		q.OrderExpr("repository.star_count DESC NULLS LAST, repository.id DESC")
+	}
 }
 
 // publicToUserTrendingV2 is like publicToUserTrending but skips post-hoc tag batch loading.
@@ -1391,7 +1405,7 @@ func (s *repoStoreImpl) publicToUserTrendingV2(ctx context.Context, repoType typ
 		return
 	}
 
-	err = q.OrderExpr("rrs.score DESC NULLS LAST").
+	err = q.OrderExpr("rrs.score DESC NULLS LAST, r.id DESC").
 		Limit(per).
 		Offset((page-1)*per).
 		Scan(ctx, &repos)

--- a/builder/store/database/repository_test.go
+++ b/builder/store/database/repository_test.go
@@ -711,6 +711,16 @@ func TestRepoStore_PublicToUser(t *testing.T) {
 		},
 		{
 			admin: false, repoType: types.CodeRepo,
+			sort:     "most_favorite",
+			expected: []string{"rp6", "rp5", "rp4", "rp2", "rp1"},
+		},
+		{
+			admin: false, repoType: types.CodeRepo,
+			sort:     "most_star",
+			expected: []string{"rp6", "rp5", "rp4", "rp2", "rp1"},
+		},
+		{
+			admin: false, repoType: types.CodeRepo,
 			sort:     "trending",
 			expected: []string{"rp6", "rp5", "rp4", "rp2", "rp1"},
 		},
@@ -768,10 +778,11 @@ func TestRepoStore_PublicToUser(t *testing.T) {
 				},
 			}
 
+			fixedUpdatedAt := time.Now()
 			for _, repo := range repos {
 				repo.GitPath = repo.Path
-				// update time forcely to make sure the order of repos since the updated_at will not be updated automatically
-				repo.UpdatedAt = time.Now()
+				// Use the same update time to verify ID provides deterministic tie-breaking.
+				repo.UpdatedAt = fixedUpdatedAt
 				rn, err := store.CreateRepo(ctx, *repo)
 				require.Nil(t, err)
 


### PR DESCRIPTION
Summary:
- Added concurrent partial indexes with `DESC NULLS LAST` and stable secondary sorting (`id DESC`) to optimize repository list and trending queries, eliminating expensive sequential scans and sorts on large datasets.
- Applied the V1 anonymous trending cache strategy to the `/api/v1/models/v2` route to improve performance for unauthenticated users.
- Ensured stable pagination by prefixing sort fields with table names and adding `id DESC` as a tiebreaker for identical sorting values.