### PR TITLE
docs: fix typo verfiy -> verify

### DIFF
--- a/builder/store/database/account_statement.go
+++ b/builder/store/database/account_statement.go
@@ -661,7 +661,7 @@ func CheckDuplicatedEvent(ctx context.Context, tx bun.Tx, input AccountStatement
 	}
 
 	if !errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("verfiy account statement, event_uuid: %s, err: %w", input.EventUUID, err)
+		return fmt.Errorf("verify account statement, event_uuid: %s, err: %w", input.EventUUID, err)
 	}
 
 	return nil


### PR DESCRIPTION
Corrects the misspelling `verfiy` -> `verify` in `builder/store/database/account_statement.go`.

Documentation only, no behaviour change.