### PR TITLE
fix(database): stabilize user likes tests

### DIFF
--- a/builder/store/database/collection_test.go
+++ b/builder/store/database/collection_test.go
@@ -254,7 +254,7 @@ func TestCollectionStore_ByUserLikesOrgs(t *testing.T) {
 	for _, c := range cs {
 		names = append(names, c.Name)
 	}
-	require.Equal(t, []string{"col1-1", "col2-1"}, names)
+	require.ElementsMatch(t, []string{"col1-1", "col2-1"}, names)
 
 	cs, total, err = store.ByUserOrgs(ctx, "ns2", 10, 1, false)
 	require.Nil(t, err)

--- a/builder/store/database/dataset_test.go
+++ b/builder/store/database/dataset_test.go
@@ -226,7 +226,7 @@ func TestDatasetStore_UserLikesDatasets(t *testing.T) {
 	for _, ds := range dss {
 		names = append(names, ds.Repository.Name)
 	}
-	require.Equal(t, []string{"repo1", "repo3"}, names)
+	require.ElementsMatch(t, []string{"repo1", "repo3"}, names)
 
 }
 

--- a/builder/store/database/model_test.go
+++ b/builder/store/database/model_test.go
@@ -223,7 +223,7 @@ func TestModelStore_UserLikes(t *testing.T) {
 	for _, ds := range dss {
 		names = append(names, ds.Repository.Name)
 	}
-	require.Equal(t, []string{"repo1", "repo3"}, names)
+	require.ElementsMatch(t, []string{"repo1", "repo3"}, names)
 
 }
 


### PR DESCRIPTION
Summary:
- Replaced insertion-order assertions with `require.ElementsMatch` for model, dataset, and collection user-likes tests to prevent false failures when the database returns sorted rows differently.
- Preserved the existing `created_at DESC` production query ordering semantics.