### PR TITLE
Use global time zone for export data

### DIFF
--- a/component/wireset.go
+++ b/component/wireset.go
@@ -535,6 +535,7 @@ func NewTestClusterComponent(config *config.Config, deployer deploy.Deployer, st
 		resStore:        stores.SpaceResource,
 		workflowStore:   stores.Workflow,
 		namespaceStore:  stores.Namespace,
+		config:          config,
 	}
 }
 


### PR DESCRIPTION
Summary:
- Replaced `.Local()` with `.In(loc)` using `config.TimeZone` in `GetDeploysByTimeRangeStream` and `GetWorkflowsByTimeRangeStream` to ensure consistent time formatting across different deployment environments.
- Added automatic fallback to UTC with a warning log for invalid timezone configurations.
- Updated `NewTestClusterComponent` to include the `config` field, preventing nil pointer issues.