### PR TITLE
feat: add PaddleOCR-VL PaddleX document parsing runtime

### DIFF
--- a/.specs/paddle-ocr/paddlex_vl.md
+++ b/.specs/paddle-ocr/paddlex_vl.md
@@ -1,0 +1,467 @@
+# PaddleOCR-VL PaddleX Runtime Specification
+
+## Status
+
+This document defines the CSGHub runtime and AIGateway architecture for serving the PaddleOCR-VL series as full PaddleX document-parsing pipelines.
+
+The classic OCR contract remains documented in [paddle_ocr.md](./paddle_ocr.md). The two runtime frameworks share an image lineage and public AIGateway route, but they intentionally expose different PaddleX pipelines and upstream protocols.
+
+## Context
+
+PaddleOCR-VL has two distinct serving modes:
+
+1. Serve the VLM directly through an inference engine such as vLLM. This provides region recognition through an OpenAI-compatible model endpoint.
+2. Serve the full PaddleX pipeline. This adds layout analysis, region cropping, reading order, recognition, and document-result assembly.
+
+Direct vLLM support for `PaddleOCRVLForConditionalGeneration` does not make vLLM a document parser. Sending a full document directly to the VLM bypasses PaddleX layout analysis and assembly, which reduces quality for complex layouts, tables, formulas, and multi-page documents.
+
+CSGHub therefore treats the two modes as different runtime choices:
+
+| Runtime framework | Purpose | Public API | Runtime API |
+| --- | --- | --- | --- |
+| `vllm` | Direct VLM inference | `/v1/chat/completions` or `/v1/responses` | OpenAI-compatible model API |
+| `paddleocr` | Classic text detection and recognition | `/v1/ocr` | `/ocr` |
+| `paddleocr-vl` | Full document parsing | `/v1/ocr` | `/layout-parsing` |
+
+## Goals
+
+- Deploy PaddleOCR-VL as a complete PaddleX document-parsing pipeline.
+- Support images and PDFs through the existing `POST /v1/ocr` AIGateway route.
+- Preserve classic PaddleOCR behavior and its `/ocr` upstream protocol.
+- Use the selected model repository for VL recognition while allowing PaddleX to resolve required submodels.
+- Match each PaddleOCR-VL model version to its corresponding top-level PaddleX pipeline.
+- Preserve provider-specific structured output behind `raw_response=true`.
+- Keep pipeline selection explicit in the selected image's baked startup command.
+
+## Non-goals
+
+- Adding PaddleX document-parser steps to vLLM.
+- Creating a second independently maintained Dockerfile for PaddleOCR-VL.
+- Supporting PaddleOCR-VL on the CPU runtime without separate validation.
+- Orchestrating a separate vLLM or SGLang recognition service in this version.
+- Uploading PaddleX base64 result images to object storage.
+- Flattening tables, formulas, and layout blocks into classic OCR line objects.
+- Adding another public document-parsing route.
+
+## Core Design Decisions
+
+### Separate runtime framework
+
+`paddleocr-vl` is a separate runtime framework rather than a mode hidden inside `paddleocr` or `vllm`.
+
+This keeps these contracts explicit:
+
+- runtime selection: `paddleocr-vl`;
+- PaddleX pipeline: a version-matched PaddleOCR-VL pipeline;
+- upstream endpoint: `/layout-parsing`;
+- supported input: image and PDF;
+- normalized result: page Markdown plus plain text.
+
+The framework is registered by `configs/inference/paddleocr-vl.json` as a GPU-only safetensors runtime supporting `PaddleOCRVLForConditionalGeneration`.
+
+### Shared image lineage
+
+The GPU image in `docker/inference/Dockerfile.paddleocr` contains a shared base with the dependencies needed by both classic OCR and PaddleOCR-VL. Its `paddleocr` and `paddleocr-vl` final targets reuse those layers but bake different startup commands. The framework configurations use distinct immutable image references because runtime-framework persistence currently uses image identity as part of framework resolution.
+
+```text
+one Dockerfile and shared filesystem layers
+  ├── target paddleocr    -> CMD serve.sh paddleocr
+  │                         -> opencsghq/paddleocr:3.7.0
+  └── target paddleocr-vl -> CMD serve.sh paddleocr-vl
+                            -> opencsghq/paddleocr-vl:3.7.0
+```
+
+The two image repositories intentionally use the same `3.7.0` release version. They do not collide because their repository names differ, and their final OCI image configurations and manifest digests are distinct because their `CMD` values differ. Selecting the runtime framework therefore selects both the implementation image and its behavior; deployment code does not inject the framework name into the container. The existing classic `opencsghq/paddleocr:3.7.0` image must not be replaced when the new VL image is published.
+
+### PaddleX owns the document pipeline
+
+PaddleX remains responsible for:
+
+- selecting the layout-analysis submodel;
+- detecting layout regions and reading order;
+- cropping document regions;
+- invoking VL recognition;
+- assembling per-page structured results and Markdown.
+
+AIGateway only transforms the client request, selects the correct adapter, proxies to PaddleX, and normalizes the response.
+
+## PaddleOCR-VL Version Mapping
+
+PaddleX registers the PaddleOCR-VL series as independent top-level pipelines. Their APIs are similar, but their default layout and VL models differ.
+
+| PaddleX pipeline | Layout-analysis model | VL-recognition model |
+| --- | --- | --- |
+| `PaddleOCR-VL` | `PP-DocLayoutV2` | `PaddleOCR-VL-0.9B` |
+| `PaddleOCR-VL-1.5` | `PP-DocLayoutV3` | `PaddleOCR-VL-1.5-0.9B` |
+| `PaddleOCR-VL-1.6` | `PP-DocLayoutV3` | `PaddleOCR-VL-1.6-0.9B` |
+
+The runtime derives the pipeline from the downloaded repository basename:
+
+| Model basename pattern | Selected pipeline |
+| --- | --- |
+| `PaddleOCR-VL-1.6*` | `PaddleOCR-VL-1.6` |
+| `PaddleOCR-VL-1.5*` | `PaddleOCR-VL-1.5` |
+| `PaddleOCR-VL*` | `PaddleOCR-VL` |
+
+The most specific patterns must be evaluated first. Names outside the PaddleOCR-VL family fail startup. The broad base-family fallback supports existing base-repository naming variants; a new version must receive an explicit mapping and validation before it is declared supported.
+
+The pipeline version, rather than custom CSGHub logic, selects `PP-DocLayoutV2` or `PP-DocLayoutV3`. `gen_pipeline.py` patches only `SubModules.VLRecognition`; it must not replace `SubModules.LayoutDetection`.
+
+## System Architecture
+
+```text
+Client
+  |
+  | POST /v1/ocr (multipart file + model + options)
+  v
+AIGateway OCR handler
+  |
+  | resolve model and runtime_framework
+  v
+OCR adapter registry
+  ├── paddleocr    -> classic PaddleX adapter -> /ocr
+  └── paddleocr-vl -> PaddleX VL adapter      -> /layout-parsing
+                                                   |
+                                                   v
+                                           PaddleX VL pipeline
+                                           ├── LayoutDetection
+                                           │   └── PP-DocLayoutV2/V3
+                                           ├── VLRecognition
+                                           │   └── selected local VL repo
+                                           └── document assembly
+```
+
+The main implementation seams are:
+
+| Responsibility | File |
+| --- | --- |
+| Runtime registration | `configs/inference/paddleocr-vl.json` |
+| Runtime image | `docker/inference/Dockerfile.paddleocr` |
+| Repository download | `docker/inference/paddleocr/entry.py` |
+| Framework and pipeline selection | `docker/inference/paddleocr/serve.sh` |
+| Generated-config patching | `docker/inference/paddleocr/gen_pipeline.py` |
+| Adapter registry and shared contract | `aigateway/component/adapter/ocr/adapter.go` |
+| Classic PaddleX adapter | `aigateway/component/adapter/ocr/paddlex.go` |
+| PaddleOCR-VL adapter | `aigateway/component/adapter/ocr/paddlex_vl.go` |
+| Public request handling | `aigateway/handler/openai_ocr.go` |
+| Normalized API types | `aigateway/types/ocr.go` |
+
+## Deployment and Startup Flow
+
+### Image-owned runtime mode
+
+Selecting a runtime framework already selects its immutable `FrameImage`. The image target owns its PaddleOCR mode through the baked command:
+
+```text
+paddleocr image    -> /etc/csghub/serve.sh paddleocr
+paddleocr-vl image -> /etc/csghub/serve.sh paddleocr-vl
+```
+
+`serve.sh` treats its first argument as authoritative. It accepts only `paddleocr` and `paddleocr-vl` and fails startup for a missing or unknown value. Repository names, deployment environment values, and user-provided engine arguments do not choose between classic OCR and VL parsing.
+
+The CPU Dockerfile explicitly invokes the classic `paddleocr` mode. PaddleOCR-VL remains GPU-only.
+
+### Selected repository download
+
+`entry.py` downloads `REPO_ID` at `REVISION` from the deployment-provided CSGHub endpoint into:
+
+```text
+/workspace/<REPO_ID>
+```
+
+This is the user-selected primary model repository. For a bare PaddleOCR-VL repository, it contains the VL-recognition weights, not the complete PaddleX pipeline and all its submodels.
+
+### Pipeline-selection precedence
+
+`serve.sh` selects the pipeline in this order:
+
+1. Use `PADDLEX_PIPELINE` when explicitly set.
+2. Use `<model repo>/pipeline.yaml` when present.
+3. For classic OCR, use `<model repo>/OCR.yaml` when present.
+4. In `local-only` mode, fail if the repository is not a self-contained pipeline bundle.
+5. For `paddleocr-vl` in hub mode, derive and generate the version-matched top-level pipeline configuration.
+6. For a classic single recognition model, generate and patch the `OCR` configuration.
+7. Otherwise start PaddleX's built-in `OCR` pipeline.
+
+The runtime generates the VL configuration under the downloaded repository's runtime-owned directory:
+
+```text
+/workspace/<REPO_ID>/.csghub/<pipeline-name>.yaml
+```
+
+For example:
+
+```bash
+paddlex --get_pipeline_config PaddleOCR-VL-1.6 \
+  --save_path /workspace/<REPO_ID>/.csghub
+```
+
+PaddleX deterministically writes `PaddleOCR-VL-1.6.yaml`. The runtime removes a stale generated copy first because `/workspace` can persist across restarts and the PaddleX CLI otherwise prompts before overwriting.
+
+`gen_pipeline.py` then updates only the selected recognition module:
+
+```yaml
+SubModules:
+  LayoutDetection:
+    model_name: PP-DocLayoutV3
+    model_dir: null
+
+  VLRecognition:
+    model_name: PaddleOCR-VL-1.6-0.9B
+    model_dir: /workspace/<REPO_ID>
+```
+
+Leaving the layout `model_dir` unset is intentional: it activates PaddleX's established submodel-resolution behavior, which is also used by classic OCR detection and optional preprocessing models.
+
+## Model Source Strategy
+
+### Hub mode
+
+`PADDLEOCR_MODEL_SOURCE=hub` is the default. The runtime configures PaddleX's Hugging Face model source to use CSGHub's compatible API:
+
+```text
+PADDLE_PDX_HUGGING_FACE_ENDPOINT=<HF_ENDPOINT>/hf
+PADDLE_PDX_MODEL_SOURCE=huggingface
+HF_TOKEN=<ACCESS_TOKEN>
+HF_HUB_OFFLINE=0
+```
+
+The selected VL repository is downloaded by `entry.py`. Required pipeline submodels, including `PP-DocLayoutV2` or `PP-DocLayoutV3`, are resolved by PaddleX from their `model_name` values and cached by PaddleX.
+
+The runtime does not contain a separate `PP-DocLayoutV3` downloader and does not bake layout-model weights into the image. This keeps model versions independent from the runtime image and follows the same design as classic OCR submodel resolution.
+
+### Local-only mode
+
+`PADDLEOCR_MODEL_SOURCE=local-only` is the strict offline mode. The selected repository must include a self-contained `pipeline.yaml` and every required model directory.
+
+Example:
+
+```text
+<repo>/
+├── pipeline.yaml
+└── models/
+    ├── PP-DocLayoutV3/
+    └── PaddleOCR-VL-1.6-0.9B/
+```
+
+The pipeline must point every required module at its local directory:
+
+```yaml
+SubModules:
+  LayoutDetection:
+    model_name: PP-DocLayoutV3
+    model_dir: /workspace/<REPO_ID>/models/PP-DocLayoutV3
+  VLRecognition:
+    model_name: PaddleOCR-VL-1.6-0.9B
+    model_dir: /workspace/<REPO_ID>/models/PaddleOCR-VL-1.6-0.9B
+```
+
+The runtime fails before generating a pipeline when a local-only repository does not contain `pipeline.yaml`. This prevents accidental network dependency in an air-gapped deployment.
+
+## Public AIGateway Contract
+
+### Request
+
+```text
+POST /v1/ocr
+Content-Type: multipart/form-data
+Authorization: Bearer <API key>
+```
+
+Required fields:
+
+- `model`: deployed model ID;
+- `file`: one image or PDF file.
+
+Supported content types:
+
+- `image/png`;
+- `image/jpeg`;
+- `image/webp`;
+- `image/bmp`;
+- `image/tiff`;
+- `application/pdf`, only for `paddleocr-vl`.
+
+The uploaded file limit is 20 MiB. The whole multipart request is bounded by an additional 1 MiB for form overhead.
+
+Optional fields:
+
+| Field | Classic OCR | PaddleOCR-VL |
+| --- | --- | --- |
+| `use_doc_orientation_classify` | forwarded | forwarded |
+| `use_doc_unwarping` | forwarded | forwarded |
+| `use_textline_orientation` | forwarded | rejected |
+| `return_image` | maps to upstream `visualize` | maps to upstream `visualize` |
+| `raw_response` | includes raw result | includes raw result and requests Markdown images |
+| `page_ranges` | rejected when non-empty | rejected when non-empty |
+
+### PaddleX VL upstream request
+
+AIGateway converts the multipart upload to PaddleX JSON:
+
+```json
+{
+  "file": "<base64 file bytes>",
+  "fileType": 1,
+  "visualize": false,
+  "returnMarkdownImages": false
+}
+```
+
+`fileType` is `1` for images and `0` for PDFs. `returnMarkdownImages` is enabled only when `raw_response=true`, because the normalized response has no stable contract for provider-specific embedded image payloads.
+
+The adapter proxies this request to `/layout-parsing`. A model-level endpoint path may override the adapter's default endpoint.
+
+### Normalized response
+
+```json
+{
+  "id": "ocr_<id>",
+  "object": "ocr.result",
+  "created": 1760000000,
+  "model": "owner/model:deploy-id",
+  "text": "combined plain text",
+  "pages": [
+    {
+      "index": 0,
+      "text": "page plain text",
+      "markdown": "page markdown",
+      "lines": []
+    }
+  ],
+  "usage": {
+    "pages": 1,
+    "images": 1
+  }
+}
+```
+
+Response mapping:
+
+| PaddleX field | AIGateway field |
+| --- | --- |
+| `layoutParsingResults[i].markdown.text` | `pages[i].markdown` |
+| `layoutParsingResults[i].prunedResult.parsing_res_list[].block_content` | joined into `pages[i].text` |
+| all page text | joined into top-level `text` |
+| number of layout parsing results | `usage.pages` |
+| complete PaddleX response | `raw_result`, only with `raw_response=true` |
+
+The upstream `markdown` field is an object, while `OCRPage.Markdown` is deliberately a string. Only `markdown.text` is placed in the normalized page. The complete Markdown object, including `markdown.images`, remains available through `raw_result` when requested.
+
+`outputImages` and `markdown.images` must not be mapped to `pages[].image_url`: PaddleX may return base64 data rather than stable URLs. AIGateway does not upload these payloads to object storage in this version.
+
+The normalized Markdown is not guaranteed to be self-contained when PaddleX emits relative image references. Clients that need provider-specific Markdown assets must request `raw_response=true` and consume the complete `markdown.images` mapping from `raw_result`.
+
+VL results use Markdown and page text rather than classic `OCRLine` values. Tables, formulas, and layout blocks remain in Markdown or `raw_result` instead of being represented as ordinary OCR lines.
+
+## Adapter and Proxy Behavior
+
+The OCR adapter registry evaluates the VL adapter before the classic adapter. This matters because the classic adapter also supports broader legacy task/provider matching.
+
+```text
+runtime_framework=paddleocr-vl
+  -> PaddleXVLAdapter
+  -> /layout-parsing
+
+runtime_framework=paddleocr
+  -> PaddleXAdapter
+  -> /ocr
+```
+
+The response wrapper buffers the non-streaming PaddleX response, passes upstream HTTP errors through unchanged, and normalizes successful responses with the selected adapter. Invalid successful payloads become an `upstream_response_error` response.
+
+The VL adapter fails normalization when:
+
+- PaddleX reports a non-zero `errorCode`;
+- `layoutParsingResults` is empty;
+- a page has no `markdown.text`;
+- a page has no `prunedResult.parsing_res_list`.
+
+## Usage, Authentication, and Observability
+
+The handler follows the standard AIGateway inference flow:
+
+1. authenticate the request;
+2. resolve the deployed model target;
+3. select the OCR adapter;
+4. validate the input against adapter capabilities;
+5. run balance checks when applicable;
+6. proxy and normalize the PaddleX response;
+7. record OCR usage asynchronously.
+
+OCR usage is derived from the normalized response and records page and image counts. Modal-generation traces include the selected model, status, page count, image count, `page_ranges`, and `return_image` metadata.
+
+Runtime model downloads use the deployment access token. AIGateway applies the resolved model's configured upstream authentication headers before proxying.
+
+## Failure Behavior
+
+| Condition | Behavior |
+| --- | --- |
+| Missing or unknown image runtime-mode argument | Container startup fails |
+| Unknown PaddleOCR model source | Container startup fails |
+| Model basename outside the PaddleOCR-VL family | Container startup fails |
+| Missing offline pipeline bundle | Container startup fails |
+| PaddleX fails to generate the selected pipeline config | Container startup fails |
+| PDF sent to classic OCR | AIGateway returns a client error |
+| `use_textline_orientation` sent to VL | AIGateway returns a client error |
+| Non-empty `page_ranges` | AIGateway returns a client error |
+| Upstream HTTP error | Status and body pass through |
+| Invalid successful upstream response | AIGateway returns `upstream_response_error` |
+
+## Verification Requirements
+
+### Runtime
+
+- Verify all three supported PaddleOCR-VL pipeline names generate the expected YAML filename.
+- Verify each model basename selects its matching pipeline.
+- Verify the base pipeline retains `PP-DocLayoutV2`.
+- Verify the 1.5 and 1.6 pipelines retain `PP-DocLayoutV3`.
+- Verify generated patching changes only `VLRecognition`.
+- Verify layout submodels download through the configured model source in hub mode.
+- Verify a complete local-only bundle starts without network access.
+- Verify missing local-only submodels fail clearly.
+- Verify missing or unknown image runtime modes and non-PaddleOCR-VL model names fail startup.
+- Require an explicit mapping and compatibility validation before declaring a future PaddleOCR-VL version supported.
+
+### AIGateway
+
+- Classic image OCR regression through `/ocr`.
+- VL image parsing through `/layout-parsing`.
+- Multi-page PDF parsing and correct page count.
+- Reading-order, table, and formula fixtures.
+- Image/PDF `fileType` mapping.
+- Unsupported classic PDF and VL text-line-orientation errors.
+- Rejection of non-empty `page_ranges`.
+- `markdown.text` string normalization.
+- Populated, missing, and null `markdown.images` inside raw results.
+- Complete raw-response gating.
+- Upstream HTTP-error passthrough and invalid-success-response handling.
+- OCR usage and trace metadata.
+
+### Operational acceptance
+
+Before publishing a new runtime tag, record:
+
+- cold-start and submodel-download time;
+- GPU memory use;
+- image and multi-page PDF latency;
+- reading-order, table, formula, and Markdown quality;
+- behavior across pod restarts with a warm model cache;
+- failure diagnostics when a required submodel cannot be downloaded.
+
+Do not build or publish an image as part of documentation-only changes.
+
+## Follow-ups
+
+- Add a separately designed external `vllm-server` or `sglang-server` recognition topology if performance requires it. This needs lifecycle, readiness, networking, credentials, and resource-accounting design.
+- Add typed document blocks only through a new normalized API contract; do not overload `OCRLine`.
+- Add Markdown asset hosting only with an explicit storage, lifetime, authorization, and URL contract.
+- Revisit PDF size and timeout limits using production document distributions.
+- Replace image-based runtime-framework identity with a stable framework ID/name in a broader runtime architecture change.
+
+## References
+
+- PaddleX PaddleOCR-VL pipeline: https://paddlepaddle.github.io/PaddleX/3.7/en/pipeline_usage/tutorials/ocr_pipelines/PaddleOCR-VL.html
+- PaddleX layout analysis: https://paddlepaddle.github.io/PaddleX/latest/en/module_usage/tutorials/ocr_modules/layout_analysis.html
+- vLLM PaddleOCR-VL recipe: https://docs.vllm.ai/projects/recipes/en/stable/PaddlePaddle/PaddleOCR-VL.html
+- GitLab issue: https://git-devops.opencsg.com/product/starhub/starhub-server/-/issues/1434

--- a/aigateway/component/adapter/ocr/adapter.go
+++ b/aigateway/component/adapter/ocr/adapter.go
@@ -1,8 +1,12 @@
 package ocr
 
 import (
+	"errors"
+
 	"opencsg.com/csghub-server/aigateway/types"
 )
+
+var ErrUnsupportedOption = errors.New("unsupported OCR option")
 
 // PaddleX fileType values for the upstream serving contract.
 const (
@@ -19,6 +23,7 @@ type UpstreamInput struct {
 	UseDocUnwarping           *bool
 	UseTextlineOrientation    *bool
 	Visualize                 bool
+	ReturnMarkdownImages      bool
 }
 
 // ResponseOptions controls how the upstream response is normalized.
@@ -33,6 +38,7 @@ type ResponseOptions struct {
 type Adapter interface {
 	Name() string
 	CanHandle(model *types.Model) bool
+	SupportsFileType(fileType int) bool
 	// EndpointPath is the upstream OCR route path, default "/ocr".
 	EndpointPath(model *types.Model) string
 	BuildUpstreamRequest(in *UpstreamInput) ([]byte, error)
@@ -46,6 +52,7 @@ type Registry struct {
 func NewRegistry() *Registry {
 	return &Registry{
 		adapters: []Adapter{
+			NewPaddleXVLAdapter(),
 			NewPaddleXAdapter(),
 		},
 	}

--- a/aigateway/component/adapter/ocr/paddlex.go
+++ b/aigateway/component/adapter/ocr/paddlex.go
@@ -50,6 +50,10 @@ func (a *PaddleXAdapter) CanHandle(model *types.Model) bool {
 	return false
 }
 
+func (a *PaddleXAdapter) SupportsFileType(fileType int) bool {
+	return fileType == FileTypeImage
+}
+
 func isValue(value, expected string) bool {
 	return strings.EqualFold(strings.TrimSpace(value), expected)
 }

--- a/aigateway/component/adapter/ocr/paddlex_test.go
+++ b/aigateway/component/adapter/ocr/paddlex_test.go
@@ -65,6 +65,12 @@ func TestPaddleXAdapter_CanHandle(t *testing.T) {
 	}
 }
 
+func TestPaddleXAdapter_SupportsFileType(t *testing.T) {
+	a := NewPaddleXAdapter()
+	assert.True(t, a.SupportsFileType(FileTypeImage))
+	assert.False(t, a.SupportsFileType(FileTypePDF))
+}
+
 func TestPaddleXAdapter_BuildUpstreamRequest(t *testing.T) {
 	a := NewPaddleXAdapter()
 
@@ -211,6 +217,10 @@ func TestPaddleXAdapter_TransformResponse_MultiPage(t *testing.T) {
 
 func TestRegistry_GetAdapter(t *testing.T) {
 	r := NewRegistry()
+	vlModel := &types.Model{
+		InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "paddleocr-vl"},
+	}
+	assert.Equal(t, paddleXVLAdapterName, r.GetAdapter(vlModel).Name())
 
 	model := &types.Model{
 		InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "paddleocr"},

--- a/aigateway/component/adapter/ocr/paddlex_vl.go
+++ b/aigateway/component/adapter/ocr/paddlex_vl.go
@@ -1,0 +1,158 @@
+package ocr
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+const (
+	paddleXVLAdapterName  = "paddlex-vl"
+	paddleXVLEndpointPath = "/layout-parsing"
+
+	// RuntimeFrameworkPaddleOCRVL is the engine_name of the full PaddleOCR-VL runtime.
+	RuntimeFrameworkPaddleOCRVL = "paddleocr-vl"
+)
+
+// PaddleXVLAdapter implements the full PaddleOCR-VL layout-parsing protocol.
+type PaddleXVLAdapter struct{}
+
+func NewPaddleXVLAdapter() *PaddleXVLAdapter {
+	return &PaddleXVLAdapter{}
+}
+
+func (a *PaddleXVLAdapter) Name() string {
+	return paddleXVLAdapterName
+}
+
+func (a *PaddleXVLAdapter) CanHandle(model *types.Model) bool {
+	return model != nil && isValue(model.RuntimeFramework, RuntimeFrameworkPaddleOCRVL)
+}
+
+func (a *PaddleXVLAdapter) SupportsFileType(fileType int) bool {
+	return fileType == FileTypeImage || fileType == FileTypePDF
+}
+
+func (a *PaddleXVLAdapter) EndpointPath(_ *types.Model) string {
+	return paddleXVLEndpointPath
+}
+
+type paddleXVLRequest struct {
+	File                      string `json:"file"`
+	FileType                  int    `json:"fileType"`
+	UseDocOrientationClassify *bool  `json:"useDocOrientationClassify,omitempty"`
+	UseDocUnwarping           *bool  `json:"useDocUnwarping,omitempty"`
+	Visualize                 bool   `json:"visualize"`
+	ReturnMarkdownImages      bool   `json:"returnMarkdownImages"`
+}
+
+func (a *PaddleXVLAdapter) BuildUpstreamRequest(in *UpstreamInput) ([]byte, error) {
+	if in == nil || len(in.FileBytes) == 0 {
+		return nil, fmt.Errorf("ocr upstream input file is empty")
+	}
+	if !a.SupportsFileType(in.FileType) {
+		return nil, fmt.Errorf("unsupported PaddleOCR-VL file type %d", in.FileType)
+	}
+	if in.UseTextlineOrientation != nil {
+		return nil, fmt.Errorf("%w: use_textline_orientation is not supported by paddleocr-vl", ErrUnsupportedOption)
+	}
+	return json.Marshal(paddleXVLRequest{
+		File:                      base64.StdEncoding.EncodeToString(in.FileBytes),
+		FileType:                  in.FileType,
+		UseDocOrientationClassify: in.UseDocOrientationClassify,
+		UseDocUnwarping:           in.UseDocUnwarping,
+		Visualize:                 in.Visualize,
+		ReturnMarkdownImages:      in.ReturnMarkdownImages,
+	})
+}
+
+type paddleXVLResponse struct {
+	LogID     string          `json:"logId"`
+	ErrorCode int             `json:"errorCode"`
+	ErrorMsg  string          `json:"errorMsg"`
+	Result    paddleXVLResult `json:"result"`
+}
+
+type paddleXVLResult struct {
+	LayoutParsingResults []paddleXVLLayoutResult `json:"layoutParsingResults"`
+}
+
+type paddleXVLLayoutResult struct {
+	PrunedResult paddleXVLPrunedResult `json:"prunedResult"`
+	Markdown     paddleXVLMarkdown     `json:"markdown"`
+}
+
+type paddleXVLPrunedResult struct {
+	ParsingResults []paddleXVLParsingResult `json:"parsing_res_list"`
+}
+
+type paddleXVLParsingResult struct {
+	BlockContent string `json:"block_content"`
+}
+
+type paddleXVLMarkdown struct {
+	Text   *string         `json:"text"`
+	Images json.RawMessage `json:"images"`
+}
+
+func (a *PaddleXVLAdapter) TransformResponse(respBody []byte, opts *ResponseOptions) (*types.OCRResponse, error) {
+	var upstream paddleXVLResponse
+	if err := json.Unmarshal(respBody, &upstream); err != nil {
+		return nil, fmt.Errorf("decode paddlex vl response: %w", err)
+	}
+	if upstream.ErrorCode != 0 {
+		return nil, fmt.Errorf("paddlex vl error %d: %s", upstream.ErrorCode, upstream.ErrorMsg)
+	}
+	if len(upstream.Result.LayoutParsingResults) == 0 {
+		return nil, fmt.Errorf("paddlex vl response has no layoutParsingResults")
+	}
+
+	resp := &types.OCRResponse{
+		ID:      types.NewOCRResponseID(),
+		Object:  types.OCRResponseObject,
+		Created: time.Now().Unix(),
+		Pages:   make([]types.OCRPage, 0, len(upstream.Result.LayoutParsingResults)),
+	}
+	if opts != nil {
+		resp.Model = opts.ModelID
+	}
+
+	pageTexts := make([]string, 0, len(upstream.Result.LayoutParsingResults))
+	for i, result := range upstream.Result.LayoutParsingResults {
+		if result.Markdown.Text == nil {
+			return nil, fmt.Errorf("paddlex vl response page %d has no markdown.text", i)
+		}
+		if result.PrunedResult.ParsingResults == nil {
+			return nil, fmt.Errorf("paddlex vl response page %d has no prunedResult.parsing_res_list", i)
+		}
+
+		blocks := make([]string, 0, len(result.PrunedResult.ParsingResults))
+		for _, block := range result.PrunedResult.ParsingResults {
+			if block.BlockContent != "" {
+				blocks = append(blocks, block.BlockContent)
+			}
+		}
+		pageText := strings.Join(blocks, "\n")
+		pageTexts = append(pageTexts, pageText)
+		resp.Pages = append(resp.Pages, types.OCRPage{
+			Index:    i,
+			Text:     pageText,
+			Markdown: *result.Markdown.Text,
+			Lines:    []types.OCRLine{},
+		})
+	}
+
+	resp.Text = strings.Join(pageTexts, "\n")
+	resp.Usage = types.OCRUsage{Pages: len(resp.Pages), Images: 1}
+	if opts != nil && opts.RawResponse {
+		var raw any
+		if err := json.Unmarshal(respBody, &raw); err == nil {
+			resp.RawResult = raw
+		}
+	}
+	return resp, nil
+}

--- a/aigateway/component/adapter/ocr/paddlex_vl_test.go
+++ b/aigateway/component/adapter/ocr/paddlex_vl_test.go
@@ -1,0 +1,143 @@
+package ocr
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+func TestPaddleXVLAdapter_CanHandleAndFileTypes(t *testing.T) {
+	a := NewPaddleXVLAdapter()
+
+	assert.True(t, a.CanHandle(&types.Model{InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "paddleocr-vl"}}))
+	assert.False(t, a.CanHandle(&types.Model{InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "paddleocr"}}))
+	assert.False(t, a.CanHandle(nil))
+	assert.True(t, a.SupportsFileType(FileTypeImage))
+	assert.True(t, a.SupportsFileType(FileTypePDF))
+	assert.Equal(t, paddleXVLEndpointPath, a.EndpointPath(nil))
+}
+
+func TestPaddleXVLAdapter_BuildUpstreamRequest(t *testing.T) {
+	a := NewPaddleXVLAdapter()
+	body, err := a.BuildUpstreamRequest(&UpstreamInput{
+		FileBytes:                 []byte("pdf-bytes"),
+		FileType:                  FileTypePDF,
+		UseDocOrientationClassify: boolPtr(true),
+		Visualize:                 true,
+		ReturnMarkdownImages:      true,
+	})
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("pdf-bytes")), got["file"])
+	assert.EqualValues(t, FileTypePDF, got["fileType"])
+	assert.Equal(t, true, got["useDocOrientationClassify"])
+	assert.Equal(t, true, got["visualize"])
+	assert.Equal(t, true, got["returnMarkdownImages"])
+	assert.NotContains(t, got, "useDocUnwarping")
+}
+
+func TestPaddleXVLAdapter_RejectsClassicTextlineOption(t *testing.T) {
+	_, err := NewPaddleXVLAdapter().BuildUpstreamRequest(&UpstreamInput{
+		FileBytes:              []byte("image"),
+		FileType:               FileTypeImage,
+		UseTextlineOrientation: boolPtr(true),
+	})
+	require.ErrorIs(t, err, ErrUnsupportedOption)
+}
+
+const paddleXVLSuccessBody = `{
+  "logId": "vl-log-1",
+  "errorCode": 0,
+  "errorMsg": "Success",
+  "result": {
+    "layoutParsingResults": [
+      {
+        "prunedResult": {
+          "parsing_res_list": [
+            {"block_label": "title", "block_content": "Title"},
+            {"block_label": "text", "block_content": "First paragraph"}
+          ]
+        },
+        "markdown": {
+          "text": "# Title\n\nFirst paragraph",
+          "images": {"imgs/figure_1.jpg": "aW1hZ2U="}
+        },
+        "outputImages": {"layout_det_res": "aW1hZ2U="}
+      },
+      {
+        "prunedResult": {"parsing_res_list": []},
+        "markdown": {"text": "| A | B |\n|---|---|", "images": null}
+      }
+    ]
+  }
+}`
+
+func TestPaddleXVLAdapter_TransformResponse(t *testing.T) {
+	a := NewPaddleXVLAdapter()
+	resp, err := a.TransformResponse([]byte(paddleXVLSuccessBody), &ResponseOptions{ModelID: "owner/vl:1"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "owner/vl:1", resp.Model)
+	assert.Equal(t, "Title\nFirst paragraph\n", resp.Text)
+	require.Len(t, resp.Pages, 2)
+	assert.Equal(t, "Title\nFirst paragraph", resp.Pages[0].Text)
+	assert.Equal(t, "# Title\n\nFirst paragraph", resp.Pages[0].Markdown)
+	assert.Empty(t, resp.Pages[0].Lines)
+	assert.Equal(t, "| A | B |\n|---|---|", resp.Pages[1].Markdown)
+	assert.Equal(t, 2, resp.Usage.Pages)
+	assert.Equal(t, 1, resp.Usage.Images)
+	assert.Nil(t, resp.RawResult)
+}
+
+func TestPaddleXVLAdapter_TransformResponseRawResult(t *testing.T) {
+	resp, err := NewPaddleXVLAdapter().TransformResponse([]byte(paddleXVLSuccessBody), &ResponseOptions{RawResponse: true})
+	require.NoError(t, err)
+
+	raw, ok := resp.RawResult.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "vl-log-1", raw["logId"])
+}
+
+func TestPaddleXVLAdapter_TransformResponseAllowsMissingMarkdownImages(t *testing.T) {
+	body := `{
+      "errorCode": 0,
+      "result": {"layoutParsingResults": [{
+        "prunedResult": {"parsing_res_list": []},
+        "markdown": {"text": "plain markdown"}
+      }]}
+    }`
+
+	resp, err := NewPaddleXVLAdapter().TransformResponse([]byte(body), nil)
+	require.NoError(t, err)
+	require.Len(t, resp.Pages, 1)
+	assert.Equal(t, "plain markdown", resp.Pages[0].Markdown)
+}
+
+func TestPaddleXVLAdapter_TransformResponseErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "malformed", body: `not-json`, want: "decode paddlex vl response"},
+		{name: "upstream error", body: `{"errorCode":42,"errorMsg":"bad document"}`, want: "bad document"},
+		{name: "no pages", body: `{"errorCode":0,"result":{"layoutParsingResults":[]}}`, want: "no layoutParsingResults"},
+		{name: "missing markdown text", body: `{"errorCode":0,"result":{"layoutParsingResults":[{"prunedResult":{"parsing_res_list":[]},"markdown":{}}]}}`, want: "markdown.text"},
+		{name: "missing parsing results", body: `{"errorCode":0,"result":{"layoutParsingResults":[{"prunedResult":{},"markdown":{"text":"ok"}}]}}`, want: "parsing_res_list"},
+		{name: "wrong markdown text type", body: `{"errorCode":0,"result":{"layoutParsingResults":[{"prunedResult":{"parsing_res_list":[]},"markdown":{"text":{}}}]}}`, want: "decode paddlex vl response"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPaddleXVLAdapter().TransformResponse([]byte(tt.body), nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}

--- a/aigateway/handler/openai_ocr.go
+++ b/aigateway/handler/openai_ocr.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -32,23 +33,24 @@ const (
 )
 
 var ocrAllowedContentTypes = map[string]struct{}{
-	"image/png":  {},
-	"image/jpeg": {},
-	"image/webp": {},
-	"image/bmp":  {},
-	"image/tiff": {},
+	"image/png":       {},
+	"image/jpeg":      {},
+	"image/webp":      {},
+	"image/bmp":       {},
+	"image/tiff":      {},
+	"application/pdf": {},
 }
 
 // OCR godoc
 // @Security     ApiKey
-// @Summary      Extract text from an image with OCR
-// @Description  Sends a multipart OCR request to a PaddleOCR-capable backend model and returns normalized text, pages and lines. PDF input is not supported yet; page_ranges is accepted for API stability but not forwarded upstream.
+// @Summary      Extract text from an image or document with OCR
+// @Description  Sends a multipart OCR request to a PaddleOCR-capable backend model and returns normalized text and pages. PDF input requires the paddleocr-vl runtime.
 // @Tags         AIGateway
 // @Accept       multipart/form-data
 // @Produce      json
 // @Param        model formData string true "Model ID"
-// @Param        file formData file true "Image file (png, jpeg, webp, bmp, tiff)"
-// @Param        page_ranges formData string false "Page range for multi-page input, e.g. 1,3-5 (reserved)"
+// @Param        file formData file true "Image or PDF file (PDF requires paddleocr-vl)"
+// @Param        page_ranges formData string false "Reserved; non-empty values are rejected"
 // @Param        use_doc_orientation_classify formData bool false "Enable document orientation classification"
 // @Param        use_doc_unwarping formData bool false "Enable document unwarping"
 // @Param        use_textline_orientation formData bool false "Enable text line orientation classification"
@@ -90,13 +92,26 @@ func (h *OpenAIHandlerImpl) OCR(c *gin.Context) {
 		handleModelTargetError(c, ctx, modelID, "failed to get ocr target address", err)
 		return
 	}
-	if !supportsOCRTask(modelTarget.Model) {
+	adapter := h.ocrRegistry.GetAdapter(modelTarget.Model)
+	if adapter == nil {
 		err := fmt.Errorf("model '%s' does not support OCR", modelID)
 		preflight.RecordError(err, "unsupported_model")
 		preflight.End()
 		c.JSON(http.StatusBadRequest, gin.H{"error": types.Error{
 			Code:    "unsupported_model",
 			Message: err.Error(),
+			Type:    "invalid_request_error",
+		}})
+		return
+	}
+	fileType, _ := ocrFileTypeForContentType(fileHeader.Header.Get("Content-Type"))
+	if !adapter.SupportsFileType(fileType) {
+		err := fmt.Errorf("content type %q is not supported by runtime framework %q", fileHeader.Header.Get("Content-Type"), modelTarget.Model.RuntimeFramework)
+		preflight.RecordError(err, "unsupported_file_type")
+		preflight.End()
+		c.JSON(http.StatusBadRequest, gin.H{"error": types.Error{
+			Code:    "invalid_request_error",
+			Message: "PDF input requires a paddleocr-vl runtime",
 			Type:    "invalid_request_error",
 		}})
 		return
@@ -128,17 +143,6 @@ func (h *OpenAIHandlerImpl) OCR(c *gin.Context) {
 		}
 	}
 
-	adapter := h.ocrRegistry.GetAdapter(modelTarget.Model)
-	if adapter == nil {
-		finishModalGenerationTraceWithError(generationRecorder, fmt.Errorf("no ocr adapter for model '%s'", modelID), types.TraceErrUpstreamUnavailable)
-		c.JSON(http.StatusBadRequest, gin.H{"error": types.Error{
-			Code:    "unsupported_model",
-			Message: fmt.Sprintf("no ocr adapter for model '%s'", modelID),
-			Type:    "invalid_request_error",
-		}})
-		return
-	}
-
 	fileBytes, err := readOCRUpload(fileHeader)
 	if err != nil {
 		finishModalGenerationTraceWithError(generationRecorder, err, types.TraceErrUpstreamUnavailable)
@@ -151,13 +155,23 @@ func (h *OpenAIHandlerImpl) OCR(c *gin.Context) {
 
 	bodyBytes, err := adapter.BuildUpstreamRequest(&ocr.UpstreamInput{
 		FileBytes:                 fileBytes,
-		FileType:                  ocr.FileTypeImage,
+		FileType:                  fileType,
 		UseDocOrientationClassify: ocrReq.UseDocOrientationClassify,
 		UseDocUnwarping:           ocrReq.UseDocUnwarping,
 		UseTextlineOrientation:    ocrReq.UseTextlineOrientation,
 		Visualize:                 ocrReq.ReturnImage,
+		ReturnMarkdownImages:      ocrReq.RawResponse,
 	})
 	if err != nil {
+		if errors.Is(err, ocr.ErrUnsupportedOption) {
+			finishModalGenerationTraceWithError(generationRecorder, err, types.TraceErrUpstreamUnavailable)
+			c.JSON(http.StatusBadRequest, gin.H{"error": types.Error{
+				Code:    "invalid_request_error",
+				Message: err.Error(),
+				Type:    "invalid_request_error",
+			}})
+			return
+		}
 		finishModalGenerationTraceWithError(generationRecorder, err, types.TraceErrUpstreamUnavailable)
 		slog.ErrorContext(ctx, "failed to build ocr upstream request", slog.Any("error", err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": types.Error{
@@ -282,11 +296,12 @@ func (h *OpenAIHandlerImpl) parseOCRMultipartForm(c *gin.Context, preflight *pre
 		return fail(fmt.Errorf("only one file is allowed"), "Only one file is allowed")
 	}
 	fileHeader := files[0]
+	pageRanges := strings.TrimSpace(firstMultipartValue(form, "page_ranges"))
+	if pageRanges != "" {
+		return fail(fmt.Errorf("page_ranges is not supported"), "page_ranges is not supported")
+	}
 
 	contentType := strings.ToLower(strings.TrimSpace(fileHeader.Header.Get("Content-Type")))
-	if contentType == "application/pdf" {
-		return fail(fmt.Errorf("pdf input is not supported yet"), "PDF input is not supported yet")
-	}
 	if _, allowed := ocrAllowedContentTypes[contentType]; !allowed {
 		return fail(fmt.Errorf("unsupported content type %q", contentType), fmt.Sprintf("Unsupported file content type: %s", contentType))
 	}
@@ -296,13 +311,24 @@ func (h *OpenAIHandlerImpl) parseOCRMultipartForm(c *gin.Context, preflight *pre
 
 	return &types.OCRRequest{
 		Model:                     modelID,
-		PageRanges:                strings.TrimSpace(firstMultipartValue(form, "page_ranges")),
+		PageRanges:                pageRanges,
 		UseDocOrientationClassify: optionalMultipartBool(form, "use_doc_orientation_classify"),
 		UseDocUnwarping:           optionalMultipartBool(form, "use_doc_unwarping"),
 		UseTextlineOrientation:    optionalMultipartBool(form, "use_textline_orientation"),
 		ReturnImage:               strings.EqualFold(firstMultipartValue(form, "return_image"), "true"),
 		RawResponse:               strings.EqualFold(firstMultipartValue(form, "raw_response"), "true"),
 	}, fileHeader, true
+}
+
+func ocrFileTypeForContentType(contentType string) (int, bool) {
+	contentType = strings.ToLower(strings.TrimSpace(contentType))
+	if contentType == "application/pdf" {
+		return ocr.FileTypePDF, true
+	}
+	if _, allowed := ocrAllowedContentTypes[contentType]; allowed {
+		return ocr.FileTypeImage, true
+	}
+	return 0, false
 }
 
 func optionalMultipartBool(form *multipart.Form, key string) *bool {
@@ -326,13 +352,4 @@ func readOCRUpload(fileHeader *multipart.FileHeader) ([]byte, error) {
 		_ = f.Close()
 	}()
 	return io.ReadAll(f)
-}
-
-// supportsOCRTask reports whether the model can serve OCR requests. Logic is
-// delegated to the OCR adapter registry so handler and adapter stay aligned.
-func supportsOCRTask(model *types.Model) bool {
-	if model == nil {
-		return false
-	}
-	return ocr.NewPaddleXAdapter().CanHandle(model)
 }

--- a/aigateway/handler/openai_ocr_test.go
+++ b/aigateway/handler/openai_ocr_test.go
@@ -83,6 +83,10 @@ func withCancelableContext(t *testing.T, req *http.Request) *http.Request {
 }
 
 func ocrTestModelWithEndpoint(id, upstreamModelName, endpoint string) *types.Model {
+	return ocrTestModelWithRuntime(id, upstreamModelName, endpoint, "paddleocr")
+}
+
+func ocrTestModelWithRuntime(id, upstreamModelName, endpoint, runtimeFramework string) *types.Model {
 	return &types.Model{
 		BaseModel: types.BaseModel{
 			ID:      id,
@@ -91,33 +95,13 @@ func ocrTestModelWithEndpoint(id, upstreamModelName, endpoint string) *types.Mod
 			Task:    string(commontypes.OpticalCharacterRecognition),
 		},
 		InternalModelInfo: types.InternalModelInfo{
-			RuntimeFramework: "paddleocr",
+			RuntimeFramework: runtimeFramework,
 		},
 		Endpoint: endpoint,
 		Upstreams: []commontypes.UpstreamConfig{
 			{URL: endpoint, Enabled: true, ModelName: upstreamModelName},
 		},
 	}
-}
-
-func TestSupportsOCRTask(t *testing.T) {
-	assert.False(t, supportsOCRTask(nil))
-	assert.True(t, supportsOCRTask(&types.Model{
-		BaseModel: types.BaseModel{Task: "optical-character-recognition"},
-	}))
-	assert.True(t, supportsOCRTask(&types.Model{
-		BaseModel: types.BaseModel{Task: "text-generation, optical-character-recognition"},
-	}))
-	assert.True(t, supportsOCRTask(&types.Model{
-		InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "paddleocr"},
-	}))
-	assert.True(t, supportsOCRTask(&types.Model{
-		ExternalModelInfo: types.ExternalModelInfo{Provider: "opencsg"},
-	}))
-	assert.False(t, supportsOCRTask(&types.Model{
-		BaseModel:         types.BaseModel{Task: "text-generation"},
-		InternalModelInfo: types.InternalModelInfo{RuntimeFramework: "vllm"},
-	}))
 }
 
 func TestOpenAIHandler_OCRValidation(t *testing.T) {
@@ -162,14 +146,14 @@ func TestOpenAIHandler_OCRValidation(t *testing.T) {
 		require.Contains(t, w.Body.String(), "Only one file is allowed")
 	})
 
-	t.Run("pdf rejected", func(t *testing.T) {
+	t.Run("page ranges rejected", func(t *testing.T) {
 		tester, c, w := setupTest(t)
-		c.Request = newMultipartOCRRequest(t, "model1", "pdf-bytes", "application/pdf", nil, 1)
+		c.Request = newMultipartOCRRequest(t, "model1", "image-bytes", "image/png", map[string]string{"page_ranges": "1-2"}, 1)
 
 		tester.handler.OCR(c)
 
 		require.Equal(t, http.StatusBadRequest, w.Code)
-		require.Contains(t, w.Body.String(), "PDF input is not supported yet")
+		require.Contains(t, w.Body.String(), "page_ranges is not supported")
 	})
 
 	t.Run("unsupported content type", func(t *testing.T) {
@@ -205,6 +189,33 @@ func TestOpenAIHandler_OCRValidation(t *testing.T) {
 }
 
 func TestOpenAIHandler_OCRPreProxyErrors(t *testing.T) {
+	t.Run("vl runtime rejects classic textline option", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = newMultipartOCRRequest(t, "model1", "image-bytes", "image/png", map[string]string{
+			"use_textline_orientation": "true",
+		}, 1)
+		model := ocrTestModelWithRuntime("model1", "paddleocr-vl-model", "https://api.example.com", "paddleocr-vl")
+		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").Return(model, nil).Once()
+		tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "use_textline_orientation is not supported by paddleocr-vl")
+	})
+
+	t.Run("classic runtime rejects pdf", func(t *testing.T) {
+		tester, c, w := setupTest(t)
+		c.Request = newMultipartOCRRequest(t, "model1", "pdf-bytes", "application/pdf", nil, 1)
+		tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").
+			Return(ocrTestModelWithEndpoint("model1", "paddleocr-model", "https://api.example.com"), nil).Once()
+
+		tester.handler.OCR(c)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "PDF input requires a paddleocr-vl runtime")
+	})
+
 	t.Run("model not found", func(t *testing.T) {
 		tester, c, w := setupTest(t)
 		c.Request = newMultipartOCRRequest(t, "missing-model", "image-bytes", "image/png", nil, 1)
@@ -247,6 +258,60 @@ func TestOpenAIHandler_OCRPreProxyErrors(t *testing.T) {
 		require.Equal(t, http.StatusPaymentRequired, w.Code)
 		require.Contains(t, w.Body.String(), `"code":"insufficient_balance"`)
 	})
+}
+
+func TestOpenAIHandler_OCRPaddleXVLPDF(t *testing.T) {
+	tester, c, w := setupTest(t)
+
+	var gotPath string
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+          "errorCode": 0,
+          "result": {"layoutParsingResults": [{
+            "prunedResult": {"parsing_res_list": [{"block_content": "page text"}]},
+            "markdown": {"text": "# Page text", "images": null}
+          }]}
+        }`))
+	}))
+	defer upstream.Close()
+
+	c.Request = withCancelableContext(t, newMultipartOCRRequest(t, "model1", "pdf-bytes", "application/pdf", nil, 1))
+	model := ocrTestModelWithRuntime("model1", "paddleocr-vl-model", upstream.URL, "paddleocr-vl")
+	tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").Return(model, nil).Once()
+	tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	tester.mocks.openAIComp.EXPECT().
+		RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, "paddleocr-vl-model", mock.MatchedBy(func(usage *token.Usage) bool {
+			return usage != nil && usage.DataType == string(commontypes.DataTypeOCR) && usage.CompletionRC == 1
+		}), mock.Anything).
+		RunAndReturn(func(context.Context, string, *types.Model, string, *token.Usage, string) error {
+			wg.Done()
+			return nil
+		}).Once()
+
+	tester.handler.OCR(c)
+
+	require.Equal(t, "/layout-parsing", gotPath)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &payload))
+	assert.EqualValues(t, 0, payload["fileType"])
+	assert.Equal(t, false, payload["returnMarkdownImages"])
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp types.OCRResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "page text", resp.Text)
+	require.Len(t, resp.Pages, 1)
+	assert.Equal(t, "# Page text", resp.Pages[0].Markdown)
+	assert.Empty(t, resp.Pages[0].Lines)
+	wg.Wait()
 }
 
 func TestOpenAIHandler_OCRUpstreamErrorPassthrough(t *testing.T) {

--- a/configs/inference/paddleocr-vl.json
+++ b/configs/inference/paddleocr-vl.json
@@ -1,0 +1,18 @@
+{
+  "engine_name": "paddleocr-vl",
+  "enabled": 1,
+  "container_port": 8000,
+  "model_format": "safetensors",
+  "description": "PaddleOCR-VL/PaddleX full document parsing runtime",
+  "engine_images": [
+    {
+      "compute_type": "gpu",
+      "image": "opencsghq/paddleocr-vl:3.7.0",
+      "driver_version": "12.8",
+      "engine_version": "3.7.0"
+    }
+  ],
+  "supported_archs": [
+    "PaddleOCRVLForConditionalGeneration"
+  ]
+}

--- a/docker/inference/Dockerfile.paddleocr
+++ b/docker/inference/Dockerfile.paddleocr
@@ -1,4 +1,4 @@
-FROM docker.m.daocloud.io/pytorch/pytorch:2.9.1-cuda12.8-cudnn9-devel
+FROM docker.m.daocloud.io/pytorch/pytorch:2.9.1-cuda12.8-cudnn9-devel AS paddleocr-base
 SHELL ["/bin/bash", "-c"]
 
 LABEL maintainer="opencsg"
@@ -23,7 +23,7 @@ RUN pip config set global.index-url https://mirrors.aliyun.com/pypi/simple && \
     pip install --no-cache-dir paddlepaddle-gpu==3.3.1 \
         -i https://www.paddlepaddle.org.cn/packages/stable/cu126/ \
         --extra-index-url https://mirrors.aliyun.com/pypi/simple && \
-    pip install --no-cache-dir paddleocr==3.7.0 "paddlex[serving]==3.7.2" csghub-sdk==0.7.10 \
+    pip install --no-cache-dir "paddleocr[doc-parser]==3.7.0" "paddlex[serving]==3.7.2" csghub-sdk==0.7.10 \
         huggingface-hub==0.36.2
 # paddlepaddle-gpu==3.3.1 downgrades nvidia-nccl-cu12 to 2.25.1, but torch 2.9.1
 # in the base image needs 2.27.5 (ncclCommWindowRegister); restore it (NCCL 2.x
@@ -40,4 +40,10 @@ ENV HUGGINGFACE_HUB_CACHE=/workspace/ \
 
 EXPOSE 8000
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["/etc/csghub/serve.sh"]
+
+FROM paddleocr-base AS paddleocr-vl
+CMD ["/etc/csghub/serve.sh", "paddleocr-vl"]
+
+# Keep the classic target last so an untargeted build remains backward-compatible.
+FROM paddleocr-base AS paddleocr
+CMD ["/etc/csghub/serve.sh", "paddleocr"]

--- a/docker/inference/Dockerfile.paddleocr-cpu
+++ b/docker/inference/Dockerfile.paddleocr-cpu
@@ -41,4 +41,4 @@ ENV HUGGINGFACE_HUB_CACHE=/workspace/ \
 
 EXPOSE 8000
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["/etc/csghub/serve.sh"]
+CMD ["/etc/csghub/serve.sh", "paddleocr"]

--- a/docker/inference/README.md
+++ b/docker/inference/README.md
@@ -103,6 +103,14 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 export IMAGE_TAG=3.7.0
 docker buildx build --platform linux/amd64 \
   -t ${OPENCSG_ACR}/opencsghq/paddleocr:${IMAGE_TAG} \
+  --target paddleocr \
+  -f Dockerfile.paddleocr \
+  --push .
+# For PaddleOCR-VL CUDA: opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/paddleocr-vl:3.7.0
+export IMAGE_TAG=3.7.0
+docker buildx build --platform linux/amd64 \
+  -t ${OPENCSG_ACR}/opencsghq/paddleocr-vl:${IMAGE_TAG} \
+  --target paddleocr-vl \
   -f Dockerfile.paddleocr \
   --push .
 # For PaddleOCR CPU: opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/paddleocr-cpu:3.7.0

--- a/docker/inference/build.sh
+++ b/docker/inference/build.sh
@@ -39,6 +39,7 @@ echo "$OPENCSG_ACR_PASSWORD" | docker login "$OPENCSG_ACR" -u "$OPENCSG_ACR_USER
 echo "Building images..."
 export IMAGE=$3
 export PLATFORMS="linux/amd64,linux/arm64"
+BUILD_TARGET_ARGS=()
 case "${IMAGE%:*}" in
   vllm-local)
     DOCKERFILE="Dockerfile.vllm"
@@ -73,6 +74,12 @@ case "${IMAGE%:*}" in
   paddleocr)
     PLATFORMS="linux/amd64"
     DOCKERFILE="Dockerfile.paddleocr"
+    BUILD_TARGET_ARGS=(--target paddleocr)
+    ;;
+  paddleocr-vl)
+    PLATFORMS="linux/amd64"
+    DOCKERFILE="Dockerfile.paddleocr"
+    BUILD_TARGET_ARGS=(--target paddleocr-vl)
     ;;
   paddleocr-cpu)
     DOCKERFILE="Dockerfile.paddleocr-cpu"
@@ -82,6 +89,7 @@ esac
 docker buildx build --platform ${PLATFORMS} \
     -t ${DOCKER_IMAGE_PREFIX}/${IMAGE} \
     -t ${DOCKER_IMAGE_PREFIX}/${IMAGE%:*}:latest \
+    "${BUILD_TARGET_ARGS[@]}" \
     -f ${DOCKERFILE} \
     --push .
 

--- a/docker/inference/paddleocr/gen_pipeline.py
+++ b/docker/inference/paddleocr/gen_pipeline.py
@@ -8,14 +8,43 @@ Language-prefixed rec repos (latin_/korean_/eslav_) map to the unprefixed det.
 
 import argparse
 
-import yaml
-
 LANG_PREFIXES = ("latin_", "korean_", "eslav_")
 
 
+def patch_classic_ocr(cfg, model_name, model_dir):
+    sub_modules = cfg.get("SubModules", {})
+
+    if "TextRecognition" in sub_modules:
+        sub_modules["TextRecognition"]["model_name"] = model_name
+        sub_modules["TextRecognition"]["model_dir"] = model_dir
+
+    det_name = model_name
+    for prefix in LANG_PREFIXES:
+        if det_name.startswith(prefix):
+            det_name = det_name[len(prefix):]
+            break
+    det_name = det_name.replace("_rec", "_det")
+    if "TextDetection" in sub_modules and det_name != model_name:
+        sub_modules["TextDetection"]["model_name"] = det_name
+        sub_modules["TextDetection"]["model_dir"] = None
+
+
+def patch_paddleocr_vl(cfg, model_name, model_dir):
+    sub_modules = cfg.get("SubModules", {})
+    vl_recognition = sub_modules.get("VLRecognition")
+    if vl_recognition is None:
+        raise ValueError("PaddleOCR-VL pipeline config has no SubModules.VLRecognition")
+
+    vl_recognition["model_name"] = model_name
+    vl_recognition["model_dir"] = model_dir
+
+
 def main():
+    import yaml
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", required=True)
+    parser.add_argument("--pipeline", choices=("ocr", "paddleocr-vl"), default="ocr")
     parser.add_argument("--rec-name", required=True)
     parser.add_argument("--rec-dir", required=True)
     args = parser.parse_args()
@@ -23,21 +52,10 @@ def main():
     with open(args.config) as f:
         cfg = yaml.safe_load(f)
 
-    sub_modules = cfg.get("SubModules", {})
-
-    if "TextRecognition" in sub_modules:
-        sub_modules["TextRecognition"]["model_name"] = args.rec_name
-        sub_modules["TextRecognition"]["model_dir"] = args.rec_dir
-
-    det_name = args.rec_name
-    for prefix in LANG_PREFIXES:
-        if det_name.startswith(prefix):
-            det_name = det_name[len(prefix):]
-            break
-    det_name = det_name.replace("_rec", "_det")
-    if "TextDetection" in sub_modules and det_name != args.rec_name:
-        sub_modules["TextDetection"]["model_name"] = det_name
-        sub_modules["TextDetection"]["model_dir"] = None
+    if args.pipeline == "paddleocr-vl":
+        patch_paddleocr_vl(cfg, args.rec_name, args.rec_dir)
+    else:
+        patch_classic_ocr(cfg, args.rec_name, args.rec_dir)
 
     with open(args.config, "w") as f:
         yaml.safe_dump(cfg, f, sort_keys=False)

--- a/docker/inference/paddleocr/serve.sh
+++ b/docker/inference/paddleocr/serve.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
+RUNTIME_MODE="${1:-}"
+
+case "${RUNTIME_MODE}" in
+  paddleocr|paddleocr-vl)
+    ;;
+  "")
+    echo "ERROR: image runtime mode is required (expected paddleocr|paddleocr-vl)" >&2
+    exit 1
+    ;;
+  *)
+    echo "ERROR: unknown image runtime mode '${RUNTIME_MODE}' (expected paddleocr|paddleocr-vl)" >&2
+    exit 1
+    ;;
+esac
+
 python /etc/csghub/entry.py
 
 PORT="${PORT:-8000}"
@@ -37,12 +52,42 @@ PIPELINE="${PADDLEX_PIPELINE:-}"
 if [ -z "${PIPELINE}" ]; then
   if [ -f "${MODEL_DIR}/pipeline.yaml" ]; then
     PIPELINE="${MODEL_DIR}/pipeline.yaml"
-  elif [ -f "${MODEL_DIR}/OCR.yaml" ]; then
+  elif [ "${RUNTIME_MODE}" = "paddleocr" ] && [ -f "${MODEL_DIR}/OCR.yaml" ]; then
     PIPELINE="${MODEL_DIR}/OCR.yaml"
   elif [ "${MODEL_SOURCE}" = "local-only" ]; then
-    echo "ERROR: ${MODEL_DIR} contains no pipeline.yaml/OCR.yaml and PADDLEOCR_MODEL_SOURCE=local-only." >&2
+    echo "ERROR: ${MODEL_DIR} contains no pipeline config for ${RUNTIME_MODE} and PADDLEOCR_MODEL_SOURCE=local-only." >&2
     echo "The model repo must be a PaddleX pipeline bundle (pipeline.yaml + local model_dir subdirs)." >&2
     exit 1
+  elif [ "${RUNTIME_MODE}" = "paddleocr-vl" ]; then
+    MODEL_NAME="$(basename "${REPO_ID}")"
+    case "${MODEL_NAME}" in
+      PaddleOCR-VL-1.6*)
+        PIPELINE_NAME="PaddleOCR-VL-1.6"
+        ;;
+      PaddleOCR-VL-1.5*)
+        PIPELINE_NAME="PaddleOCR-VL-1.5"
+        ;;
+      PaddleOCR-VL*)
+        PIPELINE_NAME="PaddleOCR-VL"
+        ;;
+      *)
+        echo "ERROR: unsupported PaddleOCR-VL model '${MODEL_NAME}'" >&2
+        exit 1
+        ;;
+    esac
+    GEN_DIR="${MODEL_DIR}/.csghub"
+    PIPELINE="${GEN_DIR}/${PIPELINE_NAME}.yaml"
+    rm -f "${PIPELINE}"
+    paddlex --get_pipeline_config "${PIPELINE_NAME}" --save_path "${GEN_DIR}"
+    [ -f "${PIPELINE}" ] || {
+      echo "ERROR: failed to generate PaddleX pipeline config at ${PIPELINE}" >&2
+      exit 1
+    }
+    python /etc/csghub/gen_pipeline.py \
+      --pipeline paddleocr-vl \
+      --config "${PIPELINE}" \
+      --rec-name "${MODEL_NAME}" \
+      --rec-dir "${MODEL_DIR}"
   else
     REC_NAME="$(basename "${REPO_ID}")"
     if [ -f "${MODEL_DIR}/inference.pdiparams" ] && [[ "${REC_NAME}" == *_rec ]]; then
@@ -59,7 +104,7 @@ if [ -z "${PIPELINE}" ]; then
         echo "ERROR: failed to generate PaddleX pipeline config at ${PIPELINE}" >&2
         exit 1
       }
-      python /etc/csghub/gen_pipeline.py --config "${PIPELINE}" --rec-name "${REC_NAME}" --rec-dir "${MODEL_DIR}"
+      python /etc/csghub/gen_pipeline.py --pipeline ocr --config "${PIPELINE}" --rec-name "${REC_NAME}" --rec-dir "${MODEL_DIR}"
     else
       # Sub-models are resolved by name from the configured model sources.
       PIPELINE="OCR"
@@ -67,7 +112,7 @@ if [ -z "${PIPELINE}" ]; then
   fi
 fi
 
-echo "Starting PaddleX serving: pipeline=${PIPELINE} device=${DEVICE} port=${PORT} model_source=${MODEL_SOURCE}"
+echo "Starting PaddleX serving: runtime_mode=${RUNTIME_MODE} pipeline=${PIPELINE} device=${DEVICE} port=${PORT} model_source=${MODEL_SOURCE}"
 
 exec paddlex --serve \
     --pipeline "${PIPELINE}" \


### PR DESCRIPTION
Summary:
- Added a dedicated `paddleocr-vl` GPU runtime framework and Docker image target to provide full `/layout-parsing` document parsing capabilities (layout detection, cropping, reading order, assembly) missing from standard VLM deployments.
- Implemented an AIGateway adapter to translate `/v1/ocr` requests into `/layout-parsing` calls for images and multi-page PDFs, normalizing responses to standard OCR formats while supporting raw upstream output.
- Enforced pipeline-specific routing and constraints: classic `paddleocr` continues using `/ocr` and rejects PDFs, while the VL pipeline explicitly rejects unsupported parameters like `use_textline_orientation` and `page_ranges`.