### PR TITLE
Lost node list in create finetune job request

### DIFF
--- a/builder/deploy/deployer.go
+++ b/builder/deploy/deployer.go
@@ -1169,6 +1169,7 @@ func (d *deployer) SubmitFinetuneJob(ctx context.Context, req types.FinetuneReq)
 		ResourceId:         req.ResourceId,
 		ResourceName:       req.ResourceName,
 		FinetunedModelName: finetunedModelName,
+		Nodes:              req.Nodes,
 		Scheduler:          common.GenerateScheduler(cluster.VXPUConfig),
 		DeployExtend: types.DeployExtend{
 			NodeAffinity: req.NodeAffinity,
@@ -1177,19 +1178,6 @@ func (d *deployer) SubmitFinetuneJob(ctx context.Context, req types.FinetuneReq)
 	}
 	if req.ResourceId == 0 {
 		flowReq.ShareMode = true
-	}
-
-	clusterNodes, err := d.clusterStore.FindNodeByClusterID(ctx, req.ClusterID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find nodes by cluster id, clusterID: %s, error: %w", req.ClusterID, err)
-	}
-
-	for _, node := range clusterNodes {
-		req.Nodes = append(req.Nodes, types.Node{
-			Name:       node.Name,
-			EnableVXPU: node.EnableVXPU,
-			HasXPU:     node.Hardware.HasXPU() || node.EnableVXPU,
-		})
 	}
 
 	slog.Debug("submit finetune workflow request to runner", slog.Any("flowReq", flowReq))

--- a/builder/deploy/deployer_test.go
+++ b/builder/deploy/deployer_test.go
@@ -969,12 +969,6 @@ func TestDeployer_SubmitFinetune(t *testing.T) {
 		},
 	)
 
-	tester.mocks.stores.ClusterInfoMock().EXPECT().FindNodeByClusterID(ctx, "").Return([]database.ClusterNode{
-		{
-			Name: "node1",
-		},
-	}, nil)
-
 	resp, err := tester.SubmitFinetuneJob(ctx, types.FinetuneReq{
 		ModelId:          "m1",
 		DatasetId:        "d1",

--- a/component/finetune.go
+++ b/component/finetune.go
@@ -187,6 +187,19 @@ func (c *finetuneComponentImpl) CreateFinetuneJob(ctx context.Context, req types
 		// req.ResourceName = resource
 	}
 
+	clusterNodes, err := c.clusterStore.FindNodeByClusterID(ctx, req.ClusterID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find nodes by cluster id, clusterID: %s, error: %w", req.ClusterID, err)
+	}
+
+	for _, node := range clusterNodes {
+		req.Nodes = append(req.Nodes, types.Node{
+			Name:       node.Name,
+			EnableVXPU: node.EnableVXPU,
+			HasXPU:     node.Hardware.HasXPU() || node.EnableVXPU,
+		})
+	}
+
 	req.Hardware = hardware
 	// choose image
 	containerImg := frame.FrameImage

--- a/component/finetune_test.go
+++ b/component/finetune_test.go
@@ -30,7 +30,7 @@ func NewTestFinetuneComponent(config *config.Config,
 	repoStore database.RepoStore, frameStore database.RuntimeFrameworksStore,
 	argoStore database.ArgoWorkFlowStore,
 	acctComp AccountingComponent, repoComp RepoComponent, deployTaskStore database.DeployTaskStore,
-	userSvcClient rpc.UserSvcClient) FinetuneComponent {
+	userSvcClient rpc.UserSvcClient, clusterStore database.ClusterInfoStore) FinetuneComponent {
 	c := &finetuneComponentImpl{}
 	c.deployer = deployer
 	c.userStore = userStore
@@ -47,6 +47,7 @@ func NewTestFinetuneComponent(config *config.Config,
 	c.repoComponent = repoComp
 	c.accountingComponent = acctComp
 	c.userSvcClient = userSvcClient
+	c.clusterStore = clusterStore
 	return c
 }
 
@@ -79,6 +80,7 @@ func TestEvaluationComponent_CreateFinetune(t *testing.T) {
 	argoStore := mockdb.NewMockArgoWorkFlowStore(t)
 	acctComp := mockComps.NewMockAccountingComponent(t)
 	repoComp := mockComps.NewMockRepoComponent(t)
+	clusterStore := mockdb.NewMockClusterInfoStore(t)
 
 	req2 := types.FinetuneReq{
 		UserUUID:           "testuser",
@@ -106,13 +108,14 @@ func TestEvaluationComponent_CreateFinetune(t *testing.T) {
 		Epochs:          3,
 		Revision:        "main",
 		DatasetRevision: "main",
+		Nodes:           []types.Node{{Name: "node1", EnableVXPU: false, HasXPU: false}},
 	}
 
 	resource, err := json.Marshal(req2.Hardware)
 	require.Nil(t, err)
 
 	c := NewTestFinetuneComponent(cfg, mockDeployer, mockUser, modelStore, spaceResStore, datasetStore, mirrorStore,
-		tokenStore, repoStore, frameStore, argoStore, acctComp, repoComp, nil, nil)
+		tokenStore, repoStore, frameStore, argoStore, acctComp, repoComp, nil, nil, clusterStore)
 
 	mockUser.EXPECT().FindByUsername(ctx, req.Username).Return(database.User{
 		Username: req.Username,
@@ -146,6 +149,10 @@ func TestEvaluationComponent_CreateFinetune(t *testing.T) {
 
 	repoComp.EXPECT().GetNamespaceBillingUUID(ctx, "testuser").Return("testuser", nil)
 	repoComp.EXPECT().CheckAccountAndResource(ctx, types.CheckResourceAndAccountReq{UserName: "testuser", ClusterID: "cluster-1", OrderDetailID: 0, CurrentUser: "testuser"}, mock.Anything).Return(&types.CheckExclusiveResp{}, nil)
+
+	clusterStore.EXPECT().FindNodeByClusterID(ctx, "cluster-1").Return([]database.ClusterNode{
+		{Name: "node1"},
+	}, nil)
 
 	req2.ResourceName = "1 GPU · 4 vCPU · 32Gi"
 	req2.ClusterID = "cluster-1"
@@ -188,7 +195,7 @@ func TestFinetuneComponent_CreateFinetuneJob_UsesRequestedDatasetRevision(t *tes
 	repoComp := mockComps.NewMockRepoComponent(t)
 
 	c := NewTestFinetuneComponent(cfg, mockDeployer, mockUser, modelStore, spaceResStore, datasetStore, mirrorStore,
-		tokenStore, repoStore, frameStore, argoStore, acctComp, repoComp, nil, nil)
+		tokenStore, repoStore, frameStore, argoStore, acctComp, repoComp, nil, nil, nil)
 
 	mockUser.EXPECT().FindByUsername(ctx, req.Username).Return(database.User{
 		Username: req.Username,
@@ -252,7 +259,7 @@ func TestFinetuneComponent_CreateFinetuneJob_NonAdminNamespace(t *testing.T) {
 
 	t.Run("namespace_permission_error", func(t *testing.T) {
 		c := NewTestFinetuneComponent(cfg, mockDeployer, mockUser, modelStore, spaceResStore, datasetStore, mirrorStore,
-			tokenStore, repoStore, frameStore, argoStore, acctComp, repoComp, nil, nil)
+			tokenStore, repoStore, frameStore, argoStore, acctComp, repoComp, nil, nil, nil)
 		mockUser.EXPECT().FindByUsername(ctx, req.Username).Return(database.User{
 			Username: req.Username,
 			UUID:     req.Username,
@@ -266,7 +273,7 @@ func TestFinetuneComponent_CreateFinetuneJob_NonAdminNamespace(t *testing.T) {
 	})
 	t.Run("namespace_forbidden", func(t *testing.T) {
 		c := NewTestFinetuneComponent(cfg, mockDeployer, mockUser, modelStore, spaceResStore, datasetStore, mirrorStore,
-			tokenStore, repoStore, frameStore, argoStore, acctComp, repoComp, nil, nil)
+			tokenStore, repoStore, frameStore, argoStore, acctComp, repoComp, nil, nil, nil)
 		mockUser.EXPECT().FindByUsername(ctx, req.Username).Return(database.User{
 			Username: req.Username,
 			UUID:     req.Username,
@@ -305,7 +312,7 @@ func TestEvaluationComponent_GetFinetune(t *testing.T) {
 	}
 
 	c := NewTestFinetuneComponent(cfg, mockDeployer, mockUser, modelStore, spaceResStore, datasetStore, mirrorStore,
-		tokenStore, repoStore, frameStore, argoStore, acctComp, repoComp, nil, nil)
+		tokenStore, repoStore, frameStore, argoStore, acctComp, repoComp, nil, nil, nil)
 
 	argoStore.EXPECT().FindByID(ctx, int64(1)).Return(database.ArgoWorkflow{
 		ID:       1,
@@ -339,7 +346,7 @@ func TestEvaluationComponent_DeleteFinetune(t *testing.T) {
 	repoComp := mockComps.NewMockRepoComponent(t)
 
 	c := NewTestFinetuneComponent(cfg, mockDeployer, mockUser, modelStore, spaceResStore, datasetStore, mirrorStore,
-		tokenStore, repoStore, frameStore, argoStore, acctComp, repoComp, nil, nil)
+		tokenStore, repoStore, frameStore, argoStore, acctComp, repoComp, nil, nil, nil)
 
 	argoStore.EXPECT().FindByID(ctx, int64(1)).Return(database.ArgoWorkflow{
 		ID:        1,
@@ -380,7 +387,7 @@ func TestFinetuneComponent_ReadJobLogsNonStream(t *testing.T) {
 		mockUserSvcClient := mockrpc.NewMockUserSvcClient(t)
 
 		c := NewTestFinetuneComponent(cfg, mockDeployer, nil, nil, nil, nil, nil,
-			nil, nil, nil, argoStore, nil, nil, nil, mockUserSvcClient)
+			nil, nil, nil, argoStore, nil, nil, nil, mockUserSvcClient, nil)
 
 		req := types.FinetuneLogReq{
 			CurrentUser: "testuser",
@@ -418,7 +425,7 @@ func TestFinetuneComponent_ReadJobLogsNonStream(t *testing.T) {
 		mockUserSvcClient := mockrpc.NewMockUserSvcClient(t)
 
 		c := NewTestFinetuneComponent(cfg, mockDeployer, nil, nil, nil, nil, nil,
-			nil, nil, nil, argoStore, nil, nil, nil, mockUserSvcClient)
+			nil, nil, nil, argoStore, nil, nil, nil, mockUserSvcClient, nil)
 
 		req := types.FinetuneLogReq{
 			CurrentUser: "testuser",
@@ -438,7 +445,7 @@ func TestFinetuneComponent_ReadJobLogsNonStream(t *testing.T) {
 		mockUserSvcClient := mockrpc.NewMockUserSvcClient(t)
 
 		c := NewTestFinetuneComponent(cfg, mockDeployer, nil, nil, nil, nil, nil,
-			nil, nil, nil, argoStore, nil, nil, nil, mockUserSvcClient)
+			nil, nil, nil, argoStore, nil, nil, nil, mockUserSvcClient, nil)
 		req := types.FinetuneLogReq{
 			CurrentUser: "testuser",
 			ID:          1,
@@ -479,7 +486,7 @@ func TestFinetuneComponent_ReadJobLogsInStream(t *testing.T) {
 		mockUserSvcClient := mockrpc.NewMockUserSvcClient(t)
 
 		c := NewTestFinetuneComponent(cfg, mockDeployer, nil, nil, nil, nil, nil,
-			nil, nil, nil, argoStore, nil, nil, nil, mockUserSvcClient)
+			nil, nil, nil, argoStore, nil, nil, nil, mockUserSvcClient, nil)
 
 		req := types.FinetuneLogReq{
 			CurrentUser: "testuser",
@@ -517,7 +524,7 @@ func TestFinetuneComponent_ReadJobLogsInStream(t *testing.T) {
 		mockUserSvcClient := mockrpc.NewMockUserSvcClient(t)
 
 		c := NewTestFinetuneComponent(cfg, mockDeployer, nil, nil, nil, nil, nil,
-			nil, nil, nil, argoStore, nil, nil, nil, mockUserSvcClient)
+			nil, nil, nil, argoStore, nil, nil, nil, mockUserSvcClient, nil)
 
 		req := types.FinetuneLogReq{
 			CurrentUser: "testuser",
@@ -548,7 +555,7 @@ func TestFinetuneComponent_OrgFinetuneInstances(t *testing.T) {
 	mockDeployTask.EXPECT().ListDeployByOwnerNamespace(ctx, "org1", mock.Anything).Return([]database.Deploy{
 		{ID: 1, DeployName: "ft1", OwnerNamespace: "org1", RepoID: 101, Status: 1},
 	}, 1, nil)
-	c := NewTestFinetuneComponent(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, mockAcctComp, mockRepoComp, mockDeployTask, nil)
+	c := NewTestFinetuneComponent(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, mockAcctComp, mockRepoComp, mockDeployTask, nil, nil)
 	res, total, err := c.OrgFinetuneInstances(ctx, req)
 	require.Nil(t, err)
 	require.Equal(t, 1, total)
@@ -572,7 +579,7 @@ func TestFinetuneComponent_OrgFinetuneJobs(t *testing.T) {
 	mockArgoStore.EXPECT().FindByUsername(ctx, "org1", types.TaskTypeFinetune, 10, 1).Return([]database.ArgoWorkflow{
 		{ID: 1, TaskName: "ftjob1", Username: "org1", TaskType: types.TaskTypeFinetune},
 	}, 1, nil)
-	c := NewTestFinetuneComponent(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, mockArgoStore, mockAcctComp, mockRepoComp, nil, nil)
+	c := NewTestFinetuneComponent(cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, mockArgoStore, mockAcctComp, mockRepoComp, nil, nil, nil)
 	res, total, err := c.OrgFinetuneJobs(ctx, req)
 	require.Nil(t, err)
 	require.Equal(t, 1, total)

--- a/runner/component/workflow.go
+++ b/runner/component/workflow.go
@@ -111,8 +111,11 @@ func (wc *workFlowComponentImpl) CreateWorkflow(ctx context.Context, req types.A
 		return nil, fmt.Errorf("failed to generate workflow: %v", err)
 	}
 	wc.setLabels(argowf, awf)
-	slog.InfoContext(ctx, "create workflow in runner", slog.Any("namespace", namespace), slog.Any("awf.name", awf.Name),
-		slog.Any("result-url", argowf.ResultURL), slog.Any("task-type", argowf.TaskType))
+	slog.InfoContext(ctx, "create workflow in runner",
+		slog.Any("namespace", namespace),
+		slog.Any("awf", awf),
+		slog.Any("result-url", argowf.ResultURL),
+		slog.Any("task-type", argowf.TaskType))
 	_, err = cluster.ArgoClient.ArgoprojV1alpha1().Workflows(namespace).Create(ctx, awf, v1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create workflow in argo: %v", err)

--- a/runner/handler/workflow.go
+++ b/runner/handler/workflow.go
@@ -48,7 +48,7 @@ func (a *ArgoHandler) CreateWorkflow(ctx *gin.Context) {
 	}
 	wf, err := a.wfc.CreateWorkflow(ctx, req)
 	if err != nil {
-		slog.ErrorContext(ctx, "fail to create workflow", slog.Any("error", err), slog.Any("req", req))
+		slog.ErrorContext(ctx, "failed to create workflow", slog.Any("error", err), slog.Any("req", req))
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}


### PR DESCRIPTION
Summary:
- Moved `FindNodeByClusterID` call from the deployer layer to the component layer to ensure the `Nodes` field is populated before constructing the workflow request, fixing empty node lists in finetune job creation.
- Removed redundant node query logic in the deployer layer and added defensive warning logs in the runner for empty node lists.
- Improved runner workflow logging and updated related unit tests to reflect the structural changes.