### PR TITLE
Remove remark from license search

### DIFF
--- a/builder/store/database/license.go
+++ b/builder/store/database/license.go
@@ -63,8 +63,10 @@ func (s *licenseStoreImpl) List(ctx context.Context, req types.QueryLicenseReq) 
 	}
 
 	if req.Search != "" {
-		query = query.Where("company LIKE ? OR email LIKE ? OR remark LIKE ?",
-			fmt.Sprintf("%%%s%%", req.Search),
+		// Issue #2495: remark is not shown in the admin license list, so
+		// matching it (e.g. "pp" matching "approve" in a remark) is confusing.
+		// Narrow search to the visible columns company and email only.
+		query = query.Where("company LIKE ? OR email LIKE ?",
 			fmt.Sprintf("%%%s%%", req.Search),
 			fmt.Sprintf("%%%s%%", req.Search))
 	}

--- a/builder/store/database/license_test.go
+++ b/builder/store/database/license_test.go
@@ -117,6 +117,13 @@ func TestLicenseStore_List(t *testing.T) {
 			req:      types.QueryLicenseReq{Search: "bar", Edition: "e2"},
 			expected: []string{"k4"},
 		},
+		{
+			// Issue #2495: "pp" only appears in k5's remark ("approved by bob"),
+			// not in company/email. After narrowing search to company+email,
+			// remark is no longer matched, so this returns nothing.
+			req:      types.QueryLicenseReq{Search: "pp"},
+			expected: []string{},
+		},
 	}
 
 	for _, c := range cases {
@@ -160,6 +167,16 @@ func TestLicenseStore_List(t *testing.T) {
 					MaxUser: 40, StartTime: time.Now(),
 					ExpireTime: time.Now().Add(time.Hour),
 					UserUUID:   "user4",
+				},
+				{
+					// Issue #2495: remark uniquely contains "pp" (in "approved"),
+					// while company/email do not — proves remark is no longer searched.
+					Key: "k5", Product: "p4",
+					Edition: "e3", Company: "acme",
+					Email: "admin@acme.com", Remark: "approved by bob",
+					MaxUser: 50, StartTime: time.Now(),
+					ExpireTime: time.Now().Add(time.Hour),
+					UserUUID: "user5",
 				},
 			}
 			for _, l := range ls {


### PR DESCRIPTION
Summary:
- Removed `remark` field matching from the license search functionality
- Resolves the issue where licenses were matched by `remark` despite the field not being displayed in search results