### PR TITLE
fix: make namespace path lookup deterministic

### DIFF
--- a/builder/store/database/migrations/20260814090033_add_namespace_lower_path_index.go
+++ b/builder/store/database/migrations/20260814090033_add_namespace_lower_path_index.go
@@ -1,0 +1,26 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		fmt.Print(" [up migration] ")
+		_, err := db.ExecContext(ctx, `
+			CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_namespaces_active_lower_path
+			ON namespaces (LOWER(path))
+			WHERE deleted_at IS NULL
+		`)
+		return err
+	}, func(ctx context.Context, db *bun.DB) error {
+		fmt.Print(" [down migration] ")
+		_, err := db.ExecContext(ctx, `
+			DROP INDEX CONCURRENTLY IF EXISTS idx_namespaces_active_lower_path
+		`)
+		return err
+	})
+}

--- a/builder/store/database/namespace.go
+++ b/builder/store/database/namespace.go
@@ -51,7 +51,14 @@ type Namespace struct {
 // FindByPath returns a namespace by case-insensitive path while preserving its stored path.
 func (s *NamespaceStoreImpl) FindByPath(ctx context.Context, path string) (namespace Namespace, err error) {
 	namespace.Path = path
-	err = s.db.Operator.Core.NewSelect().Model(&namespace).Relation("User").Where("LOWER(path) = LOWER(?)", path).Scan(ctx)
+	err = s.db.Operator.Core.NewSelect().
+		Model(&namespace).
+		Relation("User").
+		Where("LOWER(namespace.path) = LOWER(?)", path).
+		OrderExpr("(namespace.path = ?) DESC", path).
+		OrderExpr("namespace.id ASC").
+		Limit(1).
+		Scan(ctx)
 	err = errorx.HandleDBError(err, errorx.Ctx().Set("namespace", path))
 	return
 }

--- a/builder/store/database/namespace_test.go
+++ b/builder/store/database/namespace_test.go
@@ -49,3 +49,25 @@ func TestNamespaceStore_All(t *testing.T) {
 	_, err = store.FindByUUID(ctx, "non-existent-uuid")
 	require.NotNil(t, err)
 }
+
+func TestNamespaceStoreFindByPathCaseConflicts(t *testing.T) {
+	db := tests.InitTestDB()
+	defer db.Close()
+	ctx := context.TODO()
+
+	store := database.NewNamespaceStoreWithDB(db)
+	namespaces := []database.Namespace{
+		{Path: "AIWizards", UUID: "namespace-upper"},
+		{Path: "aiwizards", UUID: "namespace-lower"},
+	}
+	_, err := db.Core.NewInsert().Model(&namespaces).Exec(ctx)
+	require.NoError(t, err)
+
+	ns, err := store.FindByPath(ctx, "aiwizards")
+	require.NoError(t, err)
+	require.Equal(t, "aiwizards", ns.Path)
+
+	ns, err = store.FindByPath(ctx, "AiWizards")
+	require.NoError(t, err)
+	require.Equal(t, "AIWizards", ns.Path)
+}


### PR DESCRIPTION
Summary:
- Fixed non-deterministic `NamespaceStore.FindByPath` results by prioritizing exact case matches and falling back to the earliest created record (`id ASC`) when only case-insensitive matches exist.
- Optimized the query by adding `LIMIT 1` and introduced a concurrent partial expression index on `LOWER(path)` to improve performance without blocking writes or conflicting with existing case-collisions.