### PR TITLE
feat(mirror): support MCP and Skill repository synchronization

### DIFF
--- a/api/handler/mirror_test.go
+++ b/api/handler/mirror_test.go
@@ -78,6 +78,39 @@ func TestMirrorHandler_CreateMirrorRepo(t *testing.T) {
 
 }
 
+// TestMirrorHandler_CreateMirrorRepoIgnoresMCPServerAttributes verifies callers cannot inject internal MCP metadata through JSON.
+func TestMirrorHandler_CreateMirrorRepoIgnoresMCPServerAttributes(t *testing.T) {
+	tester := NewMirrorTester(t).WithHandleFunc(func(h *MirrorHandler) gin.HandlerFunc {
+		return h.CreateMirrorRepo
+	})
+	tester.WithUser()
+
+	tester.mocks.mirror.EXPECT().CreateMirrorRepo(tester.Ctx(), mock.MatchedBy(func(req types.CreateMirrorRepoReq) bool {
+		attributes := req.MCPServerAttributes
+		return req.RepoType == types.MCPServerRepo &&
+			attributes.StarCount == 0 &&
+			len(attributes.Tools) == 0 &&
+			attributes.AvatarURL == "" &&
+			attributes.Configuration.Type == "" &&
+			len(attributes.Configuration.Properties) == 0 &&
+			len(attributes.Configuration.Required) == 0
+	})).Return(&database.Mirror{}, nil)
+	tester.WithBody(t, map[string]any{
+		"source_namespace": "ns",
+		"source_name":      "server",
+		"repo_type":        types.MCPServerRepo,
+		"source_url":       "https://opencsg.com/ns/server.git",
+		"fork_namespace":   "target-ns",
+		"fork_name":        "server",
+		"mcp_server_attributes": map[string]any{
+			"star_count": 99,
+			"avatar_url": "https://example.com/avatar.png",
+		},
+	}).Execute()
+
+	tester.ResponseEq(t, 200, tester.OKText, nil)
+}
+
 func TestMirrorHandler_CreateMirrorRepoRequiresForkTarget(t *testing.T) {
 	cases := []struct {
 		name string
@@ -176,6 +209,33 @@ func TestMirrorHandler_CreateMirrorRepoBadRequest(t *testing.T) {
 	tester.ResponseEqSimple(t, 400, gin.H{
 		"code": "REQ-ERR-0",
 		"msg":  "REQ-ERR-0: invalid source git clone url",
+	})
+}
+
+// TestMirrorHandler_CreateMirrorRepoUnsupportedMetadataSource verifies unsupported MCP and skill sources return HTTP 400.
+func TestMirrorHandler_CreateMirrorRepoUnsupportedMetadataSource(t *testing.T) {
+	tester := NewMirrorTester(t).WithHandleFunc(func(h *MirrorHandler) gin.HandlerFunc {
+		return h.CreateMirrorRepo
+	})
+	tester.WithUser().WithBody(t, &types.CreateMirrorRepoReq{
+		SourceNamespace:   "upstream",
+		SourceName:        "reviewer",
+		RepoType:          types.SkillRepo,
+		SourceGitCloneUrl: "https://github.com/upstream/reviewer.git",
+		ForkNamespace:     "target-ns",
+		ForkName:          "reviewer",
+	})
+	badRequestErr := errorx.BadRequest(
+		errors.New("mirror_source_id with a configured info_api_url is required for non-OpenCSG skill sources"),
+		errorx.Ctx(),
+	)
+	tester.mocks.mirror.EXPECT().CreateMirrorRepo(tester.Ctx(), mock.Anything).Return(nil, badRequestErr)
+
+	tester.Execute()
+
+	tester.ResponseEqSimple(t, 400, gin.H{
+		"code": "REQ-ERR-0",
+		"msg":  "REQ-ERR-0: mirror_source_id with a configured info_api_url is required for non-OpenCSG skill sources",
 	})
 }
 

--- a/api/router/api_mcp.go
+++ b/api/router/api_mcp.go
@@ -32,7 +32,7 @@ func CreateMCPServerRoutes(
 		mcpGroup.GET("/:namespace/:name/branches", repoCommonHandler.Branches)
 		mcpGroup.GET("/:namespace/:name/tags", repoCommonHandler.Tags)
 		mcpGroup.POST("/:namespace/:name/transfer", middlewareCollection.Auth.NeedLogin, repoCommonHandler.TransferOwnership)
-	mcpGroup.POST("/:namespace/:name/preupload/:revision", repoCommonHandler.Preupload)
+		mcpGroup.POST("/:namespace/:name/preupload/:revision", repoCommonHandler.Preupload)
 		mcpGroup.POST("/:namespace/:name/tags/:category", middlewareCollection.Auth.NeedLogin, repoCommonHandler.UpdateTags)
 		mcpGroup.GET("/:namespace/:name/last_commit", repoCommonHandler.LastCommit)
 		mcpGroup.GET("/:namespace/:name/commit/:commit_id", repoCommonHandler.CommitWithDiff)
@@ -55,6 +55,7 @@ func CreateMCPServerRoutes(
 		mcpGroup.PUT("/:namespace/:name/incr_downloads", middlewareCollection.Auth.NeedAdmin, repoCommonHandler.IncrDownloads)
 		mcpGroup.POST("/:namespace/:name/upload_file", middlewareCollection.Auth.NeedLogin, repoCommonHandler.UploadFile)
 		mcpGroup.GET("/:namespace/:name/mirror", middlewareCollection.Auth.NeedLogin, repoCommonHandler.GetMirror)
+		mcpGroup.POST("/:namespace/:name/mirror", middlewareCollection.Auth.NeedLogin, repoCommonHandler.CreateMirror)
 		mcpGroup.POST("/:namespace/:name/mirror/sync", middlewareCollection.Auth.NeedLogin, repoCommonHandler.SyncMirror)
 		// Get repo size by branch
 		mcpGroup.GET("/:namespace/:name/size/:branch", repoCommonHandler.GetRepoSizeByBranch)

--- a/builder/multisync/client.go
+++ b/builder/multisync/client.go
@@ -26,7 +26,11 @@ func FromOpenCSG(endpoint string, accessToken string) Client {
 	if endpoint == "" {
 		return &commonClient{}
 	}
-	return &commonClient{rpcClent: rpc.NewHttpClient(endpoint, rpc.AuthWithApiKey(accessToken))}
+	var opts []rpc.RequestOption
+	if accessToken != "" {
+		opts = append(opts, rpc.AuthWithApiKey(accessToken))
+	}
+	return &commonClient{rpcClent: rpc.NewHttpClient(endpoint, opts...)}
 }
 
 type commonClient struct {

--- a/builder/store/database/mirror_repo.go
+++ b/builder/store/database/mirror_repo.go
@@ -48,6 +48,8 @@ type CreateMirrorRepoRecordsInput struct {
 	Repository *Repository
 	// CreateRepository controls whether repository and type-specific rows are inserted.
 	CreateRepository bool
+	// Metadata refreshes source API metadata when binding an existing target repository.
+	Metadata *MirrorRepoMetadataUpdate
 
 	// MCPServer is inserted when creating an MCP server repository.
 	MCPServer *MCPServer
@@ -56,6 +58,18 @@ type CreateMirrorRepoRecordsInput struct {
 	Mirror              Mirror
 	// Urgent routes the initial repository job to the urgent queue.
 	Urgent bool
+}
+
+// MirrorRepoMetadataUpdate contains source API metadata refreshed with a mirror task.
+type MirrorRepoMetadataUpdate struct {
+	// Repository contains the source-owned repository metadata fields to update.
+	Repository Repository
+	// MCPServer contains MCP-specific metadata for MCP repositories.
+	MCPServer *MCPServer
+	// MCPServerProperties replace existing MCP tool rows while preserving other property kinds.
+	MCPServerProperties []MCPServerProperty
+	// SkillLastUpdatedAt updates the source timestamp when the API provides one.
+	SkillLastUpdatedAt *time.Time
 }
 
 type mirrorRepoStoreImpl struct {
@@ -111,6 +125,14 @@ func (s *mirrorRepoStoreImpl) CreateMirrorRepoRecords(ctx context.Context, input
 			input.Repository.SyncStatus = types.SyncStatusPending
 			if err := updateRepoSourceFields(ctx, tx, *input.Repository); err != nil {
 				return fmt.Errorf("failed to update repository source path: %w", err)
+			}
+			if input.Metadata != nil {
+				if input.Metadata.Repository.ID != input.Repository.ID || input.Metadata.Repository.RepositoryType != input.Repository.RepositoryType {
+					return fmt.Errorf("metadata repository does not match mirror target")
+				}
+				if err := updateMirrorRepoMetadata(ctx, tx, *input.Metadata); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -325,4 +347,75 @@ func updateRepoSyncStatus(ctx context.Context, tx bun.Tx, repoID int64, status t
 		Where("id = ?", repoID).
 		Exec(ctx)
 	return err
+}
+
+// updateMirrorRepoMetadata replaces source API metadata inside the task creation transaction.
+func updateMirrorRepoMetadata(ctx context.Context, tx bun.Tx, input MirrorRepoMetadataUpdate) error {
+	if input.Repository.ID == 0 {
+		return fmt.Errorf("metadata repository id is required")
+	}
+
+	if _, err := tx.NewUpdate().
+		Model((*Repository)(nil)).
+		Set("nickname = ?", input.Repository.Nickname).
+		Set("description = ?", input.Repository.Description).
+		Set("license = ?", input.Repository.License).
+		Set("default_branch = ?", input.Repository.DefaultBranch).
+		Set("star_count = ?", input.Repository.StarCount).
+		Where("id = ?", input.Repository.ID).
+		Exec(ctx); err != nil {
+		return fmt.Errorf("failed to update mirror repository metadata: %w", err)
+	}
+
+	switch input.Repository.RepositoryType {
+	case types.MCPServerRepo:
+		if input.MCPServer == nil {
+			return fmt.Errorf("mcp server metadata is required")
+		}
+		var stored MCPServer
+		if err := tx.NewSelect().
+			Model(&stored).
+			Where("repository_id = ?", input.Repository.ID).
+			For("UPDATE").
+			Scan(ctx); err != nil {
+			return fmt.Errorf("failed to lock mcp server metadata: %w", err)
+		}
+
+		mcpServer := *input.MCPServer
+		mcpServer.ID = stored.ID
+		mcpServer.RepositoryID = input.Repository.ID
+		if _, err := tx.NewUpdate().
+			Model(&mcpServer).
+			Column("tools_num", "configuration", "schema", "program_language", "run_mode", "install_deps_cmds", "build_cmds", "launch_cmds", "avatar_url").
+			WherePK().
+			Exec(ctx); err != nil {
+			return fmt.Errorf("failed to update mcp server metadata: %w", err)
+		}
+		if _, err := tx.NewDelete().
+			Model((*MCPServerProperty)(nil)).
+			Where("mcp_server_id = ?", stored.ID).
+			Where("kind = ?", types.MCPPropTool).
+			Exec(ctx); err != nil {
+			return fmt.Errorf("failed to delete stale mcp server tool properties: %w", err)
+		}
+		for _, property := range input.MCPServerProperties {
+			property.MCPServerID = stored.ID
+			if _, err := tx.NewInsert().Model(&property).Exec(ctx, &property); err != nil {
+				return fmt.Errorf("failed to add refreshed mcp server property: %w", err)
+			}
+		}
+	case types.SkillRepo:
+		if input.SkillLastUpdatedAt != nil {
+			if _, err := tx.NewUpdate().
+				Model((*Skill)(nil)).
+				Set("last_updated_at = ?", *input.SkillLastUpdatedAt).
+				Where("repository_id = ?", input.Repository.ID).
+				Exec(ctx); err != nil {
+				return fmt.Errorf("failed to update skill source timestamp: %w", err)
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported metadata repository type: %s", input.Repository.RepositoryType)
+	}
+	return nil
 }

--- a/builder/store/database/mirror_task.go
+++ b/builder/store/database/mirror_task.go
@@ -98,6 +98,8 @@ type RequeueMirrorRepoTaskInput struct {
 	JobClient MirrorJobClient
 	// JobCancelClient cancels replaced workhub jobs inside the same transaction.
 	JobCancelClient MirrorJobCancelClient
+	// Metadata refreshes MCP or skill source API metadata in the same transaction.
+	Metadata *MirrorRepoMetadataUpdate
 }
 
 var mirrorTaskStatusToRepoStatusMap = map[types.MirrorTaskStatus]types.RepositorySyncStatus{
@@ -433,6 +435,17 @@ func (m *mirrorTaskStoreImpl) RequeueMirrorRepoTask(ctx context.Context, input R
 			return fmt.Errorf("failed to lock repository: %w", err)
 		}
 		mirror.Repository = &repo
+		if input.Metadata != nil {
+			if input.Metadata.Repository.ID != repo.ID {
+				return fmt.Errorf("metadata repository mismatch, metadata repository id: %d, mirror repository id: %d", input.Metadata.Repository.ID, repo.ID)
+			}
+			if input.Metadata.Repository.RepositoryType != repo.RepositoryType {
+				return fmt.Errorf("metadata repository type mismatch, metadata repository type: %s, mirror repository type: %s", input.Metadata.Repository.RepositoryType, repo.RepositoryType)
+			}
+			if err := updateMirrorRepoMetadata(ctx, tx, *input.Metadata); err != nil {
+				return err
+			}
+		}
 
 		var currentTask *MirrorTask
 		if mirror.CurrentTaskID != 0 {

--- a/builder/store/database/mirror_task_test.go
+++ b/builder/store/database/mirror_task_test.go
@@ -1539,3 +1539,140 @@ func TestMirrorTaskStore_UpdateProgress_DoesNotOverwritePriority(t *testing.T) {
 	require.Equal(t, types.LowMirrorPriority, dbTask.Priority,
 		"UpdateProgress must not overwrite priority set by another process")
 }
+
+// TestMirrorTaskStore_RequeueMirrorRepoTaskRefreshesMCPMetadata verifies metadata and task state commit together.
+func TestMirrorTaskStore_RequeueMirrorRepoTaskRefreshesMCPMetadata(t *testing.T) {
+	db := tests.InitTestDB()
+	defer db.Close()
+	ctx := context.TODO()
+
+	repo, err := database.NewRepoStoreWithDB(db).CreateRepo(ctx, database.Repository{
+		UserID: 1, Path: "test/mcp-refresh", GitPath: "mcpservers_test/mcp-refresh", Name: "mcp-refresh",
+		Nickname: "Old MCP", Description: "old description", License: "old-license", Readme: "old readme",
+		DefaultBranch: "main", StarCount: 1, RepositoryType: types.MCPServerRepo, SyncStatus: types.SyncStatusCompleted,
+	})
+	require.NoError(t, err)
+	mcpStore := database.NewMCPServerStoreWithDB(db)
+	server, err := mcpStore.Create(ctx, database.MCPServer{
+		RepositoryID: repo.ID, ToolsNum: 1, Configuration: `{"command":"old"}`, Schema: `{"tools":[]}`, ProgramLanguage: "python",
+	})
+	require.NoError(t, err)
+	propertiesToSeed := []database.MCPServerProperty{
+		{MCPServerID: server.ID, Kind: types.MCPPropTool, Name: "old-tool", Description: "old tool", Schema: `{}`},
+		{MCPServerID: server.ID, Kind: types.MCPPropPrompt, Name: "saved-prompt", Description: "saved prompt", Schema: `{}`},
+		{MCPServerID: server.ID, Kind: types.MCPPropResource, Name: "saved-resource", Description: "saved resource", Schema: `{}`},
+		{MCPServerID: server.ID, Kind: types.MCPPropresourceTemplate, Name: "saved-template", Description: "saved template", Schema: `{}`},
+	}
+	for _, property := range propertiesToSeed {
+		_, err = mcpStore.AddProperty(ctx, property)
+		require.NoError(t, err)
+	}
+	mirror, err := database.NewMirrorStoreWithDB(db).Create(ctx, &database.Mirror{
+		SourceUrl: "https://opencsg.com/test/mcp-refresh.git", RepositoryID: repo.ID,
+		MirrorSourceID: 1, Status: types.MirrorLfsSyncFinished, Priority: types.LowMirrorPriority,
+	})
+	require.NoError(t, err)
+
+	refreshedRepo := *repo
+	refreshedRepo.Nickname = "Fresh MCP"
+	refreshedRepo.Description = "fresh description"
+	refreshedRepo.License = "MIT"
+	refreshedRepo.Readme = "# Fresh MCP"
+	refreshedRepo.DefaultBranch = "develop"
+	refreshedRepo.StarCount = 9
+	jobClient := &fakeMirrorRepoJobClient{}
+	task, err := database.NewMirrorTaskJobStoreWithDB(db).RequeueMirrorRepoTask(ctx, database.RequeueMirrorRepoTaskInput{
+		MirrorID: mirror.ID, RepositoryID: repo.ID, Priority: types.LowMirrorPriority, JobClient: jobClient,
+		Metadata: &database.MirrorRepoMetadataUpdate{
+			Repository: refreshedRepo,
+			MCPServer: &database.MCPServer{
+				ToolsNum: 1, Configuration: `{"command":"fresh"}`, Schema: `{"tools":[{"name":"search"}]}`,
+				ProgramLanguage: "go", RunMode: "stdio", LaunchCmds: "go run .",
+			},
+			MCPServerProperties: []database.MCPServerProperty{{
+				Kind: types.MCPPropTool, Name: "search", Description: "fresh search", Schema: `{"type":"object"}`,
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.NotZero(t, task.ID)
+
+	storedRepo, err := database.NewRepoStoreWithDB(db).FindById(ctx, repo.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Fresh MCP", storedRepo.Nickname)
+	require.Equal(t, "fresh description", storedRepo.Description)
+	require.Equal(t, "MIT", storedRepo.License)
+	require.Equal(t, "old readme", storedRepo.Readme)
+	require.Equal(t, "develop", storedRepo.DefaultBranch)
+	require.Equal(t, 9, storedRepo.StarCount)
+	storedServer, err := mcpStore.ByRepoID(ctx, repo.ID)
+	require.NoError(t, err)
+	require.Equal(t, `{"command":"fresh"}`, storedServer.Configuration)
+	require.Equal(t, "go", storedServer.ProgramLanguage)
+	require.Equal(t, "stdio", storedServer.RunMode)
+	var properties []database.MCPServerProperty
+	err = db.Core.NewSelect().
+		Model(&properties).
+		Where("mcp_server_id = ?", storedServer.ID).
+		Order("kind ASC").
+		Scan(ctx)
+	require.NoError(t, err)
+	require.Len(t, properties, 4)
+	propertiesByKind := make(map[types.MCPPropertyKind]database.MCPServerProperty, len(properties))
+	for _, property := range properties {
+		propertiesByKind[property.Kind] = property
+	}
+	require.Equal(t, "search", propertiesByKind[types.MCPPropTool].Name)
+	require.Equal(t, "saved-prompt", propertiesByKind[types.MCPPropPrompt].Name)
+	require.Equal(t, "saved-resource", propertiesByKind[types.MCPPropResource].Name)
+	require.Equal(t, "saved-template", propertiesByKind[types.MCPPropresourceTemplate].Name)
+}
+
+// TestMirrorTaskStore_RequeueMirrorRepoTaskRollsBackSkillMetadata verifies failed task enqueue does not expose refreshed skill metadata.
+func TestMirrorTaskStore_RequeueMirrorRepoTaskRollsBackSkillMetadata(t *testing.T) {
+	db := tests.InitTestDB()
+	defer db.Close()
+	ctx := context.TODO()
+
+	oldUpdatedAt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	repo, err := database.NewRepoStoreWithDB(db).CreateRepo(ctx, database.Repository{
+		UserID: 1, Path: "test/skill-refresh", GitPath: "skills_test/skill-refresh", Name: "skill-refresh",
+		Nickname: "Old Skill", Description: "old description", License: "old-license", Readme: "old readme",
+		DefaultBranch: "main", RepositoryType: types.SkillRepo, SyncStatus: types.SyncStatusCompleted,
+	})
+	require.NoError(t, err)
+	_, err = database.NewSkillStoreWithDB(db).Create(ctx, database.Skill{RepositoryID: repo.ID, LastUpdatedAt: oldUpdatedAt})
+	require.NoError(t, err)
+	mirror, err := database.NewMirrorStoreWithDB(db).Create(ctx, &database.Mirror{
+		SourceUrl: "https://opencsg.com/test/skill-refresh.git", RepositoryID: repo.ID,
+		MirrorSourceID: 1, Status: types.MirrorLfsSyncFinished, Priority: types.LowMirrorPriority,
+	})
+	require.NoError(t, err)
+
+	refreshedRepo := *repo
+	refreshedRepo.Nickname = "Fresh Skill"
+	refreshedRepo.Description = "fresh description"
+	refreshedRepo.License = "Apache-2.0"
+	refreshedRepo.Readme = "# Fresh Skill"
+	refreshedRepo.DefaultBranch = "develop"
+	freshUpdatedAt := time.Date(2026, time.August, 18, 8, 0, 0, 0, time.UTC)
+	_, err = database.NewMirrorTaskJobStoreWithDB(db).RequeueMirrorRepoTask(ctx, database.RequeueMirrorRepoTaskInput{
+		MirrorID: mirror.ID, RepositoryID: repo.ID, Priority: types.LowMirrorPriority,
+		JobClient: &fakeMirrorRepoJobClient{err: errors.New("insert job failed")},
+		Metadata: &database.MirrorRepoMetadataUpdate{
+			Repository: refreshedRepo, SkillLastUpdatedAt: &freshUpdatedAt,
+		},
+	})
+	require.ErrorContains(t, err, "insert job failed")
+
+	storedRepo, err := database.NewRepoStoreWithDB(db).FindById(ctx, repo.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Old Skill", storedRepo.Nickname)
+	require.Equal(t, "old description", storedRepo.Description)
+	require.Equal(t, "old-license", storedRepo.License)
+	require.Equal(t, "old readme", storedRepo.Readme)
+	require.Equal(t, "main", storedRepo.DefaultBranch)
+	storedSkill, err := database.NewSkillStoreWithDB(db).ByRepoID(ctx, repo.ID)
+	require.NoError(t, err)
+	require.True(t, storedSkill.LastUpdatedAt.Equal(oldUpdatedAt))
+}

--- a/common/types/mirror.go
+++ b/common/types/mirror.go
@@ -245,7 +245,7 @@ type UpdateMirrorSourceReq struct {
 type CreateMirrorRepoReq struct {
 	SourceNamespace string `json:"source_namespace" binding:"required"`
 	SourceName      string `json:"source_name" binding:"required"`
-	// source id for HF,github etc
+	// MirrorSourceID selects a configured source and is required for non-OpenCSG MCP and skill metadata APIs.
 	MirrorSourceID int64 `json:"mirror_source_id"`
 
 	// repo basic info
@@ -267,8 +267,8 @@ type CreateMirrorRepoReq struct {
 	License     string `json:"license"`
 	CurrentUser string `json:"current_user"`
 
-	//MCP only
-	MCPServerAttributes MCPServerAttributes `json:"mcp_server_attributes"`
+	// MCPServerAttributes supplies metadata for internal crawler calls and is not accepted from JSON requests.
+	MCPServerAttributes MCPServerAttributes `json:"-"`
 
 	// fork repo, local namespace/name
 	ForkNamespace string `json:"fork_namespace"`

--- a/component/mirror.go
+++ b/component/mirror.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"opencsg.com/csghub-server/builder/git/membership"
+	"opencsg.com/csghub-server/builder/multisync"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/builder/workhub"
 	"opencsg.com/csghub-server/common/config"
@@ -42,6 +43,8 @@ type mirrorComponentImpl struct {
 	syncCacheMu                 sync.Mutex
 	syncCache                   mirrorcache.Cache
 	mirrorNamespaceMappingStore database.MirrorNamespaceMappingStore
+	// mirrorMetadataClientFactory creates source-specific clients used to import MCP and skill metadata.
+	mirrorMetadataClientFactory mirrorMetadataClientFactory
 }
 
 type MirrorComponent interface {
@@ -341,6 +344,7 @@ func NewMirrorComponent(config *config.Config) (MirrorComponent, error) {
 	c.userStore = database.NewUserStore()
 	c.config = config
 	c.mirrorNamespaceMappingStore = database.NewMirrorNamespaceMappingStore()
+	c.mirrorMetadataClientFactory = multisync.FromOpenCSG
 	return c, nil
 }
 
@@ -438,9 +442,14 @@ func (m *mirrorComponentImpl) CreateMirror(ctx context.Context, req types.Create
 		sourceType, sourcePath, _ := common.GetSourceTypeAndPathFromURL(req.SourceUrl)
 		applyMirrorRepositorySourcePath(repo, sourceType, sourcePath)
 	}
+	metadataUpdate, err := m.prepareExistingMirrorRepoMetadataUpdate(ctx, repo, &mirror, nil, nil)
+	if err != nil {
+		return nil, err
+	}
 	reqMirror, err := m.mirrorRepoStore.CreateMirrorRepoRecords(ctx, database.CreateMirrorRepoRecordsInput{
 		Repository:       repo,
 		CreateRepository: false,
+		Metadata:         metadataUpdate,
 		Mirror:           mirror,
 		Urgent:           req.Urgent,
 	})

--- a/component/mirror_repo.go
+++ b/component/mirror_repo.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"opencsg.com/csghub-server/builder/git/membership"
+	"opencsg.com/csghub-server/builder/multisync"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/common/errorx"
 	"opencsg.com/csghub-server/common/types"
@@ -19,8 +20,77 @@ import (
 	"opencsg.com/csghub-server/common/utils/common"
 )
 
+// mirrorMetadataClientFactory creates an OpenCSG API client for one mirror source.
+type mirrorMetadataClientFactory func(endpoint, accessToken string) multisync.Client
+
+// openCSGSaaSMetadataEndpoint is the trusted metadata API endpoint for OpenCSG SaaS Git repositories.
+const openCSGSaaSMetadataEndpoint = "https://hub.opencsg.com"
+
+// mirrorRepoMetadata contains type-specific metadata fetched before transactional mirror creation.
+type mirrorRepoMetadata struct {
+	mcpServer *types.MCPServer
+	skill     *types.Skill
+}
+
 // requeueMirrorRepoTask atomically schedules a new sync for an existing mirror target.
 func (m *mirrorComponentImpl) requeueMirrorRepoTask(ctx context.Context, repo *database.Repository, mirror *database.Mirror, username, accessToken *string, priority types.MirrorPriority, urgent bool) (database.MirrorTask, error) {
+	metadata, err := m.prepareExistingMirrorRepoMetadataUpdate(ctx, repo, mirror, username, accessToken)
+	if err != nil {
+		return database.MirrorTask{}, err
+	}
+	return m.requeueMirrorRepoTaskWithMetadata(ctx, repo, mirror, username, accessToken, priority, urgent, metadata)
+}
+
+// prepareExistingMirrorRepoMetadataUpdate converts an existing mirror into one metadata update payload.
+func (m *mirrorComponentImpl) prepareExistingMirrorRepoMetadataUpdate(ctx context.Context, repo *database.Repository, mirror *database.Mirror, username, accessToken *string) (*database.MirrorRepoMetadataUpdate, error) {
+	if repo.RepositoryType != types.MCPServerRepo && repo.RepositoryType != types.SkillRepo {
+		return nil, nil
+	}
+	sourcePath := strings.Trim(strings.TrimSuffix(mirror.SourceRepoPath, ".git"), "/")
+	if sourcePath == "" {
+		_, sourcePath, _ = common.GetSourceTypeAndPathFromURL(mirror.SourceUrl)
+		sourcePath = strings.Trim(strings.TrimSuffix(sourcePath, ".git"), "/")
+	}
+	sourceNamespace, sourceName := path.Split(sourcePath)
+	sourceNamespace = strings.Trim(sourceNamespace, "/")
+	if sourceNamespace == "" || sourceName == "" {
+		return nil, fmt.Errorf("failed to resolve source repository path for %s metadata refresh", repo.RepositoryType)
+	}
+	sourceUsername, sourceAccessToken := mirror.Username, mirror.AccessToken
+	if username != nil && accessToken != nil {
+		sourceUsername, sourceAccessToken = *username, *accessToken
+	}
+	req := types.CreateMirrorRepoReq{
+		SourceNamespace:   sourceNamespace,
+		SourceName:        sourceName,
+		MirrorSourceID:    mirror.MirrorSourceID,
+		RepoType:          repo.RepositoryType,
+		SourceGitCloneUrl: mirror.SourceUrl,
+		Username:          sourceUsername,
+		AccessToken:       sourceAccessToken,
+	}
+	metadata, err := m.prepareExistingMirrorRepoMetadata(ctx, repo, req)
+	if err != nil {
+		return nil, err
+	}
+	return buildMirrorRepoMetadataUpdate(req, repo, metadata)
+}
+
+// prepareExistingMirrorRepoMetadata fetches and applies source API metadata to an existing repository.
+func (m *mirrorComponentImpl) prepareExistingMirrorRepoMetadata(ctx context.Context, repo *database.Repository, req types.CreateMirrorRepoReq) (*mirrorRepoMetadata, error) {
+	if repo.RepositoryType != types.MCPServerRepo && repo.RepositoryType != types.SkillRepo {
+		return nil, nil
+	}
+	metadata, err := m.fetchMirrorRepoMetadata(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	applyMirrorRepoMetadataToExistingRepository(repo, metadata)
+	return metadata, nil
+}
+
+// requeueMirrorRepoTaskWithMetadata schedules a new sync task and optionally applies source metadata atomically.
+func (m *mirrorComponentImpl) requeueMirrorRepoTaskWithMetadata(ctx context.Context, repo *database.Repository, mirror *database.Mirror, username, accessToken *string, priority types.MirrorPriority, urgent bool, metadata *database.MirrorRepoMetadataUpdate) (database.MirrorTask, error) {
 	task, err := m.mirrorTaskJobStore.RequeueMirrorRepoTask(ctx, database.RequeueMirrorRepoTaskInput{
 		MirrorID:        mirror.ID,
 		RepositoryID:    repo.ID,
@@ -30,6 +100,7 @@ func (m *mirrorComponentImpl) requeueMirrorRepoTask(ctx context.Context, repo *d
 		Urgent:          urgent,
 		JobClient:       m.mirrorRepoJobClient,
 		JobCancelClient: m.mirrorJobClient,
+		Metadata:        metadata,
 	})
 	if err != nil {
 		return database.MirrorTask{}, fmt.Errorf("failed to create mirror task: %w", err)
@@ -37,9 +108,9 @@ func (m *mirrorComponentImpl) requeueMirrorRepoTask(ctx context.Context, repo *d
 	return task, nil
 }
 
-// requeueMirrorFromSaas atomically replaces existing mirror work with a new workhub repo job.
+// requeueMirrorFromSaas atomically replaces existing SaaS mirror work without fetching source API metadata.
 func (m *mirrorComponentImpl) requeueMirrorFromSaas(ctx context.Context, repo *database.Repository, mirror *database.Mirror) (database.MirrorTask, error) {
-	return m.requeueMirrorRepoTask(ctx, repo, mirror, nil, nil, types.LowMirrorPriority, false)
+	return m.requeueMirrorRepoTaskWithMetadata(ctx, repo, mirror, nil, nil, types.LowMirrorPriority, false, nil)
 }
 
 // CreateMirrorRepo creates or binds one mirror source to one target repository.
@@ -100,12 +171,21 @@ func (m *mirrorComponentImpl) CreateMirrorRepo(ctx context.Context, req types.Cr
 		// mirror exists
 		if mirror != nil && mirror.ID != 0 {
 			if mirror.SourceUrl == req.SourceGitCloneUrl {
+				metadata, err := m.prepareExistingMirrorRepoMetadata(ctx, repo, req)
+				if err != nil {
+					return nil, err
+				}
+				metadataUpdate, err := buildMirrorRepoMetadataUpdate(req, repo, metadata)
+				if err != nil {
+					return nil, err
+				}
+
 				var usernamePtr, accessTokenPtr *string
 				if req.Username != "" {
 					usernamePtr = &req.Username
 					accessTokenPtr = &req.AccessToken
 				}
-				if _, err := m.requeueMirrorRepoTask(ctx, repo, mirror, usernamePtr, accessTokenPtr, req.Priority, req.Urgent); err != nil {
+				if _, err := m.requeueMirrorRepoTaskWithMetadata(ctx, repo, mirror, usernamePtr, accessTokenPtr, req.Priority, req.Urgent, metadataUpdate); err != nil {
 					return nil, fmt.Errorf("failed to sync mirror repo, error: %w", err)
 				}
 				if req.Username != "" {
@@ -124,8 +204,12 @@ func (m *mirrorComponentImpl) CreateMirrorRepo(ctx context.Context, req types.Cr
 			)
 		}
 
+		metadata, err := m.prepareExistingMirrorRepoMetadata(ctx, repo, req)
+		if err != nil {
+			return nil, err
+		}
 		repoNamespace, _ := repo.NamespaceAndName()
-		return m.createMirrorRepoRecords(ctx, req, repo, repoNamespace, repo.Name, false)
+		return m.createMirrorRepoRecords(ctx, req, repo, repoNamespace, repo.Name, false, metadata)
 	}
 	if req.CreateTargetRepo != nil && !*req.CreateTargetRepo {
 		return nil, errorx.RepoNotFound(
@@ -141,6 +225,10 @@ func (m *mirrorComponentImpl) CreateMirrorRepo(ctx context.Context, req types.Cr
 	if req.Private != nil {
 		private = *req.Private
 	}
+	metadata, err := m.fetchMirrorRepoMetadata(ctx, req)
+	if err != nil {
+		return nil, err
+	}
 
 	createRepoReq := types.CreateRepoReq{
 		Username:      req.CurrentUser,
@@ -155,6 +243,7 @@ func (m *mirrorComponentImpl) CreateMirrorRepo(ctx context.Context, req types.Cr
 		ToolCount:     len(req.MCPServerAttributes.Tools),
 		StarCount:     req.MCPServerAttributes.StarCount,
 	}
+	applyMirrorRepoMetadata(&createRepoReq, metadata)
 
 	sourceType, sourcePath := "", ""
 	if !req.SkipSourcePath {
@@ -166,7 +255,217 @@ func (m *mirrorComponentImpl) CreateMirrorRepo(ctx context.Context, req types.Cr
 	}
 
 	repoNamespace, _ := dbRepo.NamespaceAndName()
-	return m.createMirrorRepoRecords(ctx, req, dbRepo, repoNamespace, dbRepo.Name, true)
+	return m.createMirrorRepoRecords(ctx, req, dbRepo, repoNamespace, dbRepo.Name, true, metadata)
+}
+
+// fetchMirrorRepoMetadata imports MCP or skill metadata from the source API before repository creation.
+func (m *mirrorComponentImpl) fetchMirrorRepoMetadata(ctx context.Context, req types.CreateMirrorRepoReq) (*mirrorRepoMetadata, error) {
+	if req.RepoType != types.MCPServerRepo && req.RepoType != types.SkillRepo {
+		return nil, nil
+	}
+	// Explicit MCP attributes remain authoritative for compatibility with existing callers.
+	if req.RepoType == types.MCPServerRepo && hasMCPServerAttributes(req.MCPServerAttributes) {
+		return nil, nil
+	}
+
+	endpoint, err := m.resolveMirrorMetadataEndpoint(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	clientFactory := m.mirrorMetadataClientFactory
+	if clientFactory == nil {
+		clientFactory = multisync.FromOpenCSG
+	}
+	client := clientFactory(endpoint, req.AccessToken)
+	version := types.SyncVersion{
+		RepoPath: path.Join(path.Base(strings.TrimSpace(req.SourceNamespace)), req.SourceName),
+		RepoType: req.RepoType,
+	}
+	metadata := &mirrorRepoMetadata{}
+	switch req.RepoType {
+	case types.MCPServerRepo:
+		metadata.mcpServer, err = client.MCPServerInfo(ctx, version)
+		if err == nil && metadata.mcpServer == nil {
+			err = errors.New("source returned empty mcp server metadata")
+		}
+	case types.SkillRepo:
+		metadata.skill, err = client.SkillInfo(ctx, version)
+		if err == nil && metadata.skill == nil {
+			err = errors.New("source returned empty skill metadata")
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s mirror metadata: %w", req.RepoType, err)
+	}
+	return metadata, nil
+}
+
+// resolveMirrorMetadataEndpoint returns a trusted OpenCSG-compatible API endpoint for MCP and skill metadata.
+func (m *mirrorComponentImpl) resolveMirrorMetadataEndpoint(ctx context.Context, req types.CreateMirrorRepoReq) (string, error) {
+	parsedURL, err := url.Parse(req.SourceGitCloneUrl)
+	if err != nil {
+		return "", errorx.BadRequest(
+			fmt.Errorf("failed to parse source git clone url for metadata: %w", err),
+			errorx.Ctx().Set("source url", req.SourceGitCloneUrl),
+		)
+	}
+	isOpenCSGSaaS := isOpenCSGSaaSHost(parsedURL.Hostname())
+
+	if req.MirrorSourceID != 0 {
+		source, err := m.mirrorSourceStore.Get(ctx, req.MirrorSourceID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", errorx.BadRequest(
+				fmt.Errorf("mirror source %d does not exist", req.MirrorSourceID),
+				errorx.Ctx().Set("mirror source id", req.MirrorSourceID),
+			)
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to get mirror source metadata endpoint: %w", err)
+		}
+		if source == nil {
+			return "", errorx.BadRequest(
+				fmt.Errorf("mirror source %d does not exist", req.MirrorSourceID),
+				errorx.Ctx().Set("mirror source id", req.MirrorSourceID),
+			)
+		}
+		if strings.TrimSpace(source.InfoAPIUrl) == "" {
+			if isOpenCSGSaaS {
+				return openCSGSaaSMetadataEndpoint, nil
+			}
+			return "", errorx.BadRequest(
+				fmt.Errorf("mirror source %d does not configure an info_api_url required for %s metadata", req.MirrorSourceID, req.RepoType),
+				errorx.Ctx().Set("mirror source id", req.MirrorSourceID).Set("repo type", req.RepoType),
+			)
+		}
+		endpoint, err := normalizeMirrorMetadataEndpoint(source.InfoAPIUrl)
+		if err != nil {
+			return "", errorx.BadRequest(
+				fmt.Errorf("invalid info_api_url for mirror source %d: %w", req.MirrorSourceID, err),
+				errorx.Ctx().Set("mirror source id", req.MirrorSourceID).Set("info api url", source.InfoAPIUrl),
+			)
+		}
+		return endpoint, nil
+	}
+
+	if isOpenCSGSaaS {
+		return openCSGSaaSMetadataEndpoint, nil
+	}
+
+	return "", errorx.BadRequest(
+		fmt.Errorf("mirror_source_id with a configured info_api_url is required for non-OpenCSG %s sources", req.RepoType),
+		errorx.Ctx().Set("repo type", req.RepoType).Set("source host", parsedURL.Hostname()),
+	)
+}
+
+// isOpenCSGSaaSHost reports whether a Git host uses the trusted OpenCSG SaaS metadata API.
+func isOpenCSGSaaSHost(host string) bool {
+	switch strings.ToLower(strings.TrimSpace(host)) {
+	case "opencsg.com", "hub.opencsg.com":
+		return true
+	default:
+		return false
+	}
+}
+
+// normalizeMirrorMetadataEndpoint validates a configured OpenCSG API base URL.
+func normalizeMirrorMetadataEndpoint(endpoint string) (string, error) {
+	endpoint = strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	parsedURL, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid mirror metadata endpoint: %w", err)
+	}
+	if (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") || parsedURL.Hostname() == "" {
+		return "", errors.New("mirror metadata endpoint must be an HTTP(S) URL with a host")
+	}
+	if parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
+		return "", errors.New("mirror metadata endpoint must not contain query or fragment")
+	}
+	return endpoint, nil
+}
+
+// hasMCPServerAttributes reports whether a caller supplied legacy MCP metadata explicitly.
+func hasMCPServerAttributes(attributes types.MCPServerAttributes) bool {
+	return attributes.StarCount != 0 || len(attributes.Tools) != 0 || attributes.AvatarURL != "" ||
+		attributes.Configuration.Type != "" || len(attributes.Configuration.Properties) != 0 ||
+		len(attributes.Configuration.Required) != 0
+}
+
+// applyMirrorRepoMetadata fills API metadata fields while leaving README content to the mirrored Git repository.
+func applyMirrorRepoMetadata(req *types.CreateRepoReq, metadata *mirrorRepoMetadata) {
+	if metadata == nil {
+		return
+	}
+
+	var nickname, description, license, defaultBranch string
+	switch {
+	case metadata.mcpServer != nil:
+		nickname = metadata.mcpServer.Nickname
+		description = metadata.mcpServer.Description
+		license = metadata.mcpServer.License
+		defaultBranch = metadata.mcpServer.DefaultBranch
+		req.ToolCount = metadata.mcpServer.ToolsNum
+		req.StarCount = metadata.mcpServer.StarNum
+	case metadata.skill != nil:
+		nickname = metadata.skill.Nickname
+		description = metadata.skill.Description
+		license = metadata.skill.License
+		defaultBranch = metadata.skill.DefaultBranch
+	}
+	if nickname != "" {
+		req.Nickname = nickname
+	}
+	if req.Description == "" {
+		req.Description = description
+	}
+	if req.License == "" {
+		req.License = license
+	}
+	if req.DefaultBranch == "" {
+		req.DefaultBranch = defaultBranch
+	}
+}
+
+// applyMirrorRepoMetadataToExistingRepository refreshes source-owned fields before task creation.
+func applyMirrorRepoMetadataToExistingRepository(repo *database.Repository, metadata *mirrorRepoMetadata) {
+	if metadata == nil {
+		return
+	}
+	metadataReq := types.CreateRepoReq{
+		Nickname:  repo.Nickname,
+		StarCount: repo.StarCount,
+	}
+	applyMirrorRepoMetadata(&metadataReq, metadata)
+	if metadataReq.Nickname != "" {
+		repo.Nickname = metadataReq.Nickname
+	}
+	repo.Description = metadataReq.Description
+	repo.License = metadataReq.License
+	if metadataReq.DefaultBranch != "" {
+		repo.DefaultBranch = metadataReq.DefaultBranch
+	}
+	repo.StarCount = metadataReq.StarCount
+}
+
+// buildMirrorRepoMetadataUpdate converts fetched metadata into one transactional update payload.
+func buildMirrorRepoMetadataUpdate(req types.CreateMirrorRepoReq, repo *database.Repository, metadata *mirrorRepoMetadata) (*database.MirrorRepoMetadataUpdate, error) {
+	if metadata == nil && !(req.RepoType == types.MCPServerRepo && hasMCPServerAttributes(req.MCPServerAttributes)) {
+		return nil, nil
+	}
+	update := &database.MirrorRepoMetadataUpdate{Repository: *repo}
+	if req.RepoType == types.MCPServerRepo {
+		mcpServer, properties, err := buildMCPServerRows(req.RepoType, req.MCPServerAttributes, metadata)
+		if err != nil {
+			return nil, err
+		}
+		update.MCPServer = mcpServer
+		update.MCPServerProperties = properties
+	}
+	if metadata != nil && metadata.skill != nil && !metadata.skill.UpdatedAt.IsZero() {
+		updatedAt := metadata.skill.UpdatedAt
+		update.SkillLastUpdatedAt = &updatedAt
+	}
+	return update, nil
 }
 
 // normalizeMirrorPriority defaults an omitted priority and rejects values unsupported by workhub.
@@ -254,20 +553,28 @@ func (m *mirrorComponentImpl) resolveMirrorRepoTarget(req types.CreateMirrorRepo
 }
 
 // createMirrorRepoRecords creates mirror rows transactionally, and optionally the target repo rows too.
-func (m *mirrorComponentImpl) createMirrorRepoRecords(ctx context.Context, req types.CreateMirrorRepoReq, repo *database.Repository, namespace, name string, createRepository bool) (*database.Mirror, error) {
+func (m *mirrorComponentImpl) createMirrorRepoRecords(ctx context.Context, req types.CreateMirrorRepoReq, repo *database.Repository, namespace, name string, createRepository bool, metadata *mirrorRepoMetadata) (*database.Mirror, error) {
 	mirror := buildMirrorRepoRecord(req, repo, namespace, name)
 	if !createRepository && !req.SkipSourcePath {
 		sourceType, sourcePath, _ := common.GetSourceTypeAndPathFromURL(req.SourceGitCloneUrl)
 		applyMirrorRepositorySourcePath(repo, sourceType, sourcePath)
 	}
-	mcpServer, mcpServerProperties, err := buildMCPServerRows(req.RepoType, req.MCPServerAttributes)
+	mcpServer, mcpServerProperties, err := buildMCPServerRows(req.RepoType, req.MCPServerAttributes, metadata)
 	if err != nil {
 		return nil, err
+	}
+	var metadataUpdate *database.MirrorRepoMetadataUpdate
+	if !createRepository {
+		metadataUpdate, err = buildMirrorRepoMetadataUpdate(req, repo, metadata)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	reqMirror, err := m.mirrorRepoStore.CreateMirrorRepoRecords(ctx, database.CreateMirrorRepoRecordsInput{
 		Repository:          repo,
 		CreateRepository:    createRepository,
+		Metadata:            metadataUpdate,
 		MCPServer:           mcpServer,
 		MCPServerProperties: mcpServerProperties,
 		Mirror:              mirror,
@@ -317,6 +624,7 @@ func (m *mirrorComponentImpl) prepareMirrorRepository(ctx context.Context, req t
 		Description:    req.Description,
 		Private:        req.Private,
 		License:        req.License,
+		Readme:         req.Readme,
 		DefaultBranch:  req.DefaultBranch,
 		RepositoryType: req.RepoType,
 		StarCount:      req.StarCount,
@@ -340,10 +648,13 @@ func applyMirrorRepositorySourcePath(repo *database.Repository, sourceType, sour
 	}
 }
 
-// buildMCPServerRows converts MCP mirror attributes into database rows before entering the transaction store.
-func buildMCPServerRows(repoType types.RepositoryType, attributes types.MCPServerAttributes) (*database.MCPServer, []database.MCPServerProperty, error) {
+// buildMCPServerRows converts fetched or caller-provided MCP metadata into transactional database rows.
+func buildMCPServerRows(repoType types.RepositoryType, attributes types.MCPServerAttributes, metadata *mirrorRepoMetadata) (*database.MCPServer, []database.MCPServerProperty, error) {
 	if repoType != types.MCPServerRepo {
 		return nil, nil, nil
+	}
+	if metadata != nil && metadata.mcpServer != nil {
+		return buildFetchedMCPServerRows(metadata.mcpServer)
 	}
 
 	configuration, err := json.Marshal(attributes.Configuration)
@@ -376,6 +687,49 @@ func buildMCPServerRows(repoType types.RepositoryType, attributes types.MCPServe
 			Name:        tool.Name,
 			Description: tool.Description,
 			Schema:      string(schema),
+		})
+	}
+	return mcpServer, properties, nil
+}
+
+// buildFetchedMCPServerRows preserves full MCP metadata and derives tool properties when the schema includes tools.
+func buildFetchedMCPServerRows(metadata *types.MCPServer) (*database.MCPServer, []database.MCPServerProperty, error) {
+	mcpServer := &database.MCPServer{
+		ToolsNum:        metadata.ToolsNum,
+		Configuration:   metadata.Configuration,
+		Schema:          metadata.Schema,
+		ProgramLanguage: metadata.ProgramLanguage,
+		RunMode:         metadata.RunMode,
+		InstallDepsCmds: metadata.InstallDepsCmds,
+		BuildCmds:       metadata.BuildCmds,
+		LaunchCmds:      metadata.LaunchCmds,
+		AvatarURL:       metadata.AvatarURL,
+	}
+	if strings.TrimSpace(metadata.Schema) == "" {
+		return mcpServer, nil, nil
+	}
+
+	var schema struct {
+		Tools []types.MCPTool `json:"tools"`
+	}
+	if err := json.Unmarshal([]byte(metadata.Schema), &schema); err != nil {
+		// The MCP schema is still persisted verbatim when it is not the legacy tools wrapper.
+		return mcpServer, nil, nil
+	}
+	if mcpServer.ToolsNum == 0 {
+		mcpServer.ToolsNum = len(schema.Tools)
+	}
+	properties := make([]database.MCPServerProperty, 0, len(schema.Tools))
+	for _, tool := range schema.Tools {
+		inputSchema, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal fetched mcp tool input schema: %w", err)
+		}
+		properties = append(properties, database.MCPServerProperty{
+			Kind:        types.MCPPropTool,
+			Name:        tool.Name,
+			Description: tool.Description,
+			Schema:      string(inputSchema),
 		})
 	}
 	return mcpServer, properties, nil

--- a/component/mirror_repo_test.go
+++ b/component/mirror_repo_test.go
@@ -3,6 +3,7 @@ package component
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	mockdb "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/builder/store/database"
 	mockcache "opencsg.com/csghub-server/_mocks/opencsg.com/csghub-server/mirror/cache"
 	"opencsg.com/csghub-server/builder/git/membership"
+	"opencsg.com/csghub-server/builder/multisync"
 	"opencsg.com/csghub-server/builder/store/database"
 	"opencsg.com/csghub-server/builder/workhub"
 	"opencsg.com/csghub-server/common/errorx"
@@ -163,6 +165,7 @@ func TestMirrorComponent_SyncMirrorRequiresWritePermission(t *testing.T) {
 	}
 }
 
+// TestMirrorComponent_MirrorFromSaas verifies SaaS sync creation, requeue, and permission behavior.
 func TestMirrorComponent_MirrorFromSaas(t *testing.T) {
 	t.Run("creates mirror records and repo job for existing repo without mirror", func(t *testing.T) {
 		ctx := context.TODO()
@@ -243,6 +246,42 @@ func TestMirrorComponent_MirrorFromSaas(t *testing.T) {
 			Status:       types.MirrorQueued,
 		}, result)
 	})
+
+	for _, repoType := range []types.RepositoryType{types.MCPServerRepo, types.SkillRepo} {
+		t.Run(fmt.Sprintf("requeues existing %s mirror without metadata refresh", repoType), func(t *testing.T) {
+			ctx := context.TODO()
+			mc := initializeTestMirrorComponent(ctx, t)
+			taskJobStore := mockdb.NewMockMirrorTaskJobStore(t)
+			mc.mirrorTaskJobStore = taskJobStore
+			useFakeMirrorJobClient(mc)
+
+			repo := &database.Repository{ID: 123, Path: "CSG_ns/n", RepositoryType: repoType, Source: types.OpenCSGSource}
+			mirror := &database.Mirror{
+				ID: 1, SourceUrl: fmt.Sprintf("https://sync.opencsg.com/%ss/ns/n.git", repoType), RepositoryID: repo.ID, Repository: repo,
+			}
+			mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, repoType, "CSG_ns", "n").Return(repo, nil)
+			mc.mocks.components.repo.EXPECT().GetUserRepoPermission(ctx, "writer", repo).Return(&types.UserRepoPermission{CanWrite: true}, nil)
+			mc.mocks.stores.MirrorMock().EXPECT().FindByRepoID(ctx, repo.ID).Return(mirror, nil)
+			taskJobStore.EXPECT().RequeueMirrorRepoTask(ctx, mock.MatchedBy(func(input database.RequeueMirrorRepoTaskInput) bool {
+				return input.MirrorID == mirror.ID &&
+					input.RepositoryID == repo.ID &&
+					input.Priority == types.LowMirrorPriority &&
+					!input.Urgent &&
+					input.JobClient != nil &&
+					input.JobCancelClient != nil &&
+					input.Metadata == nil
+			})).Return(database.MirrorTask{ID: 99, Status: types.MirrorQueued}, nil)
+
+			result, err := mc.MirrorFromSaas(ctx, types.MirrorFromSaasReq{
+				Namespace: "CSG_ns", Name: "n", RepoType: repoType, CurrentUser: "writer",
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, &types.MirrorFromSaasResponse{
+				RepositoryID: repo.ID, MirrorID: mirror.ID, TaskID: 99, Status: types.MirrorQueued,
+			}, result)
+		})
+	}
 
 	t.Run("rejects users without write permission", func(t *testing.T) {
 		ctx := context.TODO()
@@ -573,13 +612,25 @@ func TestMirrorComponent_CreateMirrorSkipsSourcePathForCodeAndSkill(t *testing.T
 				HTTPCloneURL:   "https://opencsg.com/repos/ns/n.git",
 				RepositoryType: repoType,
 			}
+			sourceURL := "https://github.com/upstream/repo"
+			if repoType == types.SkillRepo {
+				sourceURL = "https://opencsg.com/upstream/repo"
+				mc.mirrorMetadataClientFactory = func(endpoint, accessToken string) multisync.Client {
+					require.Equal(t, "https://hub.opencsg.com", endpoint)
+					require.Empty(t, accessToken)
+					return mc.mocks.multiSyncClient
+				}
+				mc.mocks.multiSyncClient.EXPECT().SkillInfo(ctx, types.SyncVersion{
+					RepoPath: "upstream/repo", RepoType: types.SkillRepo,
+				}).Return(&types.Skill{Description: "fresh skill description", DefaultBranch: "develop"}, nil)
+			}
 
 			mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "user", "ns", membership.RoleAdmin).Return(true, nil)
 			mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, repoType, "ns", "n").Return(repo, nil)
 			mc.mocks.stores.MirrorMock().EXPECT().FindByRepoID(ctx, repo.ID).Return(nil, sql.ErrNoRows)
 
 			got, err := mc.CreateMirror(ctx, types.CreateMirrorReq{
-				SourceUrl:      "https://github.com/upstream/repo",
+				SourceUrl:      sourceURL,
 				CurrentUser:    "user",
 				Namespace:      "ns",
 				Name:           "n",
@@ -589,9 +640,17 @@ func TestMirrorComponent_CreateMirrorSkipsSourcePathForCodeAndSkill(t *testing.T
 			require.NoError(t, err)
 			require.Equal(t, repo.ID, got.RepositoryID)
 			require.Len(t, fakeStore.inputs, 1)
-			require.Empty(t, fakeStore.inputs[0].Repository.GithubPath)
-			require.Empty(t, fakeStore.inputs[0].Repository.HFPath)
-			require.Empty(t, fakeStore.inputs[0].Repository.MSPath)
+			input := fakeStore.inputs[0]
+			require.Empty(t, input.Repository.GithubPath)
+			require.Empty(t, input.Repository.HFPath)
+			require.Empty(t, input.Repository.MSPath)
+			if repoType == types.SkillRepo {
+				require.NotNil(t, input.Metadata)
+				require.Equal(t, "fresh skill description", input.Metadata.Repository.Description)
+				require.Equal(t, "develop", input.Metadata.Repository.DefaultBranch)
+			} else {
+				require.Nil(t, input.Metadata)
+			}
 		})
 	}
 }
@@ -1216,6 +1275,24 @@ func TestMirrorComponent_CreateMirrorRepoCreatesAllMirrorRepoTypes(t *testing.T)
 					AvatarURL:     "https://example.com/avatar.png",
 				}
 			}
+			if repoType == types.SkillRepo {
+				req.MirrorSourceID = 43
+				version := types.SyncVersion{RepoPath: "upstream/repo", RepoType: types.SkillRepo}
+				mc.mocks.stores.MirrorSourceMock().EXPECT().Get(ctx, int64(43)).Return(&database.MirrorSource{
+					ID:         43,
+					InfoAPIUrl: "https://api.community.example.com/",
+				}, nil)
+				mc.mirrorMetadataClientFactory = func(endpoint, accessToken string) multisync.Client {
+					require.Equal(t, "https://api.community.example.com", endpoint)
+					return mc.mocks.multiSyncClient
+				}
+				mc.mocks.multiSyncClient.EXPECT().SkillInfo(ctx, version).Return(&types.Skill{}, nil)
+			} else {
+				mc.mirrorMetadataClientFactory = func(endpoint, accessToken string) multisync.Client {
+					t.Fatal("non-MCP/skill requests and legacy MCP attributes must not fetch metadata")
+					return nil
+				}
+			}
 
 			mc.mocks.stores.MirrorNamespaceMappingMock().EXPECT().FindBySourceNamespace(context.Background(), "upstream").Return(&database.MirrorNamespaceMapping{
 				TargetNamespace: "mapped",
@@ -1257,6 +1334,268 @@ func TestMirrorComponent_CreateMirrorRepoCreatesAllMirrorRepoTypes(t *testing.T)
 	}
 }
 
+// TestMirrorComponent_CreateMirrorRepoFetchesMCPMetadata verifies OpenCSG MCP mirrors import metadata before transactional creation.
+func TestMirrorComponent_CreateMirrorRepoFetchesMCPMetadata(t *testing.T) {
+	ctx := context.TODO()
+	mc := initializeTestMirrorComponent(ctx, t)
+	fakeStore := &fakeMirrorRepoStore{}
+	mc.mirrorRepoStore = fakeStore
+	createTargetRepo := true
+	private := false
+	req := types.CreateMirrorRepoReq{
+		SourceNamespace:   "CSG_AIWizards",
+		SourceName:        "zaturn",
+		MirrorSourceID:    42,
+		RepoType:          types.MCPServerRepo,
+		Private:           &private,
+		CreateTargetRepo:  &createTargetRepo,
+		SourceGitCloneUrl: "https://git.example.opencsg.com/CSG_AIWizards/zaturn.git",
+		AccessToken:       "source-token",
+		Username:          "source-user",
+		Description:       "web description",
+		CurrentUser:       "admin",
+		ForkNamespace:     "local",
+		ForkName:          "zaturn-mirror",
+	}
+	version := types.SyncVersion{RepoPath: "CSG_AIWizards/zaturn", RepoType: types.MCPServerRepo}
+	mcpMetadata := &types.MCPServer{
+		Nickname:        "Zaturn MCP",
+		Description:     "source description",
+		Private:         true,
+		DefaultBranch:   "develop",
+		License:         "Apache-2.0",
+		ToolsNum:        1,
+		Configuration:   `{"command":"zaturn"}`,
+		Schema:          `{"tools":[{"name":"search","description":"Search things","inputSchema":{"required":["query"],"type":"object"}}]}`,
+		StarNum:         12,
+		ProgramLanguage: "python",
+		RunMode:         "stdio",
+		InstallDepsCmds: "pip install -r requirements.txt",
+		BuildCmds:       "python -m build",
+		LaunchCmds:      "python server.py",
+		AvatarURL:       "https://example.com/avatar.png",
+		Readme:          "API README must be ignored",
+	}
+
+	mc.mocks.stores.MirrorSourceMock().EXPECT().Get(ctx, int64(42)).Return(&database.MirrorSource{
+		ID:         42,
+		InfoAPIUrl: "https://api.example.opencsg.com/",
+	}, nil)
+	mc.mirrorMetadataClientFactory = func(endpoint, accessToken string) multisync.Client {
+		require.Equal(t, "https://api.example.opencsg.com", endpoint)
+		require.Equal(t, "source-token", accessToken)
+		return mc.mocks.multiSyncClient
+	}
+	mc.mocks.multiSyncClient.EXPECT().MCPServerInfo(ctx, version).Return(mcpMetadata, nil)
+	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "admin", "local", membership.RoleWrite).Return(true, nil)
+	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.MCPServerRepo, "local", "zaturn-mirror").Return(nil, sql.ErrNoRows)
+	mc.mocks.stores.NamespaceMock().EXPECT().FindByPath(ctx, "local").Return(database.Namespace{Path: "local"}, nil)
+	mc.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "admin").Return(database.User{
+		ID: 1, Username: "admin", Email: "admin@example.com", RoleMask: "admin",
+	}, nil)
+
+	got, err := mc.CreateMirrorRepo(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, fakeStore.inputs, 1)
+	input := fakeStore.inputs[0]
+	require.Equal(t, "Zaturn MCP", input.Repository.Nickname)
+	require.Equal(t, "web description", input.Repository.Description)
+	require.Equal(t, "Apache-2.0", input.Repository.License)
+	require.Equal(t, "develop", input.Repository.DefaultBranch)
+	require.Empty(t, input.Repository.Readme)
+	require.Equal(t, 12, input.Repository.StarCount)
+	require.False(t, input.Repository.Private)
+	require.NotNil(t, input.MCPServer)
+	require.Equal(t, "python", input.MCPServer.ProgramLanguage)
+	require.Equal(t, "stdio", input.MCPServer.RunMode)
+	require.Equal(t, "python server.py", input.MCPServer.LaunchCmds)
+	require.Equal(t, "https://example.com/avatar.png", input.MCPServer.AvatarURL)
+	require.Len(t, input.MCPServerProperties, 1)
+	require.Equal(t, "search", input.MCPServerProperties[0].Name)
+	require.Contains(t, input.MCPServerProperties[0].Schema, `"required":["query"]`)
+}
+
+// TestMirrorComponent_CreateMirrorRepoFetchesSkillMetadata verifies third-party skill mirrors use the configured source API endpoint.
+func TestMirrorComponent_CreateMirrorRepoFetchesSkillMetadata(t *testing.T) {
+	ctx := context.TODO()
+	mc := initializeTestMirrorComponent(ctx, t)
+	fakeStore := &fakeMirrorRepoStore{}
+	mc.mirrorRepoStore = fakeStore
+	req := types.CreateMirrorRepoReq{
+		SourceNamespace:   "test/abc/skills",
+		SourceName:        "reviewer",
+		MirrorSourceID:    44,
+		RepoType:          types.SkillRepo,
+		SourceGitCloneUrl: "https://github.com/skills/reviewer.git",
+		CurrentUser:       "admin",
+		ForkNamespace:     "local",
+		ForkName:          "reviewer",
+	}
+	version := types.SyncVersion{RepoPath: "skills/reviewer", RepoType: types.SkillRepo}
+	skillMetadata := &types.Skill{
+		Nickname:      "Code Reviewer",
+		Description:   "Reviews code changes",
+		DefaultBranch: "master",
+		License:       "MIT",
+		Readme:        "API README must be ignored",
+	}
+
+	mc.mocks.stores.MirrorSourceMock().EXPECT().Get(ctx, int64(44)).Return(&database.MirrorSource{
+		ID:         44,
+		InfoAPIUrl: "https://community.example.com/",
+	}, nil)
+	mc.mirrorMetadataClientFactory = func(endpoint, accessToken string) multisync.Client {
+		require.Equal(t, "https://community.example.com", endpoint)
+		require.Empty(t, accessToken)
+		return mc.mocks.multiSyncClient
+	}
+	mc.mocks.multiSyncClient.EXPECT().SkillInfo(ctx, version).Return(skillMetadata, nil)
+	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "admin", "local", membership.RoleWrite).Return(true, nil)
+	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.SkillRepo, "local", "reviewer").Return(nil, sql.ErrNoRows)
+	mc.mocks.stores.NamespaceMock().EXPECT().FindByPath(ctx, "local").Return(database.Namespace{Path: "local"}, nil)
+	mc.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "admin").Return(database.User{
+		ID: 1, Username: "admin", Email: "admin@example.com", RoleMask: "admin",
+	}, nil)
+
+	got, err := mc.CreateMirrorRepo(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, fakeStore.inputs, 1)
+	input := fakeStore.inputs[0]
+	require.Equal(t, types.SkillRepo, input.Repository.RepositoryType)
+	require.Equal(t, "Code Reviewer", input.Repository.Nickname)
+	require.Equal(t, "Reviews code changes", input.Repository.Description)
+	require.Equal(t, "master", input.Repository.DefaultBranch)
+	require.Equal(t, "MIT", input.Repository.License)
+	require.Empty(t, input.Repository.Readme)
+	require.Nil(t, input.MCPServer)
+}
+
+// TestMirrorComponent_CreateMirrorRepoRejectsUnsupportedMetadataSources verifies MCP and skill metadata APIs are never inferred from arbitrary Git hosts.
+func TestMirrorComponent_CreateMirrorRepoRejectsUnsupportedMetadataSources(t *testing.T) {
+	tests := []struct {
+		name             string
+		repoType         types.RepositoryType
+		sourceURL        string
+		mirrorSourceID   int64
+		mirrorSource     *database.MirrorSource
+		mirrorSourceErr  error
+		wantErrorMessage string
+	}{
+		{
+			name:             "GitHub skill without mirror source",
+			repoType:         types.SkillRepo,
+			sourceURL:        "https://github.com/upstream/reviewer.git",
+			wantErrorMessage: "mirror_source_id with a configured info_api_url is required",
+		},
+		{
+			name:             "GitLab MCP without mirror source",
+			repoType:         types.MCPServerRepo,
+			sourceURL:        "https://gitlab.com/upstream/server.git",
+			wantErrorMessage: "mirror_source_id with a configured info_api_url is required",
+		},
+		{
+			name:             "missing mirror source",
+			repoType:         types.SkillRepo,
+			sourceURL:        "https://github.com/upstream/reviewer.git",
+			mirrorSourceID:   51,
+			mirrorSourceErr:  sql.ErrNoRows,
+			wantErrorMessage: "mirror source 51 does not exist",
+		},
+		{
+			name:           "mirror source without info API URL",
+			repoType:       types.SkillRepo,
+			sourceURL:      "https://github.com/upstream/reviewer.git",
+			mirrorSourceID: 52,
+			mirrorSource: &database.MirrorSource{
+				ID: 52,
+			},
+			wantErrorMessage: "does not configure an info_api_url",
+		},
+		{
+			name:           "mirror source with invalid info API URL",
+			repoType:       types.MCPServerRepo,
+			sourceURL:      "https://gitlab.com/upstream/server.git",
+			mirrorSourceID: 53,
+			mirrorSource: &database.MirrorSource{
+				ID:         53,
+				InfoAPIUrl: "ftp://community.example.com",
+			},
+			wantErrorMessage: "invalid info_api_url for mirror source 53",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			mc := initializeTestMirrorComponent(ctx, t)
+			fakeStore := &fakeMirrorRepoStore{}
+			mc.mirrorRepoStore = fakeStore
+			req := types.CreateMirrorRepoReq{
+				SourceNamespace:   "upstream",
+				SourceName:        "repo",
+				MirrorSourceID:    tt.mirrorSourceID,
+				RepoType:          tt.repoType,
+				SourceGitCloneUrl: tt.sourceURL,
+				CurrentUser:       "admin",
+				ForkNamespace:     "local",
+				ForkName:          "repo",
+			}
+
+			mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "admin", "local", membership.RoleWrite).Return(true, nil)
+			mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, tt.repoType, "local", "repo").Return(nil, sql.ErrNoRows)
+			if tt.mirrorSourceID != 0 {
+				mc.mocks.stores.MirrorSourceMock().EXPECT().Get(ctx, tt.mirrorSourceID).Return(tt.mirrorSource, tt.mirrorSourceErr)
+			}
+			mc.mirrorMetadataClientFactory = func(endpoint, accessToken string) multisync.Client {
+				t.Fatal("unsupported metadata sources must be rejected before creating a client")
+				return nil
+			}
+
+			got, err := mc.CreateMirrorRepo(ctx, req)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.wantErrorMessage)
+			require.True(t, errors.Is(err, errorx.ErrBadRequest))
+			require.Nil(t, got)
+			require.Empty(t, fakeStore.inputs)
+		})
+	}
+}
+
+// TestMirrorComponent_CreateMirrorRepoReturnsMetadataError verifies identified OpenCSG metadata failures abort creation before database writes.
+func TestMirrorComponent_CreateMirrorRepoReturnsMetadataError(t *testing.T) {
+	ctx := context.TODO()
+	mc := initializeTestMirrorComponent(ctx, t)
+	fakeStore := &fakeMirrorRepoStore{}
+	mc.mirrorRepoStore = fakeStore
+	req := types.CreateMirrorRepoReq{
+		SourceNamespace:   "skills",
+		SourceName:        "broken",
+		MirrorSourceID:    54,
+		RepoType:          types.SkillRepo,
+		SourceGitCloneUrl: "https://opencsg.com/skills/broken.git",
+		CurrentUser:       "admin",
+		ForkNamespace:     "local",
+		ForkName:          "broken",
+	}
+	version := types.SyncVersion{RepoPath: "skills/broken", RepoType: types.SkillRepo}
+
+	mc.mocks.stores.MirrorSourceMock().EXPECT().Get(ctx, int64(54)).Return(&database.MirrorSource{ID: 54}, nil)
+	mc.mirrorMetadataClientFactory = func(endpoint, accessToken string) multisync.Client {
+		require.Equal(t, "https://hub.opencsg.com", endpoint)
+		return mc.mocks.multiSyncClient
+	}
+	mc.mocks.multiSyncClient.EXPECT().SkillInfo(ctx, version).Return(nil, fmt.Errorf("upstream unavailable"))
+	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "admin", "local", membership.RoleWrite).Return(true, nil)
+	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.SkillRepo, "local", "broken").Return(nil, sql.ErrNoRows)
+
+	got, err := mc.CreateMirrorRepo(ctx, req)
+	require.ErrorContains(t, err, "failed to fetch skill mirror metadata")
+	require.Nil(t, got)
+	require.Empty(t, fakeStore.inputs)
+}
+
 // TestMirrorComponent_CreateMirrorRepoSkipSourcePath verifies that when SkipSourcePath is true,
 // the source path fields (HFPath/MSPath/GithubPath) are not set on the repository.
 func TestMirrorComponent_CreateMirrorRepoSkipSourcePath(t *testing.T) {
@@ -1295,4 +1634,215 @@ func TestMirrorComponent_CreateMirrorRepoSkipSourcePath(t *testing.T) {
 	require.Empty(t, fakeStore.inputs[0].Repository.GithubPath)
 	require.Empty(t, fakeStore.inputs[0].Repository.HFPath)
 	require.Empty(t, fakeStore.inputs[0].Repository.MSPath)
+}
+
+// TestMirrorComponent_CreateMirrorRepoRefreshesMCPMetadataOnRequeue verifies repeated MCP syncs refresh API metadata with the new task.
+func TestMirrorComponent_CreateMirrorRepoRefreshesMCPMetadataOnRequeue(t *testing.T) {
+	ctx := context.TODO()
+	mc := initializeTestMirrorComponent(ctx, t)
+	req := types.CreateMirrorRepoReq{
+		SourceNamespace:   "upstream",
+		SourceName:        "server",
+		RepoType:          types.MCPServerRepo,
+		CurrentUser:       "admin",
+		SourceGitCloneUrl: "https://opencsg.com/upstream/server.git",
+		ForkNamespace:     "local",
+		ForkName:          "server",
+	}
+	repo := &database.Repository{
+		ID: 11, Path: "local/server", Name: "server", Nickname: "Old MCP", Description: "old description",
+		License: "old-license", Readme: "old readme", DefaultBranch: "main", StarCount: 1, RepositoryType: types.MCPServerRepo,
+	}
+	mirror := &database.Mirror{ID: 3, RepositoryID: repo.ID, SourceUrl: req.SourceGitCloneUrl}
+	version := types.SyncVersion{RepoPath: "upstream/server", RepoType: types.MCPServerRepo}
+	metadata := &types.MCPServer{
+		Nickname: "Fresh MCP", Description: "fresh description", License: "MIT", DefaultBranch: "develop",
+		Readme: "ignored", StarNum: 9, ToolsNum: 1, Configuration: `{"command":"fresh"}`,
+		Schema:          `{"tools":[{"name":"search","description":"Fresh search","inputSchema":{"type":"object"}}]}`,
+		ProgramLanguage: "go", RunMode: "stdio", LaunchCmds: "go run .",
+	}
+
+	mc.mirrorMetadataClientFactory = func(endpoint, accessToken string) multisync.Client {
+		require.Equal(t, "https://hub.opencsg.com", endpoint)
+		require.Empty(t, accessToken)
+		return mc.mocks.multiSyncClient
+	}
+	mc.mocks.multiSyncClient.EXPECT().MCPServerInfo(ctx, version).Return(metadata, nil)
+	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "admin", "local", membership.RoleWrite).Return(true, nil)
+	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, req.RepoType, "local", "server").Return(repo, nil)
+	mc.mocks.stores.MirrorMock().EXPECT().FindByRepoID(ctx, repo.ID).Return(mirror, nil)
+
+	taskJobStore := mockdb.NewMockMirrorTaskJobStore(t)
+	mc.mirrorTaskJobStore = taskJobStore
+	useFakeMirrorJobClient(mc)
+	taskJobStore.EXPECT().RequeueMirrorRepoTask(ctx, mock.MatchedBy(func(input database.RequeueMirrorRepoTaskInput) bool {
+		if input.Metadata == nil || input.Metadata.MCPServer == nil {
+			return false
+		}
+		updatedRepo := input.Metadata.Repository
+		return updatedRepo.ID == repo.ID &&
+			updatedRepo.Nickname == "Fresh MCP" &&
+			updatedRepo.Description == "fresh description" &&
+			updatedRepo.License == "MIT" &&
+			updatedRepo.Readme == "old readme" &&
+			updatedRepo.DefaultBranch == "develop" &&
+			updatedRepo.StarCount == 9 &&
+			input.Metadata.MCPServer.Configuration == `{"command":"fresh"}` &&
+			input.Metadata.MCPServer.ProgramLanguage == "go" &&
+			len(input.Metadata.MCPServerProperties) == 1 &&
+			input.Metadata.MCPServerProperties[0].Name == "search"
+	})).Return(database.MirrorTask{ID: 99}, nil)
+
+	got, err := mc.CreateMirrorRepo(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, mirror.ID, got.ID)
+}
+
+// TestMirrorComponent_CreateMirrorRepoRefreshesSkillMetadataOnRequeue verifies repeated skill syncs refresh API metadata with the new task.
+func TestMirrorComponent_CreateMirrorRepoRefreshesSkillMetadataOnRequeue(t *testing.T) {
+	ctx := context.TODO()
+	mc := initializeTestMirrorComponent(ctx, t)
+	req := types.CreateMirrorRepoReq{
+		SourceNamespace:   "upstream",
+		SourceName:        "reviewer",
+		RepoType:          types.SkillRepo,
+		CurrentUser:       "admin",
+		SourceGitCloneUrl: "https://opencsg.com/upstream/reviewer.git",
+		Description:       "stale request description",
+		License:           "stale-request-license",
+		DefaultBranch:     "stale-request-branch",
+		ForkNamespace:     "local",
+		ForkName:          "reviewer",
+	}
+	repo := &database.Repository{
+		ID: 12, Path: "local/reviewer", Name: "reviewer", Nickname: "Old Skill", Description: "old description",
+		License: "old-license", Readme: "old readme", DefaultBranch: "main", RepositoryType: types.SkillRepo,
+	}
+	mirror := &database.Mirror{ID: 4, RepositoryID: repo.ID, SourceUrl: req.SourceGitCloneUrl}
+	version := types.SyncVersion{RepoPath: "upstream/reviewer", RepoType: types.SkillRepo}
+	updatedAt := time.Date(2026, time.August, 18, 8, 0, 0, 0, time.UTC)
+	metadata := &types.Skill{
+		Nickname: "Fresh Skill", Description: "fresh description", License: "Apache-2.0",
+		DefaultBranch: "develop", UpdatedAt: updatedAt,
+	}
+
+	mc.mirrorMetadataClientFactory = func(endpoint, accessToken string) multisync.Client {
+		require.Equal(t, "https://hub.opencsg.com", endpoint)
+		require.Empty(t, accessToken)
+		return mc.mocks.multiSyncClient
+	}
+	mc.mocks.multiSyncClient.EXPECT().SkillInfo(ctx, version).Return(metadata, nil)
+	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "admin", "local", membership.RoleWrite).Return(true, nil)
+	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, req.RepoType, "local", "reviewer").Return(repo, nil)
+	mc.mocks.stores.MirrorMock().EXPECT().FindByRepoID(ctx, repo.ID).Return(mirror, nil)
+
+	taskJobStore := mockdb.NewMockMirrorTaskJobStore(t)
+	mc.mirrorTaskJobStore = taskJobStore
+	useFakeMirrorJobClient(mc)
+	taskJobStore.EXPECT().RequeueMirrorRepoTask(ctx, mock.MatchedBy(func(input database.RequeueMirrorRepoTaskInput) bool {
+		if input.Metadata == nil || input.Metadata.SkillLastUpdatedAt == nil {
+			return false
+		}
+		updatedRepo := input.Metadata.Repository
+		return updatedRepo.ID == repo.ID &&
+			updatedRepo.Nickname == "Fresh Skill" &&
+			updatedRepo.Description == "fresh description" &&
+			updatedRepo.License == "Apache-2.0" &&
+			updatedRepo.Readme == "old readme" &&
+			updatedRepo.DefaultBranch == "develop" &&
+			input.Metadata.SkillLastUpdatedAt.Equal(updatedAt)
+	})).Return(database.MirrorTask{ID: 100}, nil)
+
+	got, err := mc.CreateMirrorRepo(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, mirror.ID, got.ID)
+}
+
+// TestMirrorComponent_CreateMirrorRepoRefreshesSkillMetadataWhenBindingExistingTarget verifies first task creation also refreshes an existing target.
+func TestMirrorComponent_CreateMirrorRepoRefreshesSkillMetadataWhenBindingExistingTarget(t *testing.T) {
+	ctx := context.TODO()
+	mc := initializeTestMirrorComponent(ctx, t)
+	fakeStore := &fakeMirrorRepoStore{}
+	mc.mirrorRepoStore = fakeStore
+	createTargetRepo := false
+	req := types.CreateMirrorRepoReq{
+		SourceNamespace: "upstream", SourceName: "writer", RepoType: types.SkillRepo,
+		CurrentUser: "admin", SourceGitCloneUrl: "https://opencsg.com/upstream/writer.git",
+		ForkNamespace: "local", ForkName: "writer", CreateTargetRepo: &createTargetRepo,
+	}
+	repo := &database.Repository{
+		ID: 13, Path: "local/writer", Name: "writer", Nickname: "Old Writer", Description: "old description",
+		License: "old-license", Readme: "old readme", DefaultBranch: "main", RepositoryType: types.SkillRepo,
+	}
+	version := types.SyncVersion{RepoPath: "upstream/writer", RepoType: types.SkillRepo}
+	updatedAt := time.Date(2026, time.August, 18, 9, 0, 0, 0, time.UTC)
+
+	mc.mirrorMetadataClientFactory = func(endpoint, accessToken string) multisync.Client {
+		require.Equal(t, "https://hub.opencsg.com", endpoint)
+		return mc.mocks.multiSyncClient
+	}
+	mc.mocks.multiSyncClient.EXPECT().SkillInfo(ctx, version).Return(&types.Skill{
+		Nickname: "Fresh Writer", Description: "fresh description", License: "MIT", DefaultBranch: "develop", UpdatedAt: updatedAt,
+	}, nil)
+	mc.mocks.components.repo.EXPECT().CheckCurrentUserPermission(ctx, "admin", "local", membership.RoleWrite).Return(true, nil)
+	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, req.RepoType, "local", "writer").Return(repo, nil)
+	mc.mocks.stores.MirrorMock().EXPECT().FindByRepoID(ctx, repo.ID).Return(nil, sql.ErrNoRows)
+
+	got, err := mc.CreateMirrorRepo(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, fakeStore.inputs, 1)
+	input := fakeStore.inputs[0]
+	require.False(t, input.CreateRepository)
+	require.NotNil(t, input.Metadata)
+	require.Equal(t, "Fresh Writer", input.Metadata.Repository.Nickname)
+	require.Equal(t, "fresh description", input.Metadata.Repository.Description)
+	require.Equal(t, "MIT", input.Metadata.Repository.License)
+	require.Equal(t, "old readme", input.Metadata.Repository.Readme)
+	require.Equal(t, "develop", input.Metadata.Repository.DefaultBranch)
+	require.NotNil(t, input.Metadata.SkillLastUpdatedAt)
+	require.True(t, input.Metadata.SkillLastUpdatedAt.Equal(updatedAt))
+}
+
+// TestMirrorComponent_SyncMirrorRefreshesSkillMetadata verifies manual sync refreshes skill API metadata before task creation.
+func TestMirrorComponent_SyncMirrorRefreshesSkillMetadata(t *testing.T) {
+	ctx := context.TODO()
+	mc := initializeTestMirrorComponent(ctx, t)
+	repo := &database.Repository{
+		ID: 21, Path: "local/reviewer", Name: "reviewer", Nickname: "Old Skill", Description: "old description",
+		License: "old-license", Readme: "old readme", DefaultBranch: "main", RepositoryType: types.SkillRepo,
+	}
+	mirror := &database.Mirror{
+		ID: 31, RepositoryID: repo.ID, Repository: repo, SourceUrl: "https://opencsg.com/upstream/reviewer.git",
+		SourceRepoPath: "upstream/reviewer", Priority: types.HighMirrorPriority,
+	}
+	version := types.SyncVersion{RepoPath: "upstream/reviewer", RepoType: types.SkillRepo}
+	updatedAt := time.Date(2026, time.August, 18, 10, 0, 0, 0, time.UTC)
+
+	mc.mirrorMetadataClientFactory = func(endpoint, accessToken string) multisync.Client {
+		require.Equal(t, "https://hub.opencsg.com", endpoint)
+		return mc.mocks.multiSyncClient
+	}
+	mc.mocks.multiSyncClient.EXPECT().SkillInfo(ctx, version).Return(&types.Skill{
+		Nickname: "Fresh Skill", Description: "fresh description", License: "MIT", DefaultBranch: "develop", UpdatedAt: updatedAt,
+	}, nil)
+	mc.mocks.stores.UserMock().EXPECT().FindByUsername(ctx, "admin").Return(database.User{RoleMask: "admin"}, nil)
+	mc.mocks.stores.RepoMock().EXPECT().FindByPath(ctx, types.SkillRepo, "local", "reviewer").Return(repo, nil)
+	mc.mocks.stores.MirrorMock().EXPECT().FindByRepoID(ctx, repo.ID).Return(mirror, nil)
+
+	taskJobStore := mockdb.NewMockMirrorTaskJobStore(t)
+	mc.mirrorTaskJobStore = taskJobStore
+	useFakeMirrorJobClient(mc)
+	taskJobStore.EXPECT().RequeueMirrorRepoTask(ctx, mock.MatchedBy(func(input database.RequeueMirrorRepoTaskInput) bool {
+		return input.Metadata != nil &&
+			input.Metadata.Repository.Nickname == "Fresh Skill" &&
+			input.Metadata.Repository.Readme == "old readme" &&
+			input.Metadata.SkillLastUpdatedAt != nil &&
+			input.Metadata.SkillLastUpdatedAt.Equal(updatedAt)
+	})).Return(database.MirrorTask{ID: 101}, nil)
+
+	err := mc.SyncMirror(ctx, types.SyncMirrorReq{
+		RepoType: types.SkillRepo, Namespace: "local", Name: "reviewer", CurrentUser: "admin",
+	})
+	require.NoError(t, err)
 }

--- a/component/wireset.go
+++ b/component/wireset.go
@@ -357,6 +357,7 @@ func NewTestMirrorComponent(config *config.Config, stores *tests.MockStores, rep
 		userStore:                   stores.User,
 		config:                      config,
 		mirrorNamespaceMappingStore: stores.MirrorNamespaceMapping,
+		mirrorMetadataClientFactory: multisync.FromOpenCSG,
 	}
 }
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -41049,14 +41049,6 @@ const docTemplate = `{
                 "license": {
                     "type": "string"
                 },
-                "mcp_server_attributes": {
-                    "description": "MCP only",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.MCPServerAttributes"
-                        }
-                    ]
-                },
                 "mirror_source_id": {
                     "description": "source id for HF,github etc",
                     "type": "integer"
@@ -43193,26 +43185,6 @@ const docTemplate = `{
                 },
                 "user_likes": {
                     "type": "boolean"
-                }
-            }
-        },
-        "types.MCPServerAttributes": {
-            "type": "object",
-            "properties": {
-                "avatar_url": {
-                    "type": "string"
-                },
-                "configuration": {
-                    "$ref": "#/definitions/types.MCPSchema"
-                },
-                "star_count": {
-                    "type": "integer"
-                },
-                "tools": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.MCPTool"
-                    }
                 }
             }
         },


### PR DESCRIPTION
Summary:
- Added synchronization support for MCP and Skill repository types to expand mirroring capabilities beyond existing model, dataset, and code types.
- Updated the mirror repository sync logic to handle the new MCP and Skill categories.
- Corresponding frontend changes implemented to support the new repository types.