### PR TITLE
fix: resolve PostHog CE lint errors

### DIFF
--- a/builder/analytics/publisher.go
+++ b/builder/analytics/publisher.go
@@ -1,0 +1,53 @@
+package analytics
+
+import "sync"
+
+type Config struct {
+	Enabled      bool
+	ProjectToken string
+	APIHost      string
+	Environment  string
+}
+
+type Event struct {
+	Name          string
+	DistinctID    string
+	SessionID     string
+	CorrelationID string
+	InsertID      string
+	Properties    map[string]any
+}
+
+type Publisher interface {
+	Capture(Event) error
+	Close() error
+}
+
+type noOpPublisher struct{}
+
+var (
+	defaultMu        sync.RWMutex
+	defaultPublisher Publisher = noOpPublisher{}
+)
+
+func New(cfg Config) (Publisher, error) {
+	return newPublisher(cfg)
+}
+
+func Default() Publisher {
+	defaultMu.RLock()
+	defer defaultMu.RUnlock()
+	return defaultPublisher
+}
+
+func Assign(publisher Publisher) {
+	if publisher == nil {
+		publisher = noOpPublisher{}
+	}
+	defaultMu.Lock()
+	defaultPublisher = publisher
+	defaultMu.Unlock()
+}
+
+func (noOpPublisher) Capture(Event) error { return nil }
+func (noOpPublisher) Close() error        { return nil }


### PR DESCRIPTION
Summary:
- Resolved CE lint failures caused by unused PostHog request analysis context and event version constants after a recent merge.
- Removed the empty Handler analysis context implementation that had no callers in CE.
- Moved the `eventVersion` constant into EE/SaaS-only compiled PostHog implementations to ensure it is only included where it is used.