### PR TITLE
feat: update csgclaw sandbox image to 2026081901

### DIFF
--- a/configs/agent_runtime/csgclaw.json
+++ b/configs/agent_runtime/csgclaw.json
@@ -1,7 +1,7 @@
 {
   "agent_type": "csgclaw",
   "version": "v0.4.5",
-  "image": "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/csgclaw-server-sandbox:2026080603",
+  "image": "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/csgclaw-server-sandbox:2026081901",
   "port": 18080,
   "command": [
     "/sbin/tini",


### PR DESCRIPTION
Summary:
- Updated the `csgclaw` sandbox image to version `2026081901`.
- Ensures the sandbox environment runs on the latest image version for improved functionality or stability.