### PR TITLE
feat(agent): gate templates by sensitive check

### DIFF
--- a/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoFileCheckStore.go
+++ b/_mocks/opencsg.com/csghub-server/builder/store/database/mock_RepoFileCheckStore.go
@@ -69,6 +69,66 @@ func (_c *MockRepoFileCheckStore_Create_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
+// ListSensitiveCheckDetails provides a mock function with given fields: ctx, repoID, branch
+func (_m *MockRepoFileCheckStore) ListSensitiveCheckDetails(ctx context.Context, repoID int64, branch string) ([]database.RepositoryFileCheckDetail, error) {
+	ret := _m.Called(ctx, repoID, branch)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListSensitiveCheckDetails")
+	}
+
+	var r0 []database.RepositoryFileCheckDetail
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string) ([]database.RepositoryFileCheckDetail, error)); ok {
+		return rf(ctx, repoID, branch)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string) []database.RepositoryFileCheckDetail); ok {
+		r0 = rf(ctx, repoID, branch)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.RepositoryFileCheckDetail)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int64, string) error); ok {
+		r1 = rf(ctx, repoID, branch)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockRepoFileCheckStore_ListSensitiveCheckDetails_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSensitiveCheckDetails'
+type MockRepoFileCheckStore_ListSensitiveCheckDetails_Call struct {
+	*mock.Call
+}
+
+// ListSensitiveCheckDetails is a helper method to define mock.On call
+//   - ctx context.Context
+//   - repoID int64
+//   - branch string
+func (_e *MockRepoFileCheckStore_Expecter) ListSensitiveCheckDetails(ctx interface{}, repoID interface{}, branch interface{}) *MockRepoFileCheckStore_ListSensitiveCheckDetails_Call {
+	return &MockRepoFileCheckStore_ListSensitiveCheckDetails_Call{Call: _e.mock.On("ListSensitiveCheckDetails", ctx, repoID, branch)}
+}
+
+func (_c *MockRepoFileCheckStore_ListSensitiveCheckDetails_Call) Run(run func(ctx context.Context, repoID int64, branch string)) *MockRepoFileCheckStore_ListSensitiveCheckDetails_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockRepoFileCheckStore_ListSensitiveCheckDetails_Call) Return(_a0 []database.RepositoryFileCheckDetail, _a1 error) *MockRepoFileCheckStore_ListSensitiveCheckDetails_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockRepoFileCheckStore_ListSensitiveCheckDetails_Call) RunAndReturn(run func(context.Context, int64, string) ([]database.RepositoryFileCheckDetail, error)) *MockRepoFileCheckStore_ListSensitiveCheckDetails_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Upsert provides a mock function with given fields: ctx, history
 func (_m *MockRepoFileCheckStore) Upsert(ctx context.Context, history database.RepositoryFileCheck) error {
 	ret := _m.Called(ctx, history)

--- a/api/middleware/i18n_test.go
+++ b/api/middleware/i18n_test.go
@@ -92,6 +92,18 @@ func TestLocalizedErrorMiddleware(t *testing.T) {
 			errorx.Ctx().Set("source_namespace", "SourceTeam"),
 		))
 	})
+	router.GET("/agent-template-sensitive-check-create", func(c *gin.Context) {
+		httpbase.ConflictError(c, errorx.AgentTemplateSensitiveCheckCreateAgentBlocked(
+			nil,
+			errorx.Ctx().Set("sensitive_check_status", "Fail"),
+		))
+	})
+	router.GET("/agent-template-sensitive-check-make-public", func(c *gin.Context) {
+		httpbase.ConflictError(c, errorx.AgentTemplateSensitiveCheckMakePublicBlocked(
+			nil,
+			errorx.Ctx().Set("sensitive_check_status", "Fail"),
+		))
+	})
 
 	// Run tests
 	t.Run("SkipRoute", func(t *testing.T) {
@@ -226,6 +238,32 @@ func TestLocalizedErrorMiddleware(t *testing.T) {
 		var resp httpbase.R
 		_ = json.Unmarshal(w.Body.Bytes(), &resp)
 		assert.Equal(t, "MIRROR-ERR-7: 源命名空间映射关系不存在。", resp.Msg)
+	})
+
+	t.Run("LocalizedAgentTemplateSensitiveCheckCreate", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/agent-template-sensitive-check-create", nil)
+		req.Header.Set("Accept-Language", "zh-CN")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code)
+		var resp httpbase.R
+		_ = json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.Equal(t, "AGENT-ERR-23: 该智能体模板未通过敏感内容检查，无法创建智能体。", resp.Msg)
+		assert.Equal(t, "Fail", resp.Context["sensitive_check_status"])
+	})
+
+	t.Run("LocalizedAgentTemplateSensitiveCheckMakePublic", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/agent-template-sensitive-check-make-public", nil)
+		req.Header.Set("Accept-Language", "zh-CN")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code)
+		var resp httpbase.R
+		_ = json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.Equal(t, "AGENT-ERR-24: 该智能体模板未通过敏感内容检查，无法设为公开。", resp.Msg)
+		assert.Equal(t, "Fail", resp.Context["sensitive_check_status"])
 	})
 }
 

--- a/builder/store/database/repository_file_check.go
+++ b/builder/store/database/repository_file_check.go
@@ -18,6 +18,12 @@ type RepositoryFileCheck struct {
 	TaskID string `bun:",nullzero" json:"task_id"`
 }
 
+type RepositoryFileCheckDetail struct {
+	Path    string
+	Status  types.SensitiveCheckStatus
+	Message string
+}
+
 type repoFileCheckStoreImpl struct {
 	db *DB
 }
@@ -25,6 +31,7 @@ type repoFileCheckStoreImpl struct {
 type RepoFileCheckStore interface {
 	Create(ctx context.Context, history RepositoryFileCheck) error
 	Upsert(ctx context.Context, history RepositoryFileCheck) error
+	ListSensitiveCheckDetails(ctx context.Context, repoID int64, branch string) ([]RepositoryFileCheckDetail, error)
 }
 
 func NewRepoFileCheckStore() RepoFileCheckStore {
@@ -49,4 +56,20 @@ func (s *repoFileCheckStoreImpl) Upsert(ctx context.Context, history RepositoryF
 		On("CONFLICT (repo_file_id) DO UPDATE").
 		Exec(ctx)
 	return err
+}
+
+func (s *repoFileCheckStoreImpl) ListSensitiveCheckDetails(ctx context.Context, repoID int64, branch string) ([]RepositoryFileCheckDetail, error) {
+	var details []RepositoryFileCheckDetail
+	err := s.db.Operator.Core.NewSelect().
+		ColumnExpr("rf.path AS path").
+		ColumnExpr("rfc.status AS status").
+		ColumnExpr("rfc.message AS message").
+		TableExpr("repository_file_checks AS rfc").
+		Join("INNER JOIN repository_files AS rf ON rf.id = rfc.repo_file_id").
+		Where("rf.repository_id = ? AND rf.branch = ?", repoID, branch).
+		Where("rfc.status IN (?, ?)", types.SensitiveCheckFail, types.SensitiveCheckException).
+		Where("rfc.message <> ''").
+		OrderExpr("rf.path ASC").
+		Scan(ctx, &details)
+	return details, err
 }

--- a/common/errorx/error_agent.go
+++ b/common/errorx/error_agent.go
@@ -26,6 +26,8 @@ const (
 	agentProvisionRequestFieldEmpty
 	agentProvisionRequestModelUnavailable
 	csgclawTemplateNotFound
+	agentTemplateSensitiveCheckCreateAgentBlocked
+	agentTemplateSensitiveCheckMakePublicBlocked
 )
 
 var (
@@ -327,6 +329,12 @@ var (
 	//
 	// zh-HK: 倉庫路徑 {{.repo_path}} 未找到對應的 csgclaw 模板
 	ErrCSGClawTemplateNotFound error = CustomError{prefix: errAgentPrefix, code: csgclawTemplateNotFound}
+
+	// agent template sensitive check blocks creating an agent
+	ErrAgentTemplateSensitiveCheckCreateAgentBlocked error = CustomError{prefix: errAgentPrefix, code: agentTemplateSensitiveCheckCreateAgentBlocked}
+
+	// agent template sensitive check blocks making a template public
+	ErrAgentTemplateSensitiveCheckMakePublicBlocked error = CustomError{prefix: errAgentPrefix, code: agentTemplateSensitiveCheckMakePublicBlocked}
 )
 
 func InstanceQuotaExceeded(err error, ctx context) error {
@@ -511,5 +519,23 @@ func CSGClawTemplateNotFound(err error, ctx context) error {
 		context: ctx,
 		err:     err,
 		code:    int(csgclawTemplateNotFound),
+	}
+}
+
+func AgentTemplateSensitiveCheckCreateAgentBlocked(err error, ctx context) error {
+	return CustomError{
+		prefix:  errAgentPrefix,
+		context: ctx,
+		err:     err,
+		code:    int(agentTemplateSensitiveCheckCreateAgentBlocked),
+	}
+}
+
+func AgentTemplateSensitiveCheckMakePublicBlocked(err error, ctx context) error {
+	return CustomError{
+		prefix:  errAgentPrefix,
+		context: ctx,
+		err:     err,
+		code:    int(agentTemplateSensitiveCheckMakePublicBlocked),
 	}
 }

--- a/common/i18n/en-US/err_agent.json
+++ b/common/i18n/en-US/err_agent.json
@@ -67,5 +67,11 @@
     },
     "error.AGENT-ERR-22": {
         "other": "csgclaw template not found for repository path {{.repo_path}}"
+    },
+    "error.AGENT-ERR-23": {
+        "other": "Cannot create an agent from this agent template because it has not passed the sensitive-content check."
+    },
+    "error.AGENT-ERR-24": {
+        "other": "Cannot make this agent template public because it has not passed the sensitive-content check."
     }
 }

--- a/common/i18n/zh-CN/err_agent.json
+++ b/common/i18n/zh-CN/err_agent.json
@@ -67,5 +67,11 @@
     },
     "error.AGENT-ERR-22": {
         "other": "仓库路径 {{.repo_path}} 未找到对应的 csgclaw 模板"
+    },
+    "error.AGENT-ERR-23": {
+        "other": "该智能体模板未通过敏感内容检查，无法创建智能体。"
+    },
+    "error.AGENT-ERR-24": {
+        "other": "该智能体模板未通过敏感内容检查，无法设为公开。"
     }
 }

--- a/common/i18n/zh-HK/err_agent.json
+++ b/common/i18n/zh-HK/err_agent.json
@@ -67,5 +67,11 @@
     },
     "error.AGENT-ERR-22": {
         "other": "倉庫路徑 {{.repo_path}} 未找到對應的 csgclaw 模板"
+    },
+    "error.AGENT-ERR-23": {
+        "other": "該智能體模板未通過敏感內容檢查，無法建立智能體。"
+    },
+    "error.AGENT-ERR-24": {
+        "other": "該智能體模板未通過敏感內容檢查，無法設為公開。"
     }
 }

--- a/common/types/agent.go
+++ b/common/types/agent.go
@@ -60,6 +60,17 @@ type AgentTemplateFilter struct {
 	Editable *bool
 }
 
+// UpdateAgentTemplateRequest is a partial update for an agent template.
+// Name and type are optional so a visibility-only update does not modify them.
+type UpdateAgentTemplateRequest struct {
+	Type        *string         `json:"type,omitempty"`
+	Name        *string         `json:"name,omitempty" binding:"omitempty,max=255"`
+	Description *string         `json:"description,omitempty" binding:"omitempty,max=500"`
+	Content     *string         `json:"content,omitempty"`
+	Public      *bool           `json:"public,omitempty"`
+	Metadata    *map[string]any `json:"metadata,omitempty"`
+}
+
 // AgentInstance represents an instance created from an agent template
 type AgentInstance struct {
 	ID          int64           `json:"id"`

--- a/component/agent_template_sensitive_check_ce.go
+++ b/component/agent_template_sensitive_check_ce.go
@@ -1,0 +1,13 @@
+//go:build !ee && !saas
+
+package component
+
+import (
+	"context"
+
+	"opencsg.com/csghub-server/builder/store/database"
+)
+
+func SyncAgentTemplateSensitiveCheckResult(context.Context, *database.Repository, database.AgentTemplateStore, database.RepoFileCheckStore) error {
+	return nil
+}

--- a/component/callback/git_callback.go
+++ b/component/callback/git_callback.go
@@ -277,16 +277,19 @@ func (c *gitCallbackComponentImpl) SyncRepositoryPackage(ctx context.Context, re
 }
 
 func (c *gitCallbackComponentImpl) SensitiveCheck(ctx context.Context, req *types.GiteaCallbackPushReq) error {
+	if c.modSvcClient == nil {
+		return nil
+	}
 	// split req.Repository.FullName by '/'
 	splits := strings.Split(req.Repository.FullName, "/")
+	if len(splits) != 2 {
+		return fmt.Errorf("invalid callback repo full name for sensitive check: %s", req.Repository.FullName)
+	}
 	fullNamespace, repoName := splits[0], splits[1]
 	repoType, namespace, _ := strings.Cut(fullNamespace, "_")
 	adjustedRepoType := types.RepositoryType(strings.TrimRight(repoType, "s"))
 
-	var err error
-	if c.modSvcClient != nil {
-		err = c.modSvcClient.SubmitRepoCheck(ctx, adjustedRepoType, namespace, repoName)
-	}
+	err := c.modSvcClient.SubmitRepoCheck(ctx, adjustedRepoType, namespace, repoName)
 	if err != nil {
 		slog.Error("fail to submit repo sensitive check", slog.Any("error", err), slog.Any("repo_type", adjustedRepoType), slog.String("namespace", namespace), slog.String("name", repoName))
 		return err

--- a/moderation/component/interfaces.go
+++ b/moderation/component/interfaces.go
@@ -19,7 +19,7 @@ type RepoComponent interface {
 type RepoFileComponent interface {
 	GenRepoFileRecords(ctx context.Context, repo *database.Repository) error
 	GenRepoFileRecordsBatch(ctx context.Context, repoType types.RepositoryType, lastRepoID int64, concurrency int) error
-	DetectRepoSensitiveCheckStatus(ctx context.Context, repoId int64, branch string) error
+	DetectRepoSensitiveCheckStatus(ctx context.Context, repoId int64, branch string) (types.SensitiveCheckStatus, error)
 }
 
 type SensitiveWordSetComponent interface {

--- a/moderation/component/repo_file.go
+++ b/moderation/component/repo_file.go
@@ -153,25 +153,26 @@ func (c *repoFileComponentImpl) createRepoFileRecords(ctx context.Context, repo 
 	return nil
 }
 
-func (c *repoFileComponentImpl) DetectRepoSensitiveCheckStatus(ctx context.Context, repoId int64, branch string) error {
+func (c *repoFileComponentImpl) DetectRepoSensitiveCheckStatus(ctx context.Context, repoId int64, branch string) (types.SensitiveCheckStatus, error) {
 	status := types.SensitiveCheckFail
 	exists, err := c.rfs.ExistsSensitiveCheckRecord(ctx, repoId, branch, types.SensitiveCheckFail)
 	if err != nil {
-		return fmt.Errorf("failed to check repo file sensitive check record exists, error: %w", err)
+		return status, fmt.Errorf("failed to check repo file sensitive check record exists, error: %w", err)
 	}
 	if exists {
 		err = c.rs.UpdateRepoSensitiveCheckStatus(ctx, repoId, status)
-		return err
+		return status, err
 	}
 
 	status = types.SensitiveCheckException
 	exists, err = c.rfs.ExistsSensitiveCheckRecord(ctx, repoId, branch, types.SensitiveCheckException)
 	if err != nil {
-		return fmt.Errorf("failed to check repo file sensitive check record exists, error: %w", err)
+		return status, fmt.Errorf("failed to check repo file sensitive check record exists, error: %w", err)
 	}
 	if exists {
-		return c.rs.UpdateRepoSensitiveCheckStatus(ctx, repoId, status)
+		return status, c.rs.UpdateRepoSensitiveCheckStatus(ctx, repoId, status)
 	}
 
-	return c.rs.UpdateRepoSensitiveCheckStatus(ctx, repoId, types.SensitiveCheckPass)
+	status = types.SensitiveCheckPass
+	return status, c.rs.UpdateRepoSensitiveCheckStatus(ctx, repoId, status)
 }

--- a/moderation/component/repo_file_test.go
+++ b/moderation/component/repo_file_test.go
@@ -89,10 +89,11 @@ func TestRepoFileComponent_DetectRepoSensitiveCheckStatus(t *testing.T) {
 		mockRepoStore.EXPECT().UpdateRepoSensitiveCheckStatus(mock.Anything, repo.ID, types.SensitiveCheckFail).Return(nil)
 
 		// Call method
-		err := componentImpl.DetectRepoSensitiveCheckStatus(ctx, repo.ID, repo.DefaultBranch)
+		status, err := componentImpl.DetectRepoSensitiveCheckStatus(ctx, repo.ID, repo.DefaultBranch)
 
 		// Assertions
 		require.NoError(t, err)
+		require.Equal(t, types.SensitiveCheckFail, status)
 	})
 	t.Run("check exception", func(t *testing.T) {
 		// Prepare mocks
@@ -125,10 +126,11 @@ func TestRepoFileComponent_DetectRepoSensitiveCheckStatus(t *testing.T) {
 		mockRepoStore.EXPECT().UpdateRepoSensitiveCheckStatus(mock.Anything, repo.ID, types.SensitiveCheckException).Return(nil)
 
 		// Call method
-		err := componentImpl.DetectRepoSensitiveCheckStatus(ctx, repo.ID, repo.DefaultBranch)
+		status, err := componentImpl.DetectRepoSensitiveCheckStatus(ctx, repo.ID, repo.DefaultBranch)
 
 		// Assertions
 		require.NoError(t, err)
+		require.Equal(t, types.SensitiveCheckException, status)
 	})
 	t.Run("check success", func(t *testing.T) {
 		// Prepare mocks
@@ -159,10 +161,11 @@ func TestRepoFileComponent_DetectRepoSensitiveCheckStatus(t *testing.T) {
 		mockRepoStore.EXPECT().UpdateRepoSensitiveCheckStatus(mock.Anything, repo.ID, types.SensitiveCheckPass).Return(nil)
 
 		// Call method
-		err := componentImpl.DetectRepoSensitiveCheckStatus(ctx, repo.ID, repo.DefaultBranch)
+		status, err := componentImpl.DetectRepoSensitiveCheckStatus(ctx, repo.ID, repo.DefaultBranch)
 
 		// Assertions
 		require.NoError(t, err)
+		require.Equal(t, types.SensitiveCheckPass, status)
 
 	})
 }

--- a/moderation/workflow/activity/repo.go
+++ b/moderation/workflow/activity/repo.go
@@ -3,11 +3,13 @@ package activity
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"go.temporal.io/sdk/activity"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/config"
 	"opencsg.com/csghub-server/common/types"
+	servercomponent "opencsg.com/csghub-server/component"
 	"opencsg.com/csghub-server/moderation/component"
 )
 
@@ -49,7 +51,14 @@ func RepoSensitiveCheckPending(ctx context.Context, repo *database.Repository, c
 	if err != nil {
 		return fmt.Errorf("failed to create repo component, error: %w", err)
 	}
-	return rc.UpdateRepoSensitiveCheckStatus(ctx, repo.ID, types.SensitiveCheckPending)
+	if err := rc.UpdateRepoSensitiveCheckStatus(ctx, repo.ID, types.SensitiveCheckPending); err != nil {
+		return err
+	}
+	repo.SensitiveCheckStatus = types.SensitiveCheckPending
+	if err := servercomponent.SyncAgentTemplateSensitiveCheckResult(ctx, repo, database.NewAgentTemplateStore(), database.NewRepoFileCheckStore()); err != nil {
+		slog.WarnContext(ctx, "failed to sync agent template sensitive check pending status", "error", err, "repo_path", repo.Path)
+	}
+	return nil
 }
 
 func DetectRepoSensitiveCheckStatus(ctx context.Context, repo *database.Repository, config *config.Config) error {
@@ -60,5 +69,13 @@ func DetectRepoSensitiveCheckStatus(ctx context.Context, repo *database.Reposito
 		return fmt.Errorf("failed to create repo file component, error: %w", err)
 	}
 	// TODO: handle other branches
-	return rfc.DetectRepoSensitiveCheckStatus(ctx, repo.ID, repo.DefaultBranch)
+	status, err := rfc.DetectRepoSensitiveCheckStatus(ctx, repo.ID, repo.DefaultBranch)
+	if err != nil {
+		return err
+	}
+	repo.SensitiveCheckStatus = status
+	if err := servercomponent.SyncAgentTemplateSensitiveCheckResult(ctx, repo, database.NewAgentTemplateStore(), database.NewRepoFileCheckStore()); err != nil {
+		slog.WarnContext(ctx, "failed to sync agent template sensitive check result", "error", err, "repo_path", repo.Path)
+	}
+	return nil
 }


### PR DESCRIPTION
Summary:
- Syncs repository sensitive content check status and failure details to the associated CSGClaw agent template metadata.
- Blocks agent creation and public visibility updates for templates that fail, are in progress, or encounter errors during sensitive checks (returning localized HTTP 409 responses).
- Maintains backward compatibility by allowing templates without sensitive check metadata to continue operating normally.