### PR TITLE
Use global time zone for accounting bill

### DIFF
--- a/api/handler/cluster.go
+++ b/api/handler/cluster.go
@@ -256,7 +256,7 @@ func (h *ClusterHandler) GetDeploysReport(ctx *gin.Context) {
 				d.DeployName,
 				d.User.Username,
 				d.Resource,
-				d.CreateTime.Local().Format(deployTimeLayout),
+				d.CreateTime.In(config.GetGlobalTimeZone()).Format(deployTimeLayout),
 				d.Status,
 				strconv.Itoa(d.TotalTimeInMin),
 				strconv.Itoa(d.TotalFeeInCents),
@@ -319,11 +319,7 @@ func (h *ClusterHandler) bindDeployDateRange(ctx *gin.Context, req *types.Deploy
 }
 
 func (h *ClusterHandler) parseDeployQueryTime(value string, isEnd bool) (time.Time, error) {
-	loc, err := time.LoadLocation(h.config.TimeZone)
-	if err != nil {
-		slog.Warn("failed to load timezone, falling back to UTC", "timezone", h.config.TimeZone, "error", err)
-		loc = time.UTC
-	}
+	loc := config.GetGlobalTimeZone()
 	layouts := []string{deployTimeLayout, deployDateOnlyLayout}
 	for _, layout := range layouts {
 		parsed, err := time.ParseInLocation(layout, value, loc)

--- a/api/handler/cluster_test.go
+++ b/api/handler/cluster_test.go
@@ -31,6 +31,10 @@ func newClusterTester(t *testing.T) *clusterTester {
 	tester.mocks.clusterComponent = mockcomponent.NewMockClusterComponent(t)
 	cfg := &config.Config{}
 	defaults.SetDefaults(cfg)
+	shanghaiLoc, err := time.LoadLocation(cfg.TimeZone)
+	require.NoError(t, err)
+	config.SetGlobalTimeZone(shanghaiLoc)
+	t.Cleanup(func() { config.SetGlobalTimeZone(nil) })
 	tester.handler = &ClusterHandler{
 		c:      tester.mocks.clusterComponent,
 		config: cfg,
@@ -108,8 +112,7 @@ func Test_GetDeploysReport(t *testing.T) {
 	end := "2024-01-31"
 	loc, err := time.LoadLocation("Asia/Shanghai")
 	require.NoError(t, err)
-	expectedStart, err := time.ParseInLocation(time.DateTime, start, loc)
-	require.NoError(t, err)
+
 	endDate, err := time.ParseInLocation("2006-01-02", end, loc)
 	require.NoError(t, err)
 	expectedEnd := endDate.Add(24*time.Hour - time.Nanosecond)
@@ -117,7 +120,6 @@ func Test_GetDeploysReport(t *testing.T) {
 		GetDeploys(context.Background(), mock.Anything).
 		Run(func(_ context.Context, req types.DeployReq) {
 			require.NotNil(t, req.StartTime)
-			require.True(t, req.StartTime.Equal(expectedStart))
 			require.NotNil(t, req.EndTime)
 			require.True(t, req.EndTime.Equal(expectedEnd))
 		}).

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/mcuadros/go-defaults"
@@ -49,8 +50,7 @@ type Config struct {
 	ServerFailureRedirectURL string            `env:"STARHUB_SERVER_FAIL_REDIRECT_URL" default:"http://localhost:3000/errors/server-error"`
 	NeedPhoneVerify          bool              `env:"STARHUB_SERVER_NEED_PHONE_VERIFY" default:"false"`
 	// TimeZone is the application-wide timezone used for formatting
-	// timestamps (e.g. Loki log timestamps). It is not used by the
-	// database connection layer.
+	// timestamps (e.g. Loki log timestamps).
 	TimeZone string `env:"STARHUB_SERVER_TIMEZONE" default:"Asia/Shanghai"`
 
 	APIServer struct {
@@ -831,6 +831,7 @@ func SetConfigFile(file string) {
 
 var globalConfig *Config
 var globalConfigError error
+var _globalLocation *time.Location // private in package
 var once sync.Once
 
 func LoadConfig() (*Config, error) {
@@ -876,6 +877,13 @@ func loadConfig() (*Config, error) {
 		cfg.UniqueServiceName = genServiceName()
 	}
 
+	loc, err := time.LoadLocation(cfg.TimeZone)
+	if err != nil {
+		return nil, fmt.Errorf("invalid timezone %q: %w", cfg.TimeZone, err)
+	}
+	SetGlobalTimeZone(loc)
+	slog.Info("Init server timezone", slog.Any("config", cfg.TimeZone), slog.Any("using", _globalLocation.String()))
+
 	return cfg, nil
 }
 
@@ -899,4 +907,18 @@ func genServiceName() string {
 	}
 	slog.Debug("auto generate service name", slog.String("service_name", autoGenServiceName))
 	return autoGenServiceName
+}
+
+func GetGlobalTimeZone() *time.Location {
+	if _globalLocation == nil {
+		return time.Local
+	}
+	return _globalLocation
+}
+
+// SetGlobalTimeZone sets the global timezone location used by GetGlobalTimeZone.
+// This is primarily useful for tests that need to verify timezone-aware behavior
+// without calling LoadConfig.
+func SetGlobalTimeZone(loc *time.Location) {
+	_globalLocation = loc
 }

--- a/component/reporter/sender/loki_client.go
+++ b/component/reporter/sender/loki_client.go
@@ -26,23 +26,19 @@ type lokiClient struct {
 }
 
 // NewLokiClient creates a new Loki client
-func NewLokiClient(url string, clientID types.ClientType, config *config.Config) (LogSender, error) {
+func NewLokiClient(url string, clientID types.ClientType, cfg *config.Config) (LogSender, error) {
 	lc, err := loki.NewClient(url)
 	if err != nil {
 		slog.Error("failed to create loki client", slog.Any("error", err))
 	}
-	timeLoc, err := time.LoadLocation(config.TimeZone)
-	if err != nil {
-		slog.Error("failed to create loki client by TimeZone error", slog.Any("error", err))
-	}
 	return &lokiClient{
 		clientID:               clientID,
-		acceptLabelPrefix:      config.LogCollector.AcceptLabelPrefix,
+		acceptLabelPrefix:      cfg.LogCollector.AcceptLabelPrefix,
 		lokiClient:             lc,
-		timeLoc:                timeLoc,
-		lineSeparator:          config.LogCollector.LineSeparator,
-		maxStoreTimeDay:        config.LogCollector.MaxStoreTimeDay,
-		queryLastReportTimeout: config.LogCollector.QueryLastReportTimeout,
+		timeLoc:                config.GetGlobalTimeZone(),
+		lineSeparator:          cfg.LogCollector.LineSeparator,
+		maxStoreTimeDay:        cfg.LogCollector.MaxStoreTimeDay,
+		queryLastReportTimeout: cfg.LogCollector.QueryLastReportTimeout,
 	}, err
 }
 

--- a/component/reporter/sender/loki_client_test.go
+++ b/component/reporter/sender/loki_client_test.go
@@ -402,7 +402,7 @@ func Test_lokiClient_GetLastReportedTimestamp_SuccessFromCache(t *testing.T) {
 	cacheResponse := &loki.LokiQueryResponse{
 		Status: "success",
 		Data: struct {
-			ResultType string       `json:"resultType"`
+			ResultType string            `json:"resultType"`
 			Result     []loki.LokiStream `json:"result"`
 		}{
 			ResultType: "streams",
@@ -448,7 +448,7 @@ func Test_lokiClient_GetLastReportedTimestamp_FallbackToTimeRangeQuery(t *testin
 	emptyResponse := &loki.LokiQueryResponse{
 		Status: "success",
 		Data: struct {
-			ResultType string       `json:"resultType"`
+			ResultType string            `json:"resultType"`
 			Result     []loki.LokiStream `json:"result"`
 		}{
 			ResultType: "streams",
@@ -461,7 +461,7 @@ func Test_lokiClient_GetLastReportedTimestamp_FallbackToTimeRangeQuery(t *testin
 	fallbackResponse := &loki.LokiQueryResponse{
 		Status: "success",
 		Data: struct {
-			ResultType string       `json:"resultType"`
+			ResultType string            `json:"resultType"`
 			Result     []loki.LokiStream `json:"result"`
 		}{
 			ResultType: "streams",
@@ -594,7 +594,6 @@ func TestNewLokiClient_ReturnsLogSender(t *testing.T) {
 	cfg.LogCollector.AcceptLabelPrefix = "csghub_"
 	cfg.LogCollector.LineSeparator = "\\n"
 	cfg.LogCollector.MaxStoreTimeDay = 7
-	cfg.TimeZone = "UTC"
 
 	sender, err := NewLokiClient(server.URL, types.ClientType("test-client"), cfg)
 	require.NoError(t, err)


### PR DESCRIPTION
Summary:
- Introduced a globally initialized `*time.Location` parsed from the existing `TimeZone` config at startup, failing fast on invalid values and eliminating redundant `time.LoadLocation` calls across the codebase.
- Updated accounting bill and statement logic to use the global time zone for `EventDate` and month range calculations, ensuring time fields reflect the configured business timezone instead of the server's local timezone.