### PR TITLE
性能优化：限制仓库列表计数查询

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,3 +104,5 @@ Folders relative to the root of the repository for each service:
 - Each PR must include a clear description of the changes made and their impact, including root cause analysis if applicable, and solution details, and local test result.
 
 ## Specific Instructions
+
+- 所有发布到 GitLab 的内容，包括 Issue、Merge Request、描述、评论和评审意见，都必须使用中文。

--- a/builder/store/database/repository.go
+++ b/builder/store/database/repository.go
@@ -48,6 +48,71 @@ func escapeLikePattern(value string) string {
 	return builder.String()
 }
 
+func repoListCountLimit(per, page int) int {
+	if per <= 0 {
+		return 0
+	}
+	return max(types.RepoListVisiblePageLimit+1, page+1) * per
+}
+
+func (s *repoStoreImpl) countRepoList(ctx context.Context, q *bun.SelectQuery, per, page int) (int, error) {
+	if per <= 0 {
+		return q.Count(ctx)
+	}
+	countQuery := q.Clone().Limit(repoListCountLimit(per, page))
+	return s.db.Operator.Core.NewSelect().
+		TableExpr("(?) AS limited_repositories", countQuery).
+		Count(ctx)
+}
+
+func applySpaceStatusFilter(q *bun.SelectQuery, status string) {
+	if status == "" {
+		return
+	}
+
+	const latestDeployStatus = `(SELECT d.status
+		FROM deploys AS d
+		WHERE d.space_id = spaces.id
+		ORDER BY d.created_at DESC
+		LIMIT 1)`
+
+	switch status {
+	case "NoAppFile":
+		q.Where("spaces.has_app_file = ? AND spaces.sdk <> ?", false, types.NGINX.Name)
+	case "NoNGINXConf":
+		q.Where("spaces.has_app_file = ? AND spaces.sdk = ?", false, types.NGINX.Name)
+	case "Pending":
+		q.Where("spaces.has_app_file = ?", true).
+			Where(latestDeployStatus+" = ?", common.Pending)
+	case "Building":
+		q.Where("spaces.has_app_file = ?", true).
+			Where(latestDeployStatus+" IN (?)", bun.In([]int{common.BuildInQueue, common.Building}))
+	case "BuildingFailed":
+		q.Where("spaces.has_app_file = ?", true).
+			Where(latestDeployStatus+" = ?", common.BuildFailed)
+	case "Deploying":
+		q.Where("spaces.has_app_file = ?", true).
+			Where(latestDeployStatus+" IN (?)", bun.In([]int{common.BuildSuccess, common.Deploying, common.Startup}))
+	case "DeployFailed":
+		q.Where("spaces.has_app_file = ?", true).
+			Where(latestDeployStatus+" = ?", common.DeployFailed)
+	case "Running":
+		q.Where("spaces.has_app_file = ?", true).
+			Where(latestDeployStatus+" = ?", common.Running)
+	case "RuntimeError":
+		q.Where("spaces.has_app_file = ?", true).
+			Where(latestDeployStatus+" = ?", common.RunTimeError)
+	case "Sleeping":
+		q.Where("spaces.has_app_file = ?", true).
+			Where(latestDeployStatus+" = ?", common.Sleeping)
+	case "Stopped":
+		q.Where("spaces.has_app_file = ?", true).
+			Where("COALESCE("+latestDeployStatus+", ?) = ?", common.Stopped, common.Stopped)
+	default:
+		q.Where("FALSE")
+	}
+}
+
 type repoStoreImpl struct {
 	config              *config.Config
 	db                  *DB
@@ -765,6 +830,7 @@ func (s *repoStoreImpl) PublicToUser(ctx context.Context, repoType types.Reposit
 		q.Join("INNER JOIN codes ON codes.repository_id = repository.id")
 	case types.SpaceRepo:
 		q.Join("INNER JOIN spaces ON spaces.repository_id = repository.id")
+		applySpaceStatusFilter(q, filter.Status)
 	case types.PromptRepo:
 		q.Join("INNER JOIN prompts ON prompts.repository_id = repository.id")
 	case types.MCPServerRepo:
@@ -892,7 +958,7 @@ func (s *repoStoreImpl) PublicToUser(ctx context.Context, repoType types.Reposit
 
 	q.Order(sortBy[filter.Sort])
 
-	count, err = q.Count(ctx)
+	count, err = s.countRepoList(ctx, q, per, page)
 	err = errorx.HandleDBError(err, errorx.Ctx().
 		Set("repo_type", repoType).
 		Set("filter", filter),
@@ -934,6 +1000,9 @@ func (s *repoStoreImpl) publicToUserTrending(ctx context.Context, repoType types
 
 	// Join with business table
 	q.Join(fmt.Sprintf("INNER JOIN %s ON %s.repository_id = r.id", bizTable, bizTable))
+	if repoType == types.SpaceRepo {
+		applySpaceStatusFilter(q, filter.Status)
+	}
 
 	// Filter by dataset type for dataset repo
 	if repoType == types.DatasetRepo && filter.DatasetType != "" {
@@ -967,8 +1036,7 @@ func (s *repoStoreImpl) publicToUserTrending(ctx context.Context, repoType types
 		}
 	}
 
-	q.Where("r.deleted_at IS NULL").
-		Where(fmt.Sprintf("EXISTS (SELECT 1 FROM %s m WHERE m.repository_id = r.id)", bizTable))
+	q.Where("r.deleted_at IS NULL")
 
 	if !isAdmin {
 		if len(ownerNamespaces) > 0 {
@@ -1041,7 +1109,10 @@ func (s *repoStoreImpl) publicToUserTrending(ctx context.Context, repoType types
 		q.Distinct()
 	}
 
-	count, err = q.Count(ctx)
+	// Repository lists only render the first 100 page numbers and use the next-page
+	// control afterwards. Count only far enough to keep that control accurate for
+	// the current page instead of scanning every matching repository.
+	count, err = s.countRepoList(ctx, q, per, page)
 	err = errorx.HandleDBError(err, errorx.Ctx().
 		Set("repo_type", repoType).
 		Set("filter", filter),

--- a/builder/store/database/repository_internal_test.go
+++ b/builder/store/database/repository_internal_test.go
@@ -1,0 +1,26 @@
+package database
+
+import "testing"
+
+func TestRepoListCountLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		per  int
+		page int
+		want int
+	}{
+		{name: "first page counts through page 101", per: 20, page: 1, want: 2020},
+		{name: "page 100 keeps page 101 reachable", per: 20, page: 100, want: 2020},
+		{name: "count advances after page 100", per: 20, page: 101, want: 2040},
+		{name: "unbounded request", per: 0, page: 1, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := repoListCountLimit(tt.per, tt.page)
+			if got != tt.want {
+				t.Errorf("repoListCountLimit(%d, %d) = %d, want %d", tt.per, tt.page, got, tt.want)
+			}
+		})
+	}
+}

--- a/builder/store/database/repository_test.go
+++ b/builder/store/database/repository_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	mockcache "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/store/cache"
+	deployCommon "opencsg.com/csghub-server/builder/deploy/common"
 	"opencsg.com/csghub-server/builder/store/cache"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
@@ -984,6 +985,112 @@ func TestRepoStore_PublicToUserRangeFilters(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 1, count)
 	require.Equal(t, "large-dataset", repos[0].Name)
+}
+
+func TestRepoStore_PublicToUserTrendingModels(t *testing.T) {
+	db := tests.InitTestDB()
+	defer db.Close()
+	ctx := context.TODO()
+
+	store := database.NewRepoStoreWithDB(db)
+	modelStore := database.NewModelStoreWithDB(db)
+	recomStore := database.NewRecomStoreWithDB(db)
+
+	for i, name := range []string{"lower-score", "higher-score"} {
+		repo, err := store.CreateRepo(ctx, database.Repository{
+			Name:           name,
+			Path:           "test/" + name,
+			GitPath:        "models_test/" + name,
+			UserID:         123,
+			RepositoryType: types.ModelRepo,
+		})
+		require.NoError(t, err)
+		_, err = modelStore.Create(ctx, database.Model{RepositoryID: repo.ID})
+		require.NoError(t, err)
+		err = recomStore.UpsertScore(ctx, []*database.RecomRepoScore{{
+			RepositoryID: repo.ID,
+			WeightName:   database.RecomWeightTotal,
+			Score:        float64(i + 1),
+		}})
+		require.NoError(t, err)
+	}
+
+	repos, count, err := store.PublicToUser(ctx, types.ModelRepo, nil, &types.RepoFilter{
+		Sort: "trending",
+	}, 20, 1, false)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+	require.Len(t, repos, 2)
+	require.Equal(t, "higher-score", repos[0].Name)
+	require.Equal(t, "lower-score", repos[1].Name)
+}
+
+func TestRepoStore_PublicToUserFiltersSpaceStatus(t *testing.T) {
+	db := tests.InitTestDB()
+	defer db.Close()
+	ctx := context.TODO()
+
+	repoStore := database.NewRepoStoreWithDB(db)
+	spaceStore := database.NewSpaceStoreWithDB(db)
+	deployStore := database.NewDeployTaskStoreWithDB(db)
+
+	createSpace := func(name string, hasAppFile bool, status *int) *database.Repository {
+		repo, err := repoStore.CreateRepo(ctx, database.Repository{
+			Name:           name,
+			Path:           "test/" + name,
+			GitPath:        "spaces_test/" + name,
+			UserID:         123,
+			RepositoryType: types.SpaceRepo,
+		})
+		require.NoError(t, err)
+		_, err = spaceStore.Create(ctx, database.Space{
+			RepositoryID: repo.ID,
+			Sdk:          types.GRADIO.Name,
+			HasAppFile:   hasAppFile,
+		})
+		require.NoError(t, err)
+		space, err := spaceStore.ByRepoID(ctx, repo.ID)
+		require.NoError(t, err)
+		if status != nil {
+			err = deployStore.CreateDeploy(ctx, &database.Deploy{
+				SpaceID: space.ID,
+				RepoID:  repo.ID,
+				Status:  *status,
+			})
+			require.NoError(t, err)
+			latestDeploy, err := deployStore.GetLatestDeployBySpaceID(ctx, space.ID)
+			require.NoError(t, err)
+			require.Equal(t, *status, latestDeploy.Status)
+		}
+		return repo
+	}
+
+	runningStatus := deployCommon.Running
+	stoppedStatus := deployCommon.Stopped
+	runningRepo := createSpace("running", true, &runningStatus)
+	createSpace("stopped", true, &stoppedStatus)
+	noAppRepo := createSpace("no-app", false, nil)
+
+	tests := []struct {
+		name       string
+		status     string
+		expectedID int64
+	}{
+		{name: "running", status: "Running", expectedID: runningRepo.ID},
+		{name: "no app file", status: "NoAppFile", expectedID: noAppRepo.ID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repos, count, err := repoStore.PublicToUser(ctx, types.SpaceRepo, nil, &types.RepoFilter{
+				Sort:   "recently_update",
+				Status: tt.status,
+			}, 20, 1, false)
+			require.NoError(t, err)
+			require.Equal(t, 1, count)
+			require.Len(t, repos, 1)
+			require.Equal(t, tt.expectedID, repos[0].ID)
+		})
+	}
 }
 
 func TestRepoStore_IsMirrorRepo(t *testing.T) {

--- a/common/types/repo.go
+++ b/common/types/repo.go
@@ -132,7 +132,8 @@ const (
 	TEI                         InferenceEngine = "tei"
 	Ktransformers               InferenceEngine = "ktransformers"
 
-	MaxFileTreeSize int = 500
+	MaxFileTreeSize          int = 500
+	RepoListVisiblePageLimit int = 100
 )
 
 var (

--- a/component/space.go
+++ b/component/space.go
@@ -546,66 +546,15 @@ func (c *spaceComponentImpl) Update(ctx context.Context, req *types.UpdateSpaceR
 }
 
 func (c *spaceComponentImpl) Index(ctx context.Context, repoFilter *types.RepoFilter, per, page int, needOpWeight bool) ([]*types.Space, int, error) {
-	var (
-		resSpaces []*types.Space
-		err       error
+	repos, total, err := c.repoComponent.PublicToUser(
+		ctx, types.SpaceRepo, repoFilter.Username, repoFilter, per, page,
 	)
-
-	if repoFilter.Status == "" {
-		repos, total, err := c.repoComponent.PublicToUser(ctx, types.SpaceRepo, repoFilter.Username, repoFilter, per, page)
-		if err != nil {
-			newError := fmt.Errorf("failed to get public space repos,error:%w", err)
-			return nil, 0, newError
-		}
-		resSpaces, err = c.convertReposToSpaces(ctx, repos)
-		if err != nil {
-			return nil, 0, err
-		}
-		if needOpWeight {
-			var repoIDs []int64
-			for _, s := range resSpaces {
-				repoIDs = append(repoIDs, s.RepositoryID)
-			}
-			c.addOpWeightToSpaces(ctx, repoIDs, resSpaces)
-		}
-		return resSpaces, total, nil
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get public space repos,error:%w", err)
 	}
-
-	currentPage := page
-	maxPages := 100
-	pagesChecked := 0
-
-	for len(resSpaces) < per && pagesChecked < maxPages {
-		repos, total, err := c.repoComponent.PublicToUser(ctx, types.SpaceRepo, repoFilter.Username, repoFilter, per, currentPage)
-		if err != nil {
-			newError := fmt.Errorf("failed to get public space repos,error:%w", err)
-			return nil, 0, newError
-		}
-
-		if len(repos) == 0 {
-			break
-		}
-
-		pageSpaces, err := c.convertReposToSpaces(ctx, repos)
-		if err != nil {
-			return nil, 0, err
-		}
-
-		for _, space := range pageSpaces {
-			if space.Status == repoFilter.Status {
-				resSpaces = append(resSpaces, space)
-				if len(resSpaces) >= per {
-					break
-				}
-			}
-		}
-
-		if total <= currentPage*per {
-			break
-		}
-
-		currentPage++
-		pagesChecked++
+	resSpaces, err := c.convertReposToSpaces(ctx, repos)
+	if err != nil {
+		return nil, 0, err
 	}
 
 	if needOpWeight {
@@ -616,36 +565,7 @@ func (c *spaceComponentImpl) Index(ctx context.Context, repoFilter *types.RepoFi
 		c.addOpWeightToSpaces(ctx, repoIDs, resSpaces)
 	}
 
-	allRepos, allTotal, err := c.repoComponent.PublicToUser(ctx, types.SpaceRepo, repoFilter.Username, repoFilter, 0, 1)
-	if err != nil {
-		return resSpaces, len(resSpaces), nil
-	}
-	_ = allRepos
-
-	filteredTotal := 0
-	batchSize := 100
-	for offset := 0; offset < allTotal; offset += batchSize {
-		batchRepos, _, err := c.repoComponent.PublicToUser(ctx, types.SpaceRepo, repoFilter.Username, repoFilter, batchSize, offset/batchSize+1)
-		if err != nil {
-			break
-		}
-		if len(batchRepos) == 0 {
-			break
-		}
-
-		batchSpaces, err := c.convertReposToSpaces(ctx, batchRepos)
-		if err != nil {
-			break
-		}
-
-		for _, space := range batchSpaces {
-			if space.Status == repoFilter.Status {
-				filteredTotal++
-			}
-		}
-	}
-
-	return resSpaces, filteredTotal, nil
+	return resSpaces, total, nil
 }
 
 func (c *spaceComponentImpl) convertReposToSpaces(ctx context.Context, repos []*database.Repository) ([]*types.Space, error) {
@@ -665,6 +585,19 @@ func (c *spaceComponentImpl) convertReposToSpaces(ctx context.Context, repos []*
 		newError := fmt.Errorf("failed to get spaces by repo ids,error:%w", err)
 		return nil, newError
 	}
+	spaceIDs := make([]int64, 0, len(spaces))
+	for i := range spaces {
+		if spaces[i].HasAppFile {
+			spaceIDs = append(spaceIDs, spaces[i].ID)
+		}
+	}
+	latestDeploys := make(map[int64]*database.Deploy)
+	if len(spaceIDs) > 0 {
+		latestDeploys, err = c.deployTaskStore.GetLatestDeploysBySpaceIDs(ctx, spaceIDs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get latest space deploys: %w", err)
+		}
+	}
 
 	for _, repo := range repos {
 		var space *database.Space
@@ -678,7 +611,7 @@ func (c *spaceComponentImpl) convertReposToSpaces(ctx context.Context, repos []*
 		if space == nil {
 			continue
 		}
-		spaceStatus, _ := c.status(ctx, space)
+		spaceStatus := persistedSpaceStatus(space, latestDeploys[space.ID])
 
 		var tags []types.RepoTag
 		for _, tag := range space.Repository.Tags {
@@ -723,6 +656,24 @@ func (c *spaceComponentImpl) convertReposToSpaces(ctx context.Context, repos []*
 	}
 
 	return resSpaces, nil
+}
+
+func persistedSpaceStatus(space *database.Space, deploy *database.Deploy) types.SpaceStatus {
+	if !space.HasAppFile {
+		if space.Sdk == types.NGINX.Name {
+			return types.SpaceStatus{Status: SpaceStatusNoNGINXConf}
+		}
+		return types.SpaceStatus{Status: SpaceStatusNoAppFile}
+	}
+	if deploy == nil {
+		return types.SpaceStatus{Status: SpaceStatusStopped}
+	}
+	return types.SpaceStatus{
+		SvcName:   deploy.SvcName,
+		Status:    deployStatusCodeToString(deploy.Status),
+		DeployID:  deploy.ID,
+		ClusterID: deploy.ClusterID,
+	}
 }
 
 func (c *spaceComponentImpl) OrgSpaces(ctx context.Context, req *types.OrgSpacesReq) ([]types.Space, int, error) {

--- a/component/space_test.go
+++ b/component/space_test.go
@@ -331,6 +331,32 @@ func TestSpaceComponent_Index(t *testing.T) {
 
 }
 
+func TestSpaceComponent_IndexWithStatusUsesFilteredRepositoryQuery(t *testing.T) {
+	ctx := context.TODO()
+	sc := initializeTestSpaceComponent(ctx, t)
+	filter := &types.RepoFilter{Sort: "z", Username: "user", Status: SpaceStatusNoAppFile}
+	repos := []*database.Repository{
+		{ID: 123, Name: "r1", User: database.User{Username: "user"}},
+		{ID: 124, Name: "r2", User: database.User{Username: "user"}},
+	}
+	spaces := []database.Space{
+		{ID: 11, RepositoryID: 123},
+		{ID: 12, RepositoryID: 124},
+	}
+
+	sc.mocks.components.repo.EXPECT().
+		PublicToUser(ctx, types.SpaceRepo, "user", filter, 10, 1).
+		Return(repos, 2, nil)
+	sc.mocks.stores.SpaceMock().EXPECT().
+		ByRepoIDs(ctx, []int64{123, 124}).
+		Return(spaces, nil)
+
+	data, total, err := sc.Index(ctx, filter, 10, 1, false)
+	require.NoError(t, err)
+	require.Len(t, data, 2)
+	require.Equal(t, 2, total)
+}
+
 func TestSpaceComponent_Index_HalfCreatedRepos(t *testing.T) {
 	ctx := context.TODO()
 	sc := initializeTestSpaceComponent(ctx, t)


### PR DESCRIPTION
Summary:
- Capped repository list `COUNT(*)` queries to a 100-page limit using subqueries, replacing expensive full-table counts since the frontend only displays up to 100 pages.
- Pushed Space status filtering down to the database level, utilizing existing indexes and batch queries to eliminate component-level looping and sequential status fetching.
- Removed redundant `EXISTS` conditions in JOINs and prevented full Space repository traversal, significantly reducing shared buffer hits and query rounds.