### PR TITLE
Apply system timezone to recharge query date ranges

### DIFF
--- a/accounting/utils/format.go
+++ b/accounting/utils/format.go
@@ -3,7 +3,13 @@ package utils
 import (
 	"errors"
 	"time"
+
+	"opencsg.com/csghub-server/common/config"
 )
+
+// timeLayoutWithOffset carries an explicit offset so timestamptz comparisons
+// are unambiguous regardless of the database session timezone.
+const timeLayoutWithOffset = "2006-01-02 15:04:05-07:00"
 
 func ValidateDateTimeFormat(timeStr, layout string) bool {
 	_, err := time.Parse(layout, timeStr)
@@ -26,4 +32,31 @@ func ValidateQueryDate(startDateStr, endDateStr, layout string) (string, string,
 	endDateStrModified := endDate.Format(layout)
 
 	return startDate, endDateStrModified, nil
+}
+
+// ConvertToGlobalTimeZone parses value as global-timezone local time and
+// returns the equivalent timestamp string with an explicit offset for the DB.
+func ConvertToGlobalTimeZone(value, layout string) (string, error) {
+	timeLoc := config.GetGlobalTimeZone()
+	t, err := time.ParseInLocation(layout, value, timeLoc)
+	if err != nil {
+		return "", err
+	}
+	return t.Format(timeLayoutWithOffset), nil
+}
+
+// ConvertDateRangeToGlobalTimeZone parses an inclusive [start, end] date range
+// in the global timezone and returns an explicit-offset [start, end+1day) range.
+func ConvertDateRangeToGlobalTimeZone(start, end, layout string) (string, string, error) {
+	timeLoc := config.GetGlobalTimeZone()
+	s, err := time.ParseInLocation(layout, start, timeLoc)
+	if err != nil {
+		return "", "", err
+	}
+	e, err := time.ParseInLocation(layout, end, timeLoc)
+	if err != nil {
+		return "", "", err
+	}
+	e = time.Date(e.Year(), e.Month(), e.Day()+1, 0, 0, 0, 0, e.Location())
+	return s.Format(timeLayoutWithOffset), e.Format(timeLayoutWithOffset), nil
 }

--- a/accounting/utils/format_test.go
+++ b/accounting/utils/format_test.go
@@ -2,8 +2,10 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/common/config"
 )
 
 func TestFormat_ValidateDateTimeFormat(t *testing.T) {
@@ -29,4 +31,33 @@ func TestFormat_ValidateQueryDate(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, startDateStr, start)
 	require.Equal(t, "2024-11-10 12:13:23", end)
+}
+
+func TestFormat_ConvertToGlobalTimeZone(t *testing.T) {
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	require.NoError(t, err)
+	config.SetGlobalTimeZone(loc)
+	t.Cleanup(func() { config.SetGlobalTimeZone(nil) })
+
+	got, err := ConvertToGlobalTimeZone("2026-08-01 08:00:00", "2006-01-02 15:04:05")
+	require.NoError(t, err)
+	require.Equal(t, "2026-08-01 08:00:00+08:00", got)
+
+	_, err = ConvertToGlobalTimeZone("invalid", "2006-01-02 15:04:05")
+	require.Error(t, err)
+}
+
+func TestFormat_ConvertDateRangeToGlobalTimeZone(t *testing.T) {
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	require.NoError(t, err)
+	config.SetGlobalTimeZone(loc)
+	t.Cleanup(func() { config.SetGlobalTimeZone(nil) })
+
+	start, end, err := ConvertDateRangeToGlobalTimeZone("2026-08-01", "2026-08-02", "2006-01-02")
+	require.NoError(t, err)
+	require.Equal(t, "2026-08-01 00:00:00+08:00", start)
+	require.Equal(t, "2026-08-03 00:00:00+08:00", end)
+
+	_, _, err = ConvertDateRangeToGlobalTimeZone("invalid", "2026-08-02", "2006-01-02")
+	require.Error(t, err)
 }


### PR DESCRIPTION
Summary:
- Fixed recharge query date/time range boundaries shifting when the business timezone differs from the database session timezone.
- Added utility functions to parse input date ranges using the global timezone and convert them to explicitly offset strings (e.g., `+08:00`) for accurate `timestamptz` database comparisons.
- Standardized error handling for invalid date formats to return a safe, user-friendly message instead of exposing internal parsing errors.