### PR TITLE
fix(component): handle large HF NDJSON commit payloads safely

### DIFF
--- a/api/handler/repo.go
+++ b/api/handler/repo.go
@@ -2059,14 +2059,23 @@ func (h *RepoHandler) CommitFiles(ctx *gin.Context) {
 
 	err = h.c.CommitFiles(ctx.Request.Context(), req)
 	if err != nil {
-		slog.ErrorContext(ctx.Request.Context(), "failed to commit files", slog.Any("error", err))
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		h.handleCommitFilesError(ctx, err)
 		return
 	}
 	httpbase.OK(ctx, nil)
 }
 
 func (h *RepoHandler) CommitFilesHF(ctx *gin.Context) {
+	maxBodySize := h.config.Git.MaxHFCommitBodySize
+	if ctx.Request.ContentLength > maxBodySize {
+		httpbase.BadRequest(ctx, fmt.Sprintf(
+			"HF commit request body exceeds the maximum allowed size: %d > %d",
+			ctx.Request.ContentLength, maxBodySize,
+		))
+		return
+	}
+	ctx.Request.Body = http.MaxBytesReader(ctx.Writer, ctx.Request.Body, maxBodySize)
+
 	req, err := h.c.ParseNDJson(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx.Request.Context(), "invalid request body", slog.Any("error", err))
@@ -2091,14 +2100,22 @@ func (h *RepoHandler) CommitFilesHF(ctx *gin.Context) {
 
 	err = h.c.CommitFiles(ctx.Request.Context(), *req)
 	if err != nil {
-		slog.ErrorContext(ctx.Request.Context(), "failed to commit files", slog.Any("error", err))
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		h.handleCommitFilesError(ctx, err)
 		return
 	}
 	ctx.JSON(http.StatusOK, gin.H{
 		"commitUrl": fmt.Sprintf("%s/%s", namespace, name),
 		"commitOid": "",
 	})
+}
+
+func (h *RepoHandler) handleCommitFilesError(ctx *gin.Context, err error) {
+	slog.ErrorContext(ctx.Request.Context(), "failed to commit files", slog.Any("error", err))
+	if errors.Is(err, errorx.ErrFileTooLarge) {
+		ctx.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 }
 
 // ChangePath    godoc

--- a/api/handler/repo_test.go
+++ b/api/handler/repo_test.go
@@ -65,6 +65,7 @@ func NewRepoTester(t *testing.T) *RepoTester {
 			MaxRepoBatchNum: 500,
 		},
 	}
+	tester.handler.config.Git.MaxHFCommitBodySize = 1 << 20
 	tester.WithParam("name", "r")
 	tester.WithParam("namespace", "u")
 	return tester
@@ -2613,6 +2614,82 @@ func TestRepoHandler_CommitFiles(t *testing.T) {
 	tester.ResponseEq(
 		t, 200, tester.OKText, nil,
 	)
+}
+
+func TestRepoHandler_CommitFilesHFRejectsOversizedBody(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		contentLength int64
+	}{
+		{name: "known content length", contentLength: 256},
+		{name: "chunked body", contentLength: -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+				return rp.CommitFilesHF
+			})
+			tester.handler.config.Git.MaxHFCommitBodySize = 128
+			tester.Gctx().Request.Body = io.NopCloser(strings.NewReader(strings.Repeat("x", 256)))
+			tester.Gctx().Request.ContentLength = tc.contentLength
+
+			if tc.contentLength < 0 {
+				tester.mocks.repo.EXPECT().ParseNDJson(mock.Anything).RunAndReturn(
+					func(ctx *gin.Context) (*types.CommitFilesReq, error) {
+						_, err := io.ReadAll(ctx.Request.Body)
+						return nil, err
+					},
+				).Once()
+			}
+
+			tester.Execute()
+
+			tester.ResponseEqCode(t, http.StatusBadRequest)
+		})
+	}
+}
+
+func TestRepoHandler_CommitFilesHFReturnsPayloadTooLargeForOversizedNonLFSFile(t *testing.T) {
+	tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+		return rp.CommitFilesHF
+	})
+	tester.WithUser().WithKV("repo_type", types.ModelRepo).WithParam("revision", "main")
+	tester.Gctx().Request.Body = io.NopCloser(strings.NewReader(""))
+
+	tester.mocks.repo.EXPECT().ParseNDJson(mock.Anything).Return(&types.CommitFilesReq{}, nil).Once()
+	tester.mocks.repo.EXPECT().CommitFiles(mock.Anything, mock.Anything).Return(
+		fmt.Errorf("%w: oversized.json", errorx.ErrFileTooLarge),
+	).Once()
+
+	tester.Execute()
+
+	tester.ResponseEqCode(t, http.StatusRequestEntityTooLarge)
+}
+
+func TestRepoHandler_CommitFilesReturnsPayloadTooLargeForOversizedNonLFSFile(t *testing.T) {
+	tester := NewRepoTester(t).WithHandleFunc(func(rp *RepoHandler) gin.HandlerFunc {
+		return rp.CommitFiles
+	})
+	req := types.CommitFilesReq{
+		Namespace:   "u",
+		Name:        "r",
+		RepoType:    types.ModelRepo,
+		Revision:    "main",
+		CurrentUser: "u",
+		Message:     "msg",
+		Files: []types.CommitFileReq{
+			{
+				Path:    "oversized.json",
+				Action:  types.CommitActionCreate,
+				Content: "",
+			},
+		},
+	}
+	tester.mocks.repo.EXPECT().CommitFiles(mock.Anything, req).Return(
+		fmt.Errorf("%w: oversized.json", errorx.ErrFileTooLarge),
+	).Once()
+	tester.WithParam("path", "CSG_u/r").WithKV("repo_type", types.ModelRepo).WithParam("revision", "main").WithBody(t, req).WithUser().Execute()
+
+	tester.ResponseEqCode(t, http.StatusRequestEntityTooLarge)
 }
 
 func TestRepoHandler_GetRepos(t *testing.T) {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -505,6 +505,7 @@ type Config struct {
 		OperationTimeout       int    `env:"STARHUB_SERVER_GIT_OPERATION_TIMEOUT" default:"10"`
 		CheckFileSizeEnabled   bool   `env:"STARHUB_SERVER_CHECK_FILE_SIZE_ENABLED" default:"true"`
 		MaxUnLfsFileSize       int64  `env:"STARHUB_SERVER_GIT_MAX_UN_LFS_FILE_SIZE" default:"20971520"`
+		MaxHFCommitBodySize    int64  `env:"STARHUB_SERVER_GIT_MAX_HF_COMMIT_BODY_SIZE" default:"268435456"`
 		SkipLfsFileValidation  bool   `env:"STARHUB_SERVER_SKIP_LFS_FILE_VALIDATION" default:"false"`
 		SignatureSecertKey     string `env:"STARHUB_SERVER_GIT_SIGNATURE_SECRET_KEY" default:"git-secret"`
 		MinMultipartSize       int64  `env:"STARHUB_SERVER_GIT_MIN_MULTIPART_SIZE" default:"52428800"`

--- a/common/types/file.go
+++ b/common/types/file.go
@@ -1,5 +1,7 @@
 package types
 
+import "encoding/json"
+
 type File struct {
 	Name   string `json:"name"`
 	Type   string `json:"type"`
@@ -334,8 +336,8 @@ type CommitFile struct {
 
 // FormField represents a form field with key-value structure
 type FormField struct {
-	Key   string `json:"key"`
-	Value any    `json:"value"`
+	Key   string          `json:"key"`
+	Value json.RawMessage `json:"value"`
 }
 
 // CommitRequest represents the complete commit request

--- a/component/repo.go
+++ b/component/repo.go
@@ -56,6 +56,10 @@ const (
 	MaxTreeLimit          = 10000
 	DefaultLogTreeLimit   = 25
 	MaxLogTreeLimit       = 100
+	// HF commit requests encode regular file content as Base64 inside one NDJSON
+	// record. Reserve room for the record envelope and path in addition to the
+	// configured maximum decoded file size.
+	maxNDJSONRecordOverhead = 64 * 1024
 )
 
 type repoComponentImpl struct {
@@ -2609,21 +2613,26 @@ func (c *repoComponentImpl) CommitFiles(ctx context.Context, req types.CommitFil
 			return fmt.Errorf("invalid action: %s", file.Action)
 		}
 		cleanedContent := cleanBase64(file.Content)
+		content, err := base64.StdEncoding.DecodeString(cleanedContent)
+		if err != nil {
+			return fmt.Errorf("failed to decode content, err: %w", err)
+		}
+		pointer, isLFSPointer := parseCanonicalLFSPointer(content)
+		if !isLFSPointer && c.config.Git.MaxUnLfsFileSize > 0 && int64(len(content)) > c.config.Git.MaxUnLfsFileSize {
+			return fmt.Errorf(
+				"%w: file %s exceeds the maximum allowed size for non-LFS files: %d > %d",
+				errorx.ErrFileTooLarge, file.Path, len(content), c.config.Git.MaxUnLfsFileSize,
+			)
+		}
 
 		files = append(files, gitserver.CommitFile{
 			Path:    file.Path,
 			Content: cleanedContent,
 			Action:  action,
 		})
-		content, err := base64.StdEncoding.DecodeString(cleanedContent)
-		if err != nil {
-			return fmt.Errorf("failed to decode content, err: %w", err)
+		if isLFSPointer {
+			lfsFiles = append(lfsFiles, pointer)
 		}
-		p, err := gitaly.ReadPointerFromBuffer(content)
-		if err != nil {
-			continue
-		}
-		lfsFiles = append(lfsFiles, p)
 	}
 
 	for _, lfsFile := range lfsFiles {
@@ -2752,6 +2761,23 @@ func cleanBase64(input string) string {
 	return cleaned
 }
 
+func parseCanonicalLFSPointer(content []byte) (types.Pointer, bool) {
+	pointer, err := gitaly.ReadPointerFromBuffer(content)
+	if err != nil || !pointer.Valid() {
+		return types.Pointer{}, false
+	}
+
+	expected := fmt.Sprintf(
+		"%s\n%s%s\nsize %d",
+		gitaly.MetaFileIdentifier, gitaly.MetaFileOidPrefix, pointer.Oid, pointer.Size,
+	)
+	if !bytes.Equal(bytes.TrimSuffix(content, []byte("\n")), []byte(expected)) {
+		return types.Pointer{}, false
+	}
+
+	return pointer, true
+}
+
 func (c *repoComponentImpl) SendAssetManagementMsg(ctx context.Context, req types.RepoNotificationReq) error {
 	if req.RepoType == types.UnknownRepo {
 		return fmt.Errorf("unknown repository")
@@ -2860,45 +2886,37 @@ func metaText(readme string) string {
 
 func (c *repoComponentImpl) ParseNDJson(ctx *gin.Context) (*types.CommitFilesReq, error) {
 	req := &types.CommitFilesReq{}
+	maxRecordSize, err := maxNDJSONRecordSize(c.config.Git.MaxUnLfsFileSize)
+	if err != nil {
+		return nil, err
+	}
 	scanner := bufio.NewScanner(ctx.Request.Body)
-	maxCapacity := int(c.config.Git.MaxUnLfsFileSize)
-	buf := make([]byte, maxCapacity)
-	scanner.Buffer(buf, maxCapacity)
+	scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), maxRecordSize)
 
 	lineNumber := 0
 	for scanner.Scan() {
 		lineNumber++
-		line := strings.TrimSpace(scanner.Text())
-		// Skip empty lines
-		if line == "" {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
 			continue
 		}
+
 		var item types.FormField
-		if err := json.Unmarshal([]byte(line), &item); err != nil {
+		if err := json.Unmarshal(line, &item); err != nil {
 			return nil, fmt.Errorf("invalid JSON on line %d: %v", lineNumber, err)
 		}
 
 		// Parse based on key type
 		switch item.Key {
 		case "header":
-			headerBytes, err := json.Marshal(item.Value)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal header value on line %d: %v", lineNumber, err)
-			}
-
 			var header types.CommitHeader
-			if err := json.Unmarshal(headerBytes, &header); err != nil {
+			if err := json.Unmarshal(item.Value, &header); err != nil {
 				return nil, fmt.Errorf("invalid header format on line %d: %v", lineNumber, err)
 			}
 			req.Message = header.Summary
 		case "file":
-			fileBytes, err := json.Marshal(item.Value)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal file value on line %d: %v", lineNumber, err)
-			}
-
 			var file types.CommitFile
-			if err := json.Unmarshal(fileBytes, &file); err != nil {
+			if err := json.Unmarshal(item.Value, &file); err != nil {
 				return nil, fmt.Errorf("invalid file format on line %d: %v", lineNumber, err)
 			}
 			req.Files = append(req.Files, types.CommitFileReq{
@@ -2907,12 +2925,8 @@ func (c *repoComponentImpl) ParseNDJson(ctx *gin.Context) (*types.CommitFilesReq
 				Action:  types.CommitActionCreate,
 			})
 		case "lfsFile":
-			fileBytes, err := json.Marshal(item.Value)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal file value on line %d: %v", lineNumber, err)
-			}
 			var file types.CommitLFSFile
-			if err := json.Unmarshal(fileBytes, &file); err != nil {
+			if err := json.Unmarshal(item.Value, &file); err != nil {
 				return nil, fmt.Errorf("invalid file format on line %d: %v", lineNumber, err)
 			}
 			oid := fmt.Sprintf("%s:%s", file.Algo, file.OID)
@@ -2927,13 +2941,8 @@ func (c *repoComponentImpl) ParseNDJson(ctx *gin.Context) (*types.CommitFilesReq
 			})
 
 		case "deletedFolder":
-			fileBytes, err := json.Marshal(item.Value)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal file value on line %d: %v", lineNumber, err)
-			}
-
 			var file types.CommitFile
-			if err := json.Unmarshal(fileBytes, &file); err != nil {
+			if err := json.Unmarshal(item.Value, &file); err != nil {
 				return nil, fmt.Errorf("invalid file format on line %d: %v", lineNumber, err)
 			}
 			req.Files = append(req.Files, types.CommitFileReq{
@@ -2941,13 +2950,8 @@ func (c *repoComponentImpl) ParseNDJson(ctx *gin.Context) (*types.CommitFilesReq
 				Action: types.CommitActionDelete,
 			})
 		case "deletedFile":
-			fileBytes, err := json.Marshal(item.Value)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal file value on line %d: %v", lineNumber, err)
-			}
-
 			var file types.CommitFile
-			if err := json.Unmarshal(fileBytes, &file); err != nil {
+			if err := json.Unmarshal(item.Value, &file); err != nil {
 				return nil, fmt.Errorf("invalid file format on line %d: %v", lineNumber, err)
 			}
 			req.Files = append(req.Files, types.CommitFileReq{
@@ -2960,9 +2964,24 @@ func (c *repoComponentImpl) ParseNDJson(ctx *gin.Context) (*types.CommitFilesReq
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading NDJSON: %v", err)
+		return nil, fmt.Errorf("error reading NDJSON: %w", err)
 	}
 	return req, nil
+}
+
+func maxNDJSONRecordSize(maxUnLfsFileSize int64) (int, error) {
+	if maxUnLfsFileSize <= 0 {
+		return 0, fmt.Errorf("max non-LFS file size must be positive")
+	}
+
+	maxInt := int64(^uint(0) >> 1)
+	maxInputSize := ((maxInt - maxNDJSONRecordOverhead) / 4 * 3) - 2
+	if maxUnLfsFileSize > maxInputSize {
+		return 0, fmt.Errorf("max non-LFS file size is too large: %d", maxUnLfsFileSize)
+	}
+
+	encodedSize := ((maxUnLfsFileSize + 2) / 3) * 4
+	return int(encodedSize + maxNDJSONRecordOverhead), nil
 }
 
 func (c *repoComponentImpl) IsSyncing(ctx context.Context, repoType types.RepositoryType, namespace, name string) (bool, error) {

--- a/component/repo_test.go
+++ b/component/repo_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http/httptest"
@@ -3802,6 +3803,61 @@ func TestRepoComponent_CommitFiles(t *testing.T) {
 	require.Equal(t, nil, err)
 }
 
+func TestRepoComponent_CommitFilesRejectsOversizedNonLFSFile(t *testing.T) {
+	ctx := context.TODO()
+	repoComp := initializeTestRepoComponent(ctx, t)
+	repoComp.config.Git.MaxUnLfsFileSize = 4
+
+	user := database.User{Username: "user_name"}
+	repoComp.mocks.stores.UserMock().EXPECT().FindByUsername(mock.Anything, user.Username).Return(user, nil)
+
+	ns := database.Namespace{NamespaceType: "user", Path: user.Username}
+	repoComp.mocks.stores.NamespaceMock().EXPECT().FindByPath(mock.Anything, ns.Path).Return(ns, nil)
+
+	repo := &database.Repository{
+		ID:      1,
+		Name:    "repo_name",
+		Private: true,
+		User:    user,
+		Path:    fmt.Sprintf("%s/%s", ns.Path, "repo_name"),
+		Source:  types.OpenCSGSource,
+	}
+	repoComp.mocks.stores.RepoMock().EXPECT().FindByPath(
+		mock.Anything, types.ModelRepo, ns.Path, repo.Name,
+	).Return(repo, nil)
+	repoComp.mocks.gitServer.EXPECT().GetRepoAllFiles(ctx, gitserver.GetRepoAllFilesReq{
+		Namespace: ns.Path,
+		Name:      repo.Name,
+		Ref:       "main",
+		RepoType:  types.ModelRepo,
+	}).Return(nil, nil)
+
+	pointerPrefix := fmt.Sprintf(
+		"version https://git-lfs.github.com/spec/v1\noid sha256:%s\nsize 1\n",
+		strings.Repeat("a", 64),
+	)
+	err := repoComp.CommitFiles(ctx, types.CommitFilesReq{
+		Namespace:   ns.Path,
+		Name:        repo.Name,
+		RepoType:    types.ModelRepo,
+		Revision:    "main",
+		CurrentUser: user.Username,
+		Message:     "msg",
+		Files: []types.CommitFileReq{
+			{
+				Path:    "oversized.json",
+				Action:  types.CommitActionCreate,
+				Content: base64.StdEncoding.EncodeToString([]byte(pointerPrefix + "trailing content")),
+			},
+		},
+	})
+
+	require.ErrorContains(t, err, "exceeds the maximum allowed size for non-LFS files")
+	require.ErrorIs(t, err, errorx.ErrFileTooLarge)
+	repoComp.mocks.gitServer.AssertNotCalled(t, "CommitFiles", mock.Anything, mock.Anything)
+	repoComp.mocks.stores.LfsMetaObjectMock().AssertNotCalled(t, "UpdateOrCreate", mock.Anything, mock.Anything)
+}
+
 func TestRepoComponent_CommitFilesIgnoresPackageSyncFailure(t *testing.T) {
 	ctx := context.TODO()
 	repoComp := initializeTestRepoComponent(ctx, t)
@@ -3972,6 +4028,76 @@ func TestParseNDJson_AllKeyTypes(t *testing.T) {
 	assert.Equal(t, "old_dir/", result.Files[3].Path)
 	assert.Equal(t, "", result.Files[3].Content)
 	assert.Equal(t, types.CommitActionDelete, result.Files[3].Action)
+}
+
+func TestParseNDJson_AcceptsBase64ExpansionAtFileSizeLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const maxUnLfsFileSize = 1 << 20
+	cfg := &config.Config{}
+	cfg.Git.MaxUnLfsFileSize = maxUnLfsFileSize
+
+	component := &repoComponentImpl{
+		config: cfg,
+	}
+
+	// HF sends regular file content as Base64. A file at the configured raw size
+	// limit therefore produces an NDJSON record larger than that limit.
+	largeContent := base64.StdEncoding.EncodeToString(
+		[]byte(strings.Repeat("a", maxUnLfsFileSize)),
+	)
+	largeFileJSON, err := json.Marshal(types.CommitFile{
+		Path:    "tokenizer.json",
+		Content: largeContent,
+	})
+	require.NoError(t, err)
+
+	requestBody := fmt.Sprintf(`{"key": "header", "value": {"summary": "Large file commit"}}
+{"key": "file", "value": %s}`, string(largeFileJSON))
+	require.Greater(t, len(requestBody), maxUnLfsFileSize)
+
+	req := httptest.NewRequest("POST", "/test", strings.NewReader(requestBody))
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+
+	result, err := component.ParseNDJson(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Large file commit", result.Message)
+	assert.Len(t, result.Files, 1)
+	assert.Equal(t, "tokenizer.json", result.Files[0].Path)
+	assert.Equal(t, largeContent, result.Files[0].Content)
+}
+
+func TestParseNDJson_RejectsOversizedRecord(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const maxUnLfsFileSize = 1 << 20
+	component := &repoComponentImpl{
+		config: &config.Config{},
+	}
+	component.config.Git.MaxUnLfsFileSize = maxUnLfsFileSize
+
+	oversizedContent := base64.StdEncoding.EncodeToString(
+		[]byte(strings.Repeat("a", 2*maxUnLfsFileSize)),
+	)
+	fileJSON, err := json.Marshal(types.CommitFile{
+		Path:    "oversized.json",
+		Content: oversizedContent,
+	})
+	require.NoError(t, err)
+
+	requestBody := fmt.Sprintf(`{"key":"file","value":%s}`, fileJSON)
+	req := httptest.NewRequest("POST", "/test", strings.NewReader(requestBody))
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+
+	result, err := component.ParseNDJson(ctx)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
 }
 
 func TestGetRepoUrl(t *testing.T) {


### PR DESCRIPTION
Fixes #1413

### Problem

The Hugging Face commit endpoint parsed NDJSON records with a `bufio.Scanner` limit equal to `MaxUnLfsFileSize`. Regular file content is Base64-encoded inside a JSON envelope, so a valid file near the configured 20 MiB raw-file limit produces a record larger than 20 MiB and fails with `bufio.Scanner: token too long` after LFS uploads have completed.

### Solution

- Size the NDJSON record limit from the Base64-encoded form of `MaxUnLfsFileSize`, with bounded envelope allowance.
- Keep parsing line-oriented and bounded while using `json.RawMessage` to remove redundant marshal/unmarshal cycles.
- Enforce the decoded non-LFS file-size limit in `CommitFiles`.
- Require exact canonical LFS pointer content so pointer-like prefixes cannot bypass the non-LFS size check.
- Add `STARHUB_SERVER_GIT_MAX_HF_COMMIT_BODY_SIZE` with a 256 MiB default and enforce it for both declared `Content-Length` and chunked request bodies.

### Testing

- Verified the exact-limit Base64 regression test fails on `origin/main` with `bufio.Scanner: token too long` and passes with this change.
- Added coverage for oversized individual records, decoded non-LFS files, pointer-prefix bypasses, declared oversized request bodies, and chunked oversized request bodies.
- `go test ./...`
- `go vet ./...`
