### PR TITLE
feat(sandbox): integrate CSGClaw instance with V2 deploy

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_DeployTaskStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_DeployTaskStore.go
@@ -437,6 +437,66 @@ func (_c *MockDeployTaskStore_FindActiveDeployByNameAndType_Call) RunAndReturn(r
 	return _c
 }
 
+// FindActiveSandboxByDeployName provides a mock function with given fields: ctx, uuid, deployName
+func (_m *MockDeployTaskStore) FindActiveSandboxByDeployName(ctx context.Context, uuid string, deployName string) (*database.Deploy, error) {
+	ret := _m.Called(ctx, uuid, deployName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindActiveSandboxByDeployName")
+	}
+
+	var r0 *database.Deploy
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*database.Deploy, error)); ok {
+		return rf(ctx, uuid, deployName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *database.Deploy); ok {
+		r0 = rf(ctx, uuid, deployName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.Deploy)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, uuid, deployName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockDeployTaskStore_FindActiveSandboxByDeployName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindActiveSandboxByDeployName'
+type MockDeployTaskStore_FindActiveSandboxByDeployName_Call struct {
+	*mock.Call
+}
+
+// FindActiveSandboxByDeployName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - uuid string
+//   - deployName string
+func (_e *MockDeployTaskStore_Expecter) FindActiveSandboxByDeployName(ctx interface{}, uuid interface{}, deployName interface{}) *MockDeployTaskStore_FindActiveSandboxByDeployName_Call {
+	return &MockDeployTaskStore_FindActiveSandboxByDeployName_Call{Call: _e.mock.On("FindActiveSandboxByDeployName", ctx, uuid, deployName)}
+}
+
+func (_c *MockDeployTaskStore_FindActiveSandboxByDeployName_Call) Run(run func(ctx context.Context, uuid string, deployName string)) *MockDeployTaskStore_FindActiveSandboxByDeployName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockDeployTaskStore_FindActiveSandboxByDeployName_Call) Return(_a0 *database.Deploy, _a1 error) *MockDeployTaskStore_FindActiveSandboxByDeployName_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockDeployTaskStore_FindActiveSandboxByDeployName_Call) RunAndReturn(run func(context.Context, string, string) (*database.Deploy, error)) *MockDeployTaskStore_FindActiveSandboxByDeployName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FindByDeployNameAndType provides a mock function with given fields: ctx, uuid, deployName, deployType
 func (_m *MockDeployTaskStore) FindByDeployNameAndType(ctx context.Context, uuid string, deployName string, deployType int) (*database.Deploy, error) {
 	ret := _m.Called(ctx, uuid, deployName, deployType)
@@ -494,66 +554,6 @@ func (_c *MockDeployTaskStore_FindByDeployNameAndType_Call) Return(_a0 *database
 }
 
 func (_c *MockDeployTaskStore_FindByDeployNameAndType_Call) RunAndReturn(run func(context.Context, string, string, int) (*database.Deploy, error)) *MockDeployTaskStore_FindByDeployNameAndType_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// FindSandboxByDeployName provides a mock function with given fields: ctx, uuid, deployName
-func (_m *MockDeployTaskStore) FindSandboxByDeployName(ctx context.Context, uuid string, deployName string) (*database.Deploy, error) {
-	ret := _m.Called(ctx, uuid, deployName)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FindSandboxByDeployName")
-	}
-
-	var r0 *database.Deploy
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*database.Deploy, error)); ok {
-		return rf(ctx, uuid, deployName)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) *database.Deploy); ok {
-		r0 = rf(ctx, uuid, deployName)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*database.Deploy)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, uuid, deployName)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockDeployTaskStore_FindSandboxByDeployName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindSandboxByDeployName'
-type MockDeployTaskStore_FindSandboxByDeployName_Call struct {
-	*mock.Call
-}
-
-// FindSandboxByDeployName is a helper method to define mock.On call
-//   - ctx context.Context
-//   - uuid string
-//   - deployName string
-func (_e *MockDeployTaskStore_Expecter) FindSandboxByDeployName(ctx interface{}, uuid interface{}, deployName interface{}) *MockDeployTaskStore_FindSandboxByDeployName_Call {
-	return &MockDeployTaskStore_FindSandboxByDeployName_Call{Call: _e.mock.On("FindSandboxByDeployName", ctx, uuid, deployName)}
-}
-
-func (_c *MockDeployTaskStore_FindSandboxByDeployName_Call) Run(run func(ctx context.Context, uuid string, deployName string)) *MockDeployTaskStore_FindSandboxByDeployName_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
-	})
-	return _c
-}
-
-func (_c *MockDeployTaskStore_FindSandboxByDeployName_Call) Return(_a0 *database.Deploy, _a1 error) *MockDeployTaskStore_FindSandboxByDeployName_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockDeployTaskStore_FindSandboxByDeployName_Call) RunAndReturn(run func(context.Context, string, string) (*database.Deploy, error)) *MockDeployTaskStore_FindSandboxByDeployName_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/builder/deploy/deployer.go
+++ b/builder/deploy/deployer.go
@@ -147,7 +147,9 @@ func (d *deployer) serverlessDeploy(ctx context.Context, dr types.DeployRequest)
 		// Sandbox-only fields and state reset: a reused sandbox deploy must restart from
 		// Pending. Space/serverless reset their status via StartDeploy instead, and
 		// dr.Sandbox is zero-valued for them (overwriting Timeout here would clear it).
+		deploy.RuntimeFramework = types.SandboxV2RuntimeFramework
 		deploy.Timeout = int(dr.Sandbox.Timeout)
+		deploy.ReadinessProbe = dr.Sandbox.ReadinessProbe
 		deploy.Status = common.Pending
 		deploy.StatusUpdateAt = time.Now()
 	}
@@ -205,6 +207,11 @@ func (d *deployer) dedicatedDeploy(ctx context.Context, dr types.DeployRequest) 
 		Tolerations:      dr.Tolerations,
 		PD:               dr.PD,
 		VolumeMounts:     dr.VolumeMounts,
+	}
+	if types.IsSandboxType(dr.Type) {
+		deploy.RuntimeFramework = types.SandboxV2RuntimeFramework
+		deploy.ReadinessProbe = dr.Sandbox.ReadinessProbe
+		deploy.Timeout = int(dr.Sandbox.Timeout)
 	}
 	updateDatabaseDeploy(deploy, dr)
 	err := d.deployTaskStore.CreateDeploy(ctx, deploy)
@@ -301,9 +308,18 @@ func (d *deployer) Deploy(ctx context.Context, dr types.DeployRequest) (int64, e
 }
 
 func (d *deployer) Status(ctx context.Context, dr types.DeployRequest, needDetails bool) (string, int, []types.Instance, error) {
-	deploy, err := d.deployTaskStore.GetDeployByID(ctx, dr.DeployID)
+	var deploy *database.Deploy
+	var err error
+	if dr.DeployID != 0 {
+		deploy, err = d.deployTaskStore.GetDeployByID(ctx, dr.DeployID)
+	} else if dr.SvcName != "" {
+		deploy, err = d.deployTaskStore.GetDeployBySvcName(ctx, dr.SvcName)
+	} else {
+		slog.ErrorContext(ctx, "failed to get deploy: neither deploy_id nor svc_name provided")
+		return "", common.Stopped, nil, fmt.Errorf("can't get deploy: neither deploy_id nor svc_name provided")
+	}
 	if err != nil || deploy == nil {
-		slog.ErrorContext(ctx, "failed to get deploy by deploy id", slog.Any("DeployID", dr.DeployID), slog.Any("error", err))
+		slog.ErrorContext(ctx, "failed to get deploy", slog.Any("DeployID", dr.DeployID), slog.Any("SvcName", dr.SvcName), slog.Any("error", err))
 		return "", common.Stopped, nil, fmt.Errorf("can't get deploy, %w", err)
 	}
 

--- a/builder/deploy/deployer_test.go
+++ b/builder/deploy/deployer_test.go
@@ -290,6 +290,7 @@ func TestDeployer_Deploy(t *testing.T) {
 func TestDeployer_Status(t *testing.T) {
 	t.Run("no deploy", func(t *testing.T) {
 		dr := types.DeployRequest{
+			DeployID: 1,
 			UserUUID: "1",
 			Path:     "namespace/name",
 			Type:     types.InferenceType,
@@ -308,6 +309,25 @@ func TestDeployer_Status(t *testing.T) {
 		require.Equal(t, common.Stopped, deployStatus)
 		require.Nil(t, instances)
 
+	})
+	t.Run("neither deploy_id nor svc_name", func(t *testing.T) {
+		dr := types.DeployRequest{
+			UserUUID: "1",
+			Path:     "namespace/name",
+			Type:     types.InferenceType,
+		}
+
+		mockDeployTaskStore := mockdb.NewMockDeployTaskStore(t)
+		// no store expectation: the method must fail fast without querying
+		d := &deployer{
+			deployTaskStore: mockDeployTaskStore,
+		}
+
+		svcName, deployStatus, instances, err := d.Status(context.TODO(), dr, false)
+		require.NotNil(t, err)
+		require.Equal(t, "", svcName)
+		require.Equal(t, common.Stopped, deployStatus)
+		require.Nil(t, instances)
 	})
 	t.Run("cache miss and running", func(t *testing.T) {
 		dr := types.DeployRequest{

--- a/builder/store/database/deploy_task.go
+++ b/builder/store/database/deploy_task.go
@@ -55,25 +55,26 @@ type Deploy struct {
 	// 1-public, 2-private, 3-extension in future
 	SecureLevel int `json:"secure_level"`
 	// 0-space, 1-inference, 2-finetune, 3-serverless, 4-evaluation, 5-notebook
-	Type           int                  `json:"type"`
-	Task           types.PipelineTask   `bun:",nullzero" json:"task"` // text-generation,text-to-image,image-to-image,text-to-speech
-	UserUUID       string               `bun:"," json:"user_uuid"`
-	SKU            string               `bun:"," json:"sku"`
-	OrderDetailID  int64                `bun:"," json:"order_detail_id"`
-	EngineArgs     string               `bun:"," json:"engine_args"`
-	Variables      string               `bun:",nullzero" json:"variables"`
-	Message        string               `bun:",nullzero" json:"message"`
-	Reason         string               `bun:",nullzero" json:"reason"`
-	ClusterNode    string               `bun:"," json:"cluster_node"`
-	QueueName      string               `bun:"," json:"queue_name"`
-	OwnerNamespace string               `bun:"," json:"owner_namespace"`
-	Instances      []types.Instance     `bun:"type:jsonb" json:"instances"`
-	NodeAffinity   *corev1.NodeAffinity `json:"node_affinity,omitempty"`
-	Tolerations    []types.Toleration   `json:"tolerations,omitempty"`
-	PD             *types.PDConfig      `bun:"type:jsonb,nullzero" json:"pd,omitempty"`
-	VolumeMounts   []types.VolumeMount  `bun:"type:jsonb,nullzero" json:"volume_mounts,omitempty"`
-	Timeout        int                  `json:"timeout,omitempty"` // reserved: written from dr.Sandbox.Timeout but not yet consumed downstream
-	StatusUpdateAt time.Time            `bun:",nullzero,notnull,default:current_timestamp" json:"status_update_at,omitempty"`
+	Type           int                          `json:"type"`
+	Task           types.PipelineTask           `bun:",nullzero" json:"task"` // text-generation,text-to-image,image-to-image,text-to-speech
+	UserUUID       string                       `bun:"," json:"user_uuid"`
+	SKU            string                       `bun:"," json:"sku"`
+	OrderDetailID  int64                        `bun:"," json:"order_detail_id"`
+	EngineArgs     string                       `bun:"," json:"engine_args"`
+	Variables      string                       `bun:",nullzero" json:"variables"`
+	Message        string                       `bun:",nullzero" json:"message"`
+	Reason         string                       `bun:",nullzero" json:"reason"`
+	ClusterNode    string                       `bun:"," json:"cluster_node"`
+	QueueName      string                       `bun:"," json:"queue_name"`
+	OwnerNamespace string                       `bun:"," json:"owner_namespace"`
+	Instances      []types.Instance             `bun:"type:jsonb" json:"instances"`
+	NodeAffinity   *corev1.NodeAffinity         `json:"node_affinity,omitempty"`
+	Tolerations    []types.Toleration           `json:"tolerations,omitempty"`
+	PD             *types.PDConfig              `bun:"type:jsonb,nullzero" json:"pd,omitempty"`
+	VolumeMounts   []types.VolumeMount          `bun:"type:jsonb,nullzero" json:"volume_mounts,omitempty"`
+	ReadinessProbe *types.SandboxReadinessProbe `bun:"type:jsonb,nullzero" json:"readiness_probe,omitempty"`
+	Timeout        int                          `json:"timeout,omitempty"` // reserved: written from dr.Sandbox.Timeout but not yet consumed downstream
+	StatusUpdateAt time.Time                    `bun:",nullzero,notnull,default:current_timestamp" json:"status_update_at,omitempty"`
 	times
 }
 
@@ -131,7 +132,7 @@ type DeployTaskStore interface {
 	ListDeploysByTimeRange(ctx context.Context, req types.DeployTimeRangeReq) ([]Deploy, int, error)
 	FindByDeployNameAndType(ctx context.Context, uuid, deployName string, deployType int) (*Deploy, error)
 	FindActiveDeployByNameAndType(ctx context.Context, userUUID, deployName string, deployType int) (*Deploy, error)
-	FindSandboxByDeployName(ctx context.Context, uuid, deployName string) (*Deploy, error)
+	FindActiveSandboxByDeployName(ctx context.Context, uuid, deployName string) (*Deploy, error)
 	CountRunningDeploysByNodeName(ctx context.Context, nodeName string) (int, error)
 	ListDeploysNeedingReconcile(ctx context.Context, statuses []int, timeoutMin int, limit int) ([]Deploy, error)
 	CountByRepoID(ctx context.Context, repoID int64) (int, error)
@@ -799,13 +800,16 @@ func (s *deployTaskStoreImpl) FindActiveDeployByNameAndType(ctx context.Context,
 	return &result, nil
 }
 
-// FindSandboxByDeployName looks up a sandbox deploy (persistent or ephemeral) by user UUID
-// and deploy name. Returns (nil, nil) when absent.
-func (s *deployTaskStoreImpl) FindSandboxByDeployName(ctx context.Context, uuid, deployName string) (*Deploy, error) {
+// FindActiveSandboxByDeployName looks up a non-deleted sandbox deploy (persistent or
+// ephemeral) by user UUID and deploy name. Returns (nil, nil) when absent. The
+// status != Deleted filter matters for proxy lookup: a deleted deploy's SvcName is
+// still populated, so without it GetProxyURL would hand back a proxy URL for a
+// sandbox that no longer exists (404).
+func (s *deployTaskStoreImpl) FindActiveSandboxByDeployName(ctx context.Context, uuid, deployName string) (*Deploy, error) {
 	var result Deploy
 	err := s.db.Operator.Core.NewSelect().Model(&result).
-		Where("user_uuid = ? and deploy_name = ? and type IN (?)", uuid, deployName,
-			bun.In([]int{types.SandboxType, types.SandboxEphemeralType})).
+		Where("user_uuid = ? and deploy_name = ? and type IN (?) and status != ?", uuid, deployName,
+			bun.In([]int{types.SandboxType, types.SandboxEphemeralType}), common.Deleted).
 		Order("id DESC").
 		Limit(1).
 		Scan(ctx, &result)

--- a/builder/store/database/migrations/20260817000000_add_readiness_probe_to_deploys.down.sql
+++ b/builder/store/database/migrations/20260817000000_add_readiness_probe_to_deploys.down.sql
@@ -1,0 +1,5 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE deploys DROP COLUMN IF EXISTS readiness_probe;

--- a/builder/store/database/migrations/20260817000000_add_readiness_probe_to_deploys.up.sql
+++ b/builder/store/database/migrations/20260817000000_add_readiness_probe_to_deploys.up.sql
@@ -1,0 +1,5 @@
+SET statement_timeout = 0;
+
+--bun:split
+
+ALTER TABLE deploys ADD COLUMN IF NOT EXISTS readiness_probe JSONB;

--- a/builder/store/database/scenario_constraint.go
+++ b/builder/store/database/scenario_constraint.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/uptrace/bun"
 	"opencsg.com/csghub-server/common/errorx"
+	"opencsg.com/csghub-server/common/types"
 )
 
 type scenarioConstraintStoreImpl struct {
@@ -75,6 +76,19 @@ type ScenarioConstraint struct {
 	ExcludeHardware  int64  `bun:",notnull,default:0" json:"exclude_hardware"`
 	MaxReplica       int    `bun:",notnull,default:0" json:"max_replica"`
 	times
+}
+
+// Satisfies reports whether the given hardware (and its replica count) meets this
+// scenario's constraints. It combines the required/exclude hardware bitmask check
+// and the max_replica check into a single predicate, delegating to the shared
+// types.HardwareSatisfiesConstraint / types.ReplicaSatisfiesConstraint. A nil
+// receiver means "no constraint configured" and always satisfies.
+func (c *ScenarioConstraint) Satisfies(hardware types.HardWare) bool {
+	if c == nil {
+		return true
+	}
+	return types.HardwareSatisfiesConstraint(c.RequiredHardware, c.ExcludeHardware, hardware) &&
+		types.ReplicaSatisfiesConstraint(c.MaxReplica, hardware.Replicas)
 }
 
 func (s *scenarioConstraintStoreImpl) FindByScenario(ctx context.Context, scenario string) (*ScenarioConstraint, error) {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -213,14 +213,11 @@ type Config struct {
 		StatusCheckInterval       int    `env:"STARHUB_SERVER_SPACE_STATUS_CHECK_INTERVAL" default:"10"` // 10 seconds
 		SandboxPVCName            string `env:"STARHUB_SERVER_SANDBOX_PVC_NAME" default:"sandbox-storage"`
 		SandboxRuntimeClass       string `env:"STARHUB_SERVER_SANDBOX_RUNTIME_CLASS" default:"gvisor"`
-		// SandboxEphemeralIdleTimeoutMin: how long an ephemeral sandbox stays idle before being deleted
-		// (destroys CR+PVC, irreversible). Measured from the last active-counter change.
-		// Defaults to 10 minutes.
-		SandboxEphemeralIdleTimeoutMin int `env:"STARHUB_SERVER_SANDBOX_EPHEMERAL_IDLE_TIMEOUT_MIN" default:"10"`
-		// SandboxPersistentIdleTimeoutHours: how long a persistent sandbox stays idle before being suspended
-		// (reversible, keeps PVC). Measured from the last active-counter change.
-		// Defaults to 24 hours.
-		SandboxPersistentIdleTimeoutHours int `env:"STARHUB_SERVER_SANDBOX_PERSISTENT_IDLE_TIMEOUT_HOURS" default:"24"`
+		// SandboxFreeResourceMaxIdleTimeoutMin: the idle-reclaim timeout (in minutes) applied to
+		// sandboxes created on free resources (price == 0). It acts as BOTH the default (when the
+		// caller does not pass a timeout) and the upper bound (a larger caller-provided timeout is
+		// clamped down to this value), so free resources cannot be held indefinitely. Defaults to 10.
+		SandboxFreeResourceMaxIdleTimeoutMin int `env:"STARHUB_SERVER_SANDBOX_FREE_RESOURCE_MAX_IDLE_TIMEOUT_MIN" default:"10"`
 		// SandboxIdleSweepIntervalSec is the idle scan period. The scan reads the informer cache, zero API calls.
 		SandboxIdleSweepIntervalSec int `env:"STARHUB_SERVER_SANDBOX_IDLE_SWEEP_INTERVAL_SECONDS" default:"60"`
 		// SandboxIdleStartupGraceMin: for how many minutes after Runner startup only record activity and do not

--- a/common/types/repo.go
+++ b/common/types/repo.go
@@ -287,8 +287,9 @@ type DeployRequest struct {
 	DeployExtend
 
 	Sandbox struct {
-		Timeout    int64  `json:"timeout,omitempty"`
-		TemplateID string `json:"templateID,omitempty"`
+		Timeout        int64                  `json:"timeout,omitempty"`
+		TemplateID     string                 `json:"templateID,omitempty"`
+		ReadinessProbe *SandboxReadinessProbe `json:"readiness_probe,omitempty"`
 	}
 }
 

--- a/common/types/sandbox_v2.go
+++ b/common/types/sandbox_v2.go
@@ -6,7 +6,32 @@ package types
 // (volume_mounts jsonb column). WorkingDir is not stored and defaults to the first
 // mount_path on the runner side.
 
-// SandboxV2Type is the sandbox storage type expected by the runner.
+// SandboxV2RuntimeFramework is the runtime_framework value set on deploy records
+// created through the deployer for sandbox V2. The aigateway reads this field to
+// route proxy requests to the V2 runner endpoint instead of the V1 one.
+const SandboxV2RuntimeFramework = "sandbox-v2"
+
+// SandboxV2CreateRequest is the component-layer create request for a sandbox-v2
+// sandbox. It deliberately does NOT carry resource-derived fields (Hardware,
+// ClusterID, SKU): those are resolved inside SandboxV2Component.Create from
+// ResourceID, or auto-allocated from a free sandbox resource when ResourceID is 0.
+type SandboxV2CreateRequest struct {
+	DeployName     string                 `json:"deploy_name,omitempty"`
+	SvcName        string                 `json:"svc_name,omitempty"`
+	ImageID        string                 `json:"image_id,omitempty"`
+	Env            string                 `json:"env,omitempty"` // JSON-encoded map[string]string
+	ContainerPort  int                    `json:"container_port,omitempty"`
+	UserUUID       string                 `json:"user_uuid,omitempty"`
+	ResourceID     int64                  `json:"resource_id,omitempty"`     // 0 = auto-allocate a free sandbox resource
+	MinCPU         string                 `json:"min_cpu,omitempty"`         // lower bound for auto-allocation, e.g. "500m"
+	MinMemory      string                 `json:"min_memory,omitempty"`      // lower bound for auto-allocation, e.g. "512Mi"
+	ReadinessProbe *SandboxReadinessProbe `json:"readiness_probe,omitempty"` // app-level readiness (persistent only)
+	Timeout        int                    `json:"timeout,omitempty"`         // idle-reclaim timeout in minutes; 0 = permanent (paid resources only)
+	VolumeMounts   []VolumeMount          `json:"volume_mounts,omitempty"`
+	MinReplica     int                    `json:"min_replica,omitempty"`
+	MaxReplica     int                    `json:"max_replica,omitempty"`
+}
+
 type SandboxV2Type string
 
 const (

--- a/component/sandbox_v2_ce.go
+++ b/component/sandbox_v2_ce.go
@@ -1,0 +1,8 @@
+//go:build !ee && !saas
+
+package component
+
+// SandboxV2Component is empty in CE builds: sandbox-v2 is ee/saas only.
+// The CSGClawAgentInstanceAdapter that uses this interface is also ee/saas only,
+// so no CE code references it.
+type SandboxV2Component interface{}

--- a/component/space_resource.go
+++ b/component/space_resource.go
@@ -145,12 +145,9 @@ func (c *spaceResourceComponentImpl) Index(ctx context.Context, req *types.Space
 					availableStatusList[i].NodeName = maskNodeName(availableStatusList[i].NodeName)
 				}
 			}
-			if !c.hardwareSatisfiesConstraint(constraint, hardware) {
-				// resource hardware does not meet the scenario's required_hardware bitmask
-				continue
-			}
-			if !c.replicaSatisfiesConstraint(constraint, hardware.Replicas) {
-				// resource replicas exceed the scenario's max_replica (0 = unlimited)
+			if !constraint.Satisfies(hardware) {
+				// resource hardware/replicas do not meet the scenario's constraint
+				// (required_hardware / exclude_hardware / max_replica)
 				continue
 			}
 			resourceType := common.ResourceType(hardware)
@@ -189,29 +186,6 @@ func (c *spaceResourceComponentImpl) Index(ctx context.Context, req *types.Space
 	}
 	total = len(result)
 	return result, total, nil
-}
-
-// hardwareSatisfiesConstraint reports whether the resource hardware meets the
-// scenario's hardware constraints. Delegates to the shared
-// types.HardwareSatisfiesConstraint so the Index query and the sandbox
-// auto-allocator apply identical rules. A nil constraint means no rule
-// configured => always satisfied.
-func (c *spaceResourceComponentImpl) hardwareSatisfiesConstraint(constraint *database.ScenarioConstraint, hardware types.HardWare) bool {
-	if constraint == nil {
-		return true
-	}
-	return types.HardwareSatisfiesConstraint(constraint.RequiredHardware, constraint.ExcludeHardware, hardware)
-}
-
-// replicaSatisfiesConstraint reports whether the resource replica count is within
-// the scenario's max_replica. Delegates to the shared types.ReplicaSatisfiesConstraint
-// so the Index query and the sandbox auto-allocator apply identical rules. A nil
-// constraint or a zero max_replica means "unlimited" (always satisfied).
-func (c *spaceResourceComponentImpl) replicaSatisfiesConstraint(constraint *database.ScenarioConstraint, replicas int) bool {
-	if constraint == nil {
-		return true
-	}
-	return types.ReplicaSatisfiesConstraint(constraint.MaxReplica, replicas)
 }
 
 func (c *spaceResourceComponentImpl) getHardwareModel(hardware types.HardWare) types.HardwareModel {


### PR DESCRIPTION
Summary:
- Migrated CSGClaw agent sandbox creation to use the new `SandboxV2Component` for unified deploy-layer management and introduced per-sandbox idle timeouts.
- Fixed V2 proxy routing issues (trailing slashes, unforwarded paths, 404s) and corrected resource auto-allocation logic by replacing paginated queries with accurate list calls and adding capacity/balance checks.
- Refactored hardware constraint validation into a shared `ScenarioConstraint.Satisfies` method and simplified probes to a single `ReadinessProbe`.