### PR TITLE
feat: add Anthropic Messages API (/v1/messages) support for AIGateway

### DIFF
--- a/aigateway/handler/anthropic/common.go
+++ b/aigateway/handler/anthropic/common.go
@@ -1,0 +1,742 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+// unsupportedFeature returns an error indicating a feature is not supported
+// by the current adapter path.  The error message uses the prefix
+// "unsupported_feature:" so that the handler can distinguish it from
+// validation errors.
+func unsupportedFeature(feature string) error {
+	return fmt.Errorf("unsupported_feature:%s", feature)
+}
+
+// checkAdapterCapabilities inspects the request against the upstream protocol
+// capabilities and returns a list of capabilities that are requested but not
+// supported.  An empty list means all capabilities are satisfied.
+func checkAdapterCapabilities(req *types.AnthropicMessagesRequest, cap types.ProtocolCapability) []string {
+	var missing []string
+
+	if req.HasCacheControl() && !cap.PromptCaching {
+		missing = append(missing, "prompt_caching")
+	}
+	if req.HasThinking() && !cap.Thinking {
+		missing = append(missing, "thinking")
+	}
+	if req.HasVision() && !cap.Vision {
+		missing = append(missing, "vision")
+	}
+	if len(req.Tools) > 0 && !cap.Tools {
+		missing = append(missing, "tools")
+	}
+
+	return missing
+}
+
+// --- Anthropic Messages → OpenAI Chat Completions conversion ---
+
+// messagesToChatMessages converts Anthropic messages (including system prompt)
+// into OpenAI Chat Completions messages.  When includeReasoning is false,
+// thinking blocks in assistant history are omitted (they are not meaningful
+// for upstreams that do not support reasoning).
+func messagesToChatMessages(req *types.AnthropicMessagesRequest, includeReasoning bool) ([]map[string]any, error) {
+	var messages []map[string]any
+
+	// System prompt → system message
+	if len(req.System) > 0 && string(req.System) != "null" {
+		systemText := types.AnthropicMessageContentText(req.System)
+		if systemText != "" {
+			messages = append(messages, map[string]any{
+				"role":    "system",
+				"content": systemText,
+			})
+		}
+	}
+
+	for _, msg := range req.Messages {
+		blocks, err := types.ParseAnthropicContentBlocks(msg.Content)
+		if err != nil {
+			return nil, fmt.Errorf("parse message content: %w", err)
+		}
+
+switch msg.Role {
+			case "user":
+				userMsgs, err := anthropicUserBlocksToChat(blocks)
+				if err != nil {
+					return nil, err
+				}
+				messages = append(messages, userMsgs...)
+			case "assistant":
+				asstMsg, err := anthropicAssistantBlocksToChat(blocks, includeReasoning)
+				if err != nil {
+					return nil, err
+				}
+				if asstMsg != nil {
+					messages = append(messages, asstMsg)
+				}
+			case "system":
+				// Anthropic allows system messages in the messages array (e.g.
+				// Claude Code sends them).  Convert to a Chat-compatible system
+				// message — only the text content is meaningful.
+				text := types.AnthropicMessageContentText(msg.Content)
+				if text != "" {
+					messages = append(messages, map[string]any{
+						"role":    "system",
+						"content": text,
+					})
+				}
+			default:
+			return nil, fmt.Errorf("unsupported role: %s", msg.Role)
+		}
+	}
+
+	return messages, nil
+}
+
+// anthropicUserBlocksToChat converts Anthropic user content blocks to Chat messages.
+// A tool_result block becomes a separate {role: "tool"} message.
+func anthropicUserBlocksToChat(blocks []types.AnthropicContentBlock) ([]map[string]any, error) {
+	var toolResults []map[string]any
+	var otherParts []map[string]any
+
+	for _, block := range blocks {
+		switch block.Type {
+		case "text":
+			otherParts = append(otherParts, map[string]any{"type": "text", "text": block.Text})
+		case "image":
+		 imageURL, err := anthropicImageToChatURL(block.Source)
+			if err != nil {
+				return nil, err
+			}
+			otherParts = append(otherParts, map[string]any{
+				"type":      "image_url",
+				"image_url": imageURL,
+			})
+		case "tool_result":
+			resultContent := extractToolResultContent(block)
+			toolResults = append(toolResults, map[string]any{
+				"role":         "tool",
+				"tool_call_id": block.ToolUseID,
+				"content":      resultContent,
+			})
+		default:
+			return nil, unsupportedFeature("content." + block.Type)
+		}
+	}
+
+	var messages []map[string]any
+	if len(otherParts) > 0 {
+		// If there's only one text part, use a plain string for compatibility.
+		if len(otherParts) == 1 && otherParts[0]["type"] == "text" {
+			messages = append(messages, map[string]any{
+				"role":    "user",
+				"content": otherParts[0]["text"],
+			})
+		} else {
+			messages = append(messages, map[string]any{
+				"role":    "user",
+				"content": otherParts,
+			})
+		}
+	}
+	messages = append(messages, toolResults...)
+	return messages, nil
+}
+
+// anthropicAssistantBlocksToChat converts Anthropic assistant content blocks to
+// a single Chat assistant message.  text → content, tool_use → tool_calls,
+// thinking → reasoning_content (when includeReasoning is true).
+func anthropicAssistantBlocksToChat(blocks []types.AnthropicContentBlock, includeReasoning bool) (map[string]any, error) {
+	var textParts []string
+	var toolCalls []map[string]any
+	var reasoningContent string
+
+	for _, block := range blocks {
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				textParts = append(textParts, block.Text)
+			}
+		case "tool_use":
+			argsStr := string(block.Input)
+			if argsStr == "" {
+				argsStr = "{}"
+			}
+			toolCalls = append(toolCalls, map[string]any{
+				"id":   block.ID,
+				"type": "function",
+				"function": map[string]any{
+					"name":      block.Name,
+					"arguments": argsStr,
+				},
+			})
+		case "thinking":
+			if includeReasoning && block.Thinking != "" {
+				if reasoningContent != "" {
+					reasoningContent += "\n"
+				}
+				reasoningContent += block.Thinking
+			}
+		default:
+			return nil, unsupportedFeature("content." + block.Type)
+		}
+	}
+
+	msg := map[string]any{
+		"role":    "assistant",
+		"content": strings.Join(textParts, ""),
+	}
+	if len(toolCalls) > 0 {
+		msg["tool_calls"] = toolCalls
+	}
+	if reasoningContent != "" {
+		msg["reasoning_content"] = reasoningContent
+	}
+
+	// Skip empty assistant messages.
+	if msg["content"] == "" && len(toolCalls) == 0 && reasoningContent == "" {
+		return nil, nil
+	}
+	return msg, nil
+}
+
+func anthropicImageToChatURL(source *types.AnthropicImageSource) (map[string]any, error) {
+	if source == nil {
+		return nil, fmt.Errorf("image source is nil")
+	}
+	switch source.Type {
+	case "base64":
+		dataURL := fmt.Sprintf("data:%s;base64,%s", source.MediaType, source.Data)
+		return map[string]any{"url": dataURL}, nil
+	case "url":
+		return map[string]any{"url": source.URL}, nil
+	default:
+		return nil, fmt.Errorf("unsupported image source type: %s", source.Type)
+	}
+}
+
+func extractToolResultContent(block types.AnthropicContentBlock) string {
+	if len(block.Content) == 0 {
+		return ""
+	}
+	// Try string first.
+	var asString string
+	if err := json.Unmarshal(block.Content, &asString); err == nil {
+		return asString
+	}
+	// Fall back to extracting text from content blocks.
+	return types.AnthropicMessageContentText(block.Content)
+}
+
+// messagesToolsToChatTools converts Anthropic tools to OpenAI Chat tools.
+func messagesToolsToChatTools(tools []types.AnthropicTool) []map[string]any {
+	chatTools := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		schema := tool.InputSchema
+		if len(schema) == 0 {
+			schema = json.RawMessage(`{"type":"object"}`)
+		}
+		chatTool := map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        tool.Name,
+				"description": tool.Description,
+				"parameters":  json.RawMessage(schema),
+			},
+		}
+		chatTools = append(chatTools, chatTool)
+	}
+	return chatTools
+}
+
+// --- OpenAI Chat → Anthropic Messages response conversion ---
+
+// chatResponseToMessagesResponse converts an OpenAI Chat Completions response
+// to an Anthropic Messages response.
+func chatResponseToMessagesResponse(data []byte, model string) (*types.AnthropicMessagesResponse, error) {
+	var chat types.ChatCompletion
+	if err := json.Unmarshal(data, &chat); err != nil {
+		return nil, fmt.Errorf("unmarshal chat response: %w", err)
+	}
+
+	resp := &types.AnthropicMessagesResponse{
+		ID:    newMessagesResponseID(),
+		Type:  "message",
+		Role:  "assistant",
+		Model: model,
+		Usage: types.AnthropicMessagesUsage{
+			InputTokens:          int(chat.Usage.PromptTokens),
+			OutputTokens:         int(chat.Usage.CompletionTokens),
+			CacheReadInputTokens: int(chat.Usage.PromptTokensDetails.CachedTokens),
+		},
+	}
+
+	reasoning := chatResponseReasoning(data)
+
+	if len(chat.Choices) == 0 {
+		endTurn := "end_turn"
+		resp.StopReason = &endTurn
+		return resp, nil
+	}
+
+	choice := chat.Choices[0]
+	msg := choice.Message
+	var contentBlocks []types.AnthropicContentBlock
+
+	// Build content blocks in Anthropic's canonical order:
+	// thinking → text → tool_use.
+	if reasoning != "" {
+		contentBlocks = append(contentBlocks, types.AnthropicContentBlock{
+			Type:     "thinking",
+			Thinking: reasoning,
+		})
+	}
+
+	// Text content.
+	if msg.Content != "" {
+		contentBlocks = append(contentBlocks, types.AnthropicContentBlock{
+			Type: "text",
+			Text: msg.Content,
+		})
+	}
+
+	// Tool calls.
+	if len(msg.ToolCalls) > 0 {
+		for _, call := range msg.ToolCalls {
+			contentBlocks = append(contentBlocks, types.AnthropicContentBlock{
+				Type:  "tool_use",
+				ID:    call.ID,
+				Name:  call.Function.Name,
+				Input: json.RawMessage(call.Function.Arguments),
+			})
+		}
+	}
+
+	if len(contentBlocks) == 0 {
+		// Ensure content is never null.
+		contentBlocks = []types.AnthropicContentBlock{{Type: "text", Text: ""}}
+	}
+	resp.Content = contentBlocks
+
+	stopReason := chatFinishReasonToStopReason(string(choice.FinishReason))
+	resp.StopReason = &stopReason
+
+	return resp, nil
+}
+
+// chatResponseReasoning extracts reasoning content from a raw Chat response.
+func chatResponseReasoning(data []byte) string {
+	var raw struct {
+		Choices []struct {
+			Message map[string]json.RawMessage `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil || len(raw.Choices) == 0 {
+		return ""
+	}
+	return reasoningFromRawFields(raw.Choices[0].Message)
+}
+
+func reasoningFromRawFields(fields map[string]json.RawMessage) string {
+	if len(fields) == 0 {
+		return ""
+	}
+	for _, key := range []string{"reasoning_content", "reasoning"} {
+		var value string
+		if err := json.Unmarshal(fields[key], &value); err == nil {
+			value = strings.TrimSpace(value)
+			if value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func chatFinishReasonToStopReason(finishReason string) string {
+	switch finishReason {
+	case "stop":
+		return "end_turn"
+	case "length":
+		return "max_tokens"
+	case "tool_calls", "function_call":
+		return "tool_use"
+	case "stop_sequence":
+		return "stop_sequence"
+	default:
+		return "end_turn"
+	}
+}
+
+// messagesStopReasonToFinishReason is the inverse of chatFinishReasonToStopReason,
+// mapping an Anthropic stop_reason back to an OpenAI finish_reason for the
+// LLM log recorder.
+func messagesStopReasonToFinishReason(stopReason string) string {
+	switch stopReason {
+	case "end_turn":
+		return "stop"
+	case "max_tokens":
+		return "length"
+	case "tool_use":
+		return "tool_calls"
+	case "stop_sequence":
+		return "stop_sequence"
+	default:
+		return "stop"
+	}
+}
+
+// newMessagesResponseID generates an Anthropic-style message ID.
+func newMessagesResponseID() string {
+	return fmt.Sprintf("msg_agw_%s", randomHexID())
+}
+
+// --- OpenAI Responses → Anthropic Messages response conversion ---
+
+// responsesResponseToMessagesResponse converts an OpenAI Responses response
+// to an Anthropic Messages response.
+func responsesResponseToMessagesResponse(resp *types.ResponsesResponse, model string) (*types.AnthropicMessagesResponse, error) {
+	result := &types.AnthropicMessagesResponse{
+		ID:    newMessagesResponseID(),
+		Type:  "message",
+		Role:  "assistant",
+		Model: model,
+	}
+
+	if resp.Usage != nil {
+		usage := types.AnthropicMessagesUsage{
+			InputTokens:  int(resp.Usage.InputTokens),
+			OutputTokens: int(resp.Usage.OutputTokens),
+		}
+		if resp.Usage.InputTokensDetails != nil {
+			usage.CacheReadInputTokens = int(resp.Usage.InputTokensDetails.CachedTokens)
+			usage.CacheCreationInputTokens = int(resp.Usage.InputTokensDetails.CachedCreationTokens)
+		}
+		result.Usage = usage
+	}
+
+	var contentBlocks []types.AnthropicContentBlock
+
+	for _, item := range resp.Output {
+		switch item.Type {
+		case "message":
+			for _, part := range item.Content {
+				switch part.Type {
+				case "output_text":
+					contentBlocks = append(contentBlocks, types.AnthropicContentBlock{
+						Type: "text",
+						Text: part.Text,
+					})
+				case "refusal":
+					contentBlocks = append(contentBlocks, types.AnthropicContentBlock{
+						Type: "text",
+						Text: part.Refusal,
+					})
+				}
+			}
+		case "function_call":
+			inputArgs := json.RawMessage(item.Arguments)
+			if len(inputArgs) == 0 {
+				inputArgs = json.RawMessage(`{}`)
+			}
+			contentBlocks = append(contentBlocks, types.AnthropicContentBlock{
+				Type:  "tool_use",
+				ID:    item.CallID,
+				Name:  item.Name,
+				Input: inputArgs,
+			})
+		case "reasoning":
+			for _, summary := range item.Summary {
+				if summary.Text != "" {
+					contentBlocks = append(contentBlocks, types.AnthropicContentBlock{
+						Type:     "thinking",
+						Thinking: summary.Text,
+					})
+				}
+			}
+		}
+	}
+
+	if len(contentBlocks) == 0 {
+		contentBlocks = []types.AnthropicContentBlock{{Type: "text", Text: ""}}
+	}
+	result.Content = contentBlocks
+
+	stopReason := responsesStatusToStopReason(resp.Status)
+	result.StopReason = &stopReason
+
+	return result, nil
+}
+
+func responsesStatusToStopReason(status string) string {
+	switch status {
+	case "completed":
+		return "end_turn"
+	case "incomplete":
+		return "max_tokens"
+	default:
+		return "end_turn"
+	}
+}
+
+// --- Anthropic Messages → OpenAI Responses request conversion ---
+
+// messagesToResponsesRequest converts an Anthropic Messages request to an
+// OpenAI Responses request.
+func messagesToResponsesRequest(req *types.AnthropicMessagesRequest, modelName string) (*types.ResponsesRequest, error) {
+	// Build input items from messages.
+	inputItems, err := messagesToResponsesInput(req)
+	if err != nil {
+		return nil, err
+	}
+
+	inputRaw, err := json.Marshal(inputItems)
+	if err != nil {
+		return nil, fmt.Errorf("marshal responses input: %w", err)
+	}
+
+	respReq := &types.ResponsesRequest{
+		Model:           modelName,
+		Input:           inputRaw,
+		Stream:          req.Stream,
+		MaxOutputTokens: &req.MaxTokens,
+	}
+	if req.Temperature != nil {
+		respReq.Temperature = req.Temperature
+	}
+	if req.TopP != nil {
+		respReq.TopP = req.TopP
+	}
+	if len(req.StopSequences) > 0 {
+		stopRaw, err := json.Marshal(req.StopSequences)
+		if err != nil {
+			return nil, fmt.Errorf("marshal stop sequences: %w", err)
+		}
+		if respReq.ExtraFields == nil {
+			respReq.ExtraFields = make(map[string]json.RawMessage)
+		}
+		respReq.ExtraFields["stop"] = stopRaw
+	}
+	if len(req.ToolChoice) > 0 {
+		converted, err := convertToolChoiceForResponses(req.ToolChoice)
+		if err != nil {
+			return nil, fmt.Errorf("convert tool_choice: %w", err)
+		}
+		respReq.ToolChoice = converted
+	}
+	if req.Metadata != nil && req.Metadata.UserID != "" {
+		respReq.User = req.Metadata.UserID
+	}
+
+	// System prompt → instructions.
+	if len(req.System) > 0 && string(req.System) != "null" {
+		systemText := types.AnthropicMessageContentText(req.System)
+		if systemText != "" {
+			respReq.Instructions = json.RawMessage(jsonString(systemText))
+		}
+	}
+
+	// Tools conversion.
+	if len(req.Tools) > 0 {
+		respTools := messagesToolsToResponsesTools(req.Tools)
+		toolsRaw, err := json.Marshal(respTools)
+		if err != nil {
+			return nil, fmt.Errorf("marshal responses tools: %w", err)
+		}
+		respReq.Tools = toolsRaw
+	}
+
+	// Thinking → reasoning.
+	if req.HasThinking() {
+		effort := "medium"
+		if req.Thinking.BudgetTokens > 0 {
+			effort = budgetToEffort(req.Thinking.BudgetTokens)
+		}
+		respReq.Reasoning = json.RawMessage(fmt.Sprintf(`{"effort":%q}`, effort))
+	}
+
+	return respReq, nil
+}
+
+// messagesToResponsesInput converts Anthropic messages to Responses API input items.
+func messagesToResponsesInput(req *types.AnthropicMessagesRequest) ([]map[string]any, error) {
+	var items []map[string]any
+
+	for _, msg := range req.Messages {
+		blocks, err := types.ParseAnthropicContentBlocks(msg.Content)
+		if err != nil {
+			return nil, fmt.Errorf("parse message content: %w", err)
+		}
+
+		switch msg.Role {
+		case "user":
+			// Group text and image blocks into a single message with multipart
+			// content, then append tool_result blocks as separate items.
+			var contentParts []map[string]any
+			for _, block := range blocks {
+				switch block.Type {
+				case "text":
+					contentParts = append(contentParts, map[string]any{
+						"type": "input_text",
+						"text": block.Text,
+					})
+				case "image":
+					if block.Source != nil {
+						switch block.Source.Type {
+						case "base64":
+							contentParts = append(contentParts, map[string]any{
+								"type":      "input_image",
+								"image_url": fmt.Sprintf("data:%s;base64,%s",
+									block.Source.MediaType, block.Source.Data),
+							})
+						case "url":
+							contentParts = append(contentParts, map[string]any{
+								"type":      "input_image",
+								"image_url": block.Source.URL,
+							})
+						}
+					}
+				case "tool_result":
+					outputContent := extractToolResultContent(block)
+					items = append(items, map[string]any{
+						"type":    "function_call_output",
+						"call_id": block.ToolUseID,
+						"output":  outputContent,
+					})
+				}
+			}
+			if len(contentParts) > 0 {
+				items = append(items, map[string]any{
+					"type":    "message",
+					"role":    "user",
+					"content": contentParts,
+				})
+			}
+		case "assistant":
+			for _, block := range blocks {
+				switch block.Type {
+				case "text":
+					items = append(items, map[string]any{
+						"type": "message",
+						"role": "assistant",
+						"content": []map[string]any{{
+							"type": "output_text",
+							"text": block.Text,
+						}},
+					})
+				case "tool_use":
+					argsStr := string(block.Input)
+					if argsStr == "" {
+						argsStr = "{}"
+					}
+					items = append(items, map[string]any{
+						"type":      "function_call",
+						"call_id":   block.ID,
+						"name":      block.Name,
+						"arguments": argsStr,
+					})
+				case "thinking":
+					if block.Thinking != "" {
+						items = append(items, map[string]any{
+							"type": "reasoning",
+							"summary": []map[string]any{{
+								"type": "summary_text",
+								"text": block.Thinking,
+							}},
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return items, nil
+}
+
+// messagesToolsToResponsesTools converts Anthropic tools to Responses API tools.
+func messagesToolsToResponsesTools(tools []types.AnthropicTool) []map[string]any {
+	respTools := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		schema := tool.InputSchema
+		if len(schema) == 0 {
+			schema = json.RawMessage(`{"type":"object"}`)
+		}
+		respTool := map[string]any{
+			"type":        "function",
+			"name":        tool.Name,
+			"description": tool.Description,
+			"parameters":  json.RawMessage(schema),
+		}
+		respTools = append(respTools, respTool)
+	}
+	return respTools
+}
+
+func budgetToEffort(budget int) string {
+	switch {
+	case budget <= 5000:
+		return "low"
+	case budget <= 20000:
+		return "medium"
+	default:
+		return "high"
+	}
+}
+
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// convertToolChoiceForResponses converts an Anthropic tool_choice value to
+// the format expected by the OpenAI Responses API.
+// Anthropic: {"type":"auto"}, {"type":"any"}, {"type":"tool","name":"..."}
+// Responses: "auto", "required", {"type":"function","name":"..."}
+func convertToolChoiceForResponses(raw json.RawMessage) (json.RawMessage, error) {
+	var tc struct {
+		Type string `json:"type"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &tc); err != nil {
+		return nil, fmt.Errorf("invalid tool_choice: %w", err)
+	}
+	switch tc.Type {
+	case "auto":
+		return json.RawMessage(`"auto"`), nil
+	case "any":
+		return json.RawMessage(`"required"`), nil
+	case "tool":
+		return json.RawMessage(fmt.Sprintf(`{"type":"function","name":%s}`, jsonString(tc.Name))), nil
+	default:
+		return json.RawMessage(`"auto"`), nil
+	}
+}
+
+// convertToolChoiceForChat converts an Anthropic tool_choice value to the
+// format expected by the OpenAI Chat Completions API.
+// Anthropic: {"type":"auto"}, {"type":"any"}, {"type":"tool","name":"..."}
+// Chat:      "auto", "required", {"type":"function","function":{"name":"..."}}
+func convertToolChoiceForChat(raw json.RawMessage) (json.RawMessage, error) {
+	var tc struct {
+		Type string `json:"type"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &tc); err != nil {
+		return nil, fmt.Errorf("invalid tool_choice: %w", err)
+	}
+	switch tc.Type {
+	case "auto":
+		return json.RawMessage(`"auto"`), nil
+	case "any":
+		return json.RawMessage(`"required"`), nil
+	case "tool":
+		return json.RawMessage(fmt.Sprintf(`{"type":"function","function":{"name":%s}}`, jsonString(tc.Name))), nil
+	default:
+		return json.RawMessage(`"auto"`), nil
+	}
+}

--- a/aigateway/handler/anthropic/common_test.go
+++ b/aigateway/handler/anthropic/common_test.go
@@ -1,0 +1,556 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+func TestCheckAdapterCapabilities(t *testing.T) {
+	t.Run("all satisfied", func(t *testing.T) {
+		req := &types.AnthropicMessagesRequest{
+			Messages: []types.AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"hello"`)},
+			},
+		}
+		cap := types.CapabilityFor(types.ProtocolChat)
+		missing := checkAdapterCapabilities(req, cap)
+		assert.Empty(t, missing)
+	})
+
+	t.Run("cache_control not supported", func(t *testing.T) {
+		req := &types.AnthropicMessagesRequest{
+			Messages: []types.AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`[{"type":"text","text":"hi","cache_control":{"type":"ephemeral"}}]`)},
+			},
+		}
+		cap := types.CapabilityFor(types.ProtocolChat)
+		missing := checkAdapterCapabilities(req, cap)
+		assert.Contains(t, missing, "prompt_caching")
+	})
+
+t.Run("thinking not supported", func(t *testing.T) {
+			req := &types.AnthropicMessagesRequest{
+				Thinking: &types.AnthropicThinking{Type: "enabled", BudgetTokens: 5000},
+				Messages: []types.AnthropicMessage{
+					{Role: "user", Content: json.RawMessage(`"hello"`)},
+				},
+			}
+			// Use a custom capability with Thinking disabled — the default
+			// ProtocolChat capability now supports thinking via reasoning_effort.
+			cap := types.ProtocolCapability{Thinking: false}
+			missing := checkAdapterCapabilities(req, cap)
+			assert.Contains(t, missing, "thinking")
+		})
+
+	t.Run("vision not supported", func(t *testing.T) {
+		req := &types.AnthropicMessagesRequest{
+			Messages: []types.AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"abc"}}]`)},
+			},
+		}
+		cap := types.ProtocolCapability{Tools: true}
+		missing := checkAdapterCapabilities(req, cap)
+		assert.Contains(t, missing, "vision")
+	})
+}
+
+func TestMessagesToChatMessages(t *testing.T) {
+	t.Run("simple text conversation", func(t *testing.T) {
+		req := &types.AnthropicMessagesRequest{
+			System: json.RawMessage(`"You are helpful"`),
+			Messages: []types.AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"Hello"`)},
+				{Role: "assistant", Content: json.RawMessage(`"Hi there"`)},
+				{Role: "user", Content: json.RawMessage(`"How are you?"`)},
+			},
+		}
+		msgs, err := messagesToChatMessages(req, true)
+		require.NoError(t, err)
+		require.Len(t, msgs, 4)
+
+		assert.Equal(t, "system", msgs[0]["role"])
+		assert.Equal(t, "You are helpful", msgs[0]["content"])
+
+		assert.Equal(t, "user", msgs[1]["role"])
+		assert.Equal(t, "Hello", msgs[1]["content"])
+
+		assert.Equal(t, "assistant", msgs[2]["role"])
+		assert.Equal(t, "Hi there", msgs[2]["content"])
+
+		assert.Equal(t, "user", msgs[3]["role"])
+		assert.Equal(t, "How are you?", msgs[3]["content"])
+	})
+
+	t.Run("tool use and tool result", func(t *testing.T) {
+		req := &types.AnthropicMessagesRequest{
+			Messages: []types.AnthropicMessage{
+				{
+					Role: "user",
+					Content: json.RawMessage(`"What's the weather?"`),
+				},
+				{
+					Role: "assistant",
+					Content: json.RawMessage(`[{"type":"tool_use","id":"tool_1","name":"get_weather","input":{"city":"SF"}}]`),
+				},
+				{
+					Role: "user",
+					Content: json.RawMessage(`[{"type":"tool_result","tool_use_id":"tool_1","content":"72°F sunny"}]`),
+				},
+			},
+		}
+		msgs, err := messagesToChatMessages(req, true)
+		require.NoError(t, err)
+		require.Len(t, msgs, 3)
+
+		// User message
+		assert.Equal(t, "user", msgs[0]["role"])
+
+		// Assistant with tool_calls
+		assert.Equal(t, "assistant", msgs[1]["role"])
+		toolCalls, ok := msgs[1]["tool_calls"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, toolCalls, 1)
+		assert.Equal(t, "tool_1", toolCalls[0]["id"])
+		fn := toolCalls[0]["function"].(map[string]any)
+		assert.Equal(t, "get_weather", fn["name"])
+
+		// Tool result
+		assert.Equal(t, "tool", msgs[2]["role"])
+		assert.Equal(t, "tool_1", msgs[2]["tool_call_id"])
+		assert.Equal(t, "72°F sunny", msgs[2]["content"])
+	})
+
+	t.Run("thinking blocks", func(t *testing.T) {
+		req := &types.AnthropicMessagesRequest{
+			Messages: []types.AnthropicMessage{
+				{
+					Role: "assistant",
+					Content: json.RawMessage(`[{"type":"thinking","thinking":"Let me think..."},{"type":"text","text":"The answer is 42"}]`),
+				},
+			},
+		}
+		msgs, err := messagesToChatMessages(req, true)
+		require.NoError(t, err)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, "assistant", msgs[0]["role"])
+		assert.Equal(t, "The answer is 42", msgs[0]["content"])
+		assert.Equal(t, "Let me think...", msgs[0]["reasoning_content"])
+	})
+
+	t.Run("thinking blocks without reasoning support", func(t *testing.T) {
+		req := &types.AnthropicMessagesRequest{
+			Messages: []types.AnthropicMessage{
+				{
+					Role:    "assistant",
+					Content: json.RawMessage(`[{"type":"thinking","thinking":"Let me think..."},{"type":"text","text":"The answer is 42"}]`),
+				},
+			},
+		}
+		// When the upstream does not support thinking, reasoning_content should be omitted.
+		msgs, err := messagesToChatMessages(req, false)
+		require.NoError(t, err)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, "assistant", msgs[0]["role"])
+		assert.Equal(t, "The answer is 42", msgs[0]["content"])
+		_, hasReasoning := msgs[0]["reasoning_content"]
+		assert.False(t, hasReasoning)
+	})
+
+	t.Run("system as content blocks", func(t *testing.T) {
+		req := &types.AnthropicMessagesRequest{
+			System: json.RawMessage(`[{"type":"text","text":"Be concise"}]`),
+			Messages: []types.AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"Hello"`)},
+			},
+		}
+		msgs, err := messagesToChatMessages(req, true)
+		require.NoError(t, err)
+		require.Len(t, msgs, 2)
+		assert.Equal(t, "system", msgs[0]["role"])
+		assert.Equal(t, "Be concise", msgs[0]["content"])
+	})
+}
+
+func TestMessagesToolsToChatTools(t *testing.T) {
+	tools := []types.AnthropicTool{
+		{
+			Name:        "get_weather",
+			Description: "Get the weather",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+		},
+	}
+	chatTools := messagesToolsToChatTools(tools)
+	require.Len(t, chatTools, 1)
+	assert.Equal(t, "function", chatTools[0]["type"])
+	fn := chatTools[0]["function"].(map[string]any)
+	assert.Equal(t, "get_weather", fn["name"])
+	assert.Equal(t, "Get the weather", fn["description"])
+}
+
+func TestChatResponseToMessagesResponse(t *testing.T) {
+	t.Run("text response", func(t *testing.T) {
+		chatJSON := `{
+			"id": "chatcmpl-1",
+			"object": "chat.completion",
+			"created": 1234567890,
+			"model": "qwen3",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "Hello!"},
+				"finish_reason": "stop"
+			}],
+			"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+		}`
+		resp, err := chatResponseToMessagesResponse([]byte(chatJSON), "claude-3")
+		require.NoError(t, err)
+		assert.Equal(t, "message", resp.Type)
+		assert.Equal(t, "assistant", resp.Role)
+		require.Len(t, resp.Content, 1)
+		assert.Equal(t, "text", resp.Content[0].Type)
+		assert.Equal(t, "Hello!", resp.Content[0].Text)
+		assert.Equal(t, "end_turn", *resp.StopReason)
+		assert.Equal(t, 10, resp.Usage.InputTokens)
+		assert.Equal(t, 5, resp.Usage.OutputTokens)
+	})
+
+	t.Run("tool use response", func(t *testing.T) {
+		chatJSON := `{
+			"id": "chatcmpl-2",
+			"object": "chat.completion",
+			"created": 1234567890,
+			"model": "qwen3",
+			"choices": [{
+				"index": 0,
+				"message": {
+					"role": "assistant",
+					"content": "",
+					"tool_calls": [{
+						"id": "call_1",
+						"type": "function",
+						"function": {"name": "get_weather", "arguments": "{\"city\":\"SF\"}"}
+					}]
+				},
+				"finish_reason": "tool_calls"
+			}],
+			"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+		}`
+		resp, err := chatResponseToMessagesResponse([]byte(chatJSON), "claude-3")
+		require.NoError(t, err)
+		require.Len(t, resp.Content, 1)
+		assert.Equal(t, "tool_use", resp.Content[0].Type)
+		assert.Equal(t, "call_1", resp.Content[0].ID)
+		assert.Equal(t, "get_weather", resp.Content[0].Name)
+		assert.Equal(t, "tool_use", *resp.StopReason)
+	})
+
+	t.Run("with reasoning", func(t *testing.T) {
+		chatJSON := `{
+			"id": "chatcmpl-3",
+			"object": "chat.completion",
+			"created": 1234567890,
+			"model": "qwen3",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "42", "reasoning_content": "Thinking..."},
+				"finish_reason": "stop"
+			}],
+			"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+		}`
+		resp, err := chatResponseToMessagesResponse([]byte(chatJSON), "claude-3")
+		require.NoError(t, err)
+		require.Len(t, resp.Content, 2)
+		assert.Equal(t, "thinking", resp.Content[0].Type)
+		assert.Equal(t, "Thinking...", resp.Content[0].Thinking)
+		assert.Equal(t, "text", resp.Content[1].Type)
+		assert.Equal(t, "42", resp.Content[1].Text)
+	})
+
+	t.Run("max_tokens finish reason", func(t *testing.T) {
+		chatJSON := `{
+			"id": "chatcmpl-4",
+			"object": "chat.completion",
+			"created": 1234567890,
+			"model": "qwen3",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "partial..."},
+				"finish_reason": "length"
+			}],
+			"usage": {"prompt_tokens": 10, "completion_tokens": 100, "total_tokens": 110}
+		}`
+		resp, err := chatResponseToMessagesResponse([]byte(chatJSON), "claude-3")
+		require.NoError(t, err)
+		assert.Equal(t, "max_tokens", *resp.StopReason)
+	})
+}
+
+func TestResponsesResponseToMessagesResponse(t *testing.T) {
+	t.Run("text output", func(t *testing.T) {
+		resp := &types.ResponsesResponse{
+			ID:     "resp_1",
+			Status: "completed",
+			Model:  "gpt-4",
+			Output: []types.ResponsesOutputItem{
+				{
+					Type: "message",
+					Role: "assistant",
+					Content: []types.ResponsesContentPart{
+						{Type: "output_text", Text: "Hello from responses!"},
+					},
+				},
+			},
+			Usage: &types.ResponsesUsage{
+				InputTokens:  10,
+				OutputTokens: 5,
+			},
+		}
+		result, err := responsesResponseToMessagesResponse(resp, "claude-3")
+		require.NoError(t, err)
+		require.Len(t, result.Content, 1)
+		assert.Equal(t, "text", result.Content[0].Type)
+		assert.Equal(t, "Hello from responses!", result.Content[0].Text)
+		assert.Equal(t, "end_turn", *result.StopReason)
+		assert.Equal(t, 10, result.Usage.InputTokens)
+	})
+
+	t.Run("function call output", func(t *testing.T) {
+		resp := &types.ResponsesResponse{
+			Status: "completed",
+			Output: []types.ResponsesOutputItem{
+				{
+					Type:      "function_call",
+					CallID:    "call_1",
+					Name:      "get_weather",
+					Arguments: `{"city":"SF"}`,
+				},
+			},
+		}
+		result, err := responsesResponseToMessagesResponse(resp, "claude-3")
+		require.NoError(t, err)
+		require.Len(t, result.Content, 1)
+		assert.Equal(t, "tool_use", result.Content[0].Type)
+		assert.Equal(t, "call_1", result.Content[0].ID)
+	})
+
+	t.Run("reasoning output", func(t *testing.T) {
+		resp := &types.ResponsesResponse{
+			Status: "completed",
+			Output: []types.ResponsesOutputItem{
+				{
+					Type: "reasoning",
+					Summary: []types.ResponsesSummaryPart{
+						{Type: "summary_text", Text: "Reasoning here"},
+					},
+				},
+			},
+		}
+		result, err := responsesResponseToMessagesResponse(resp, "claude-3")
+		require.NoError(t, err)
+		require.Len(t, result.Content, 1)
+		assert.Equal(t, "thinking", result.Content[0].Type)
+		assert.Equal(t, "Reasoning here", result.Content[0].Thinking)
+	})
+
+	t.Run("incomplete status", func(t *testing.T) {
+		resp := &types.ResponsesResponse{
+			Status: "incomplete",
+			Output: []types.ResponsesOutputItem{
+				{Type: "message", Role: "assistant", Content: []types.ResponsesContentPart{{Type: "output_text", Text: "partial"}}},
+			},
+		}
+		result, err := responsesResponseToMessagesResponse(resp, "claude-3")
+		require.NoError(t, err)
+		assert.Equal(t, "max_tokens", *result.StopReason)
+	})
+}
+
+func TestMessagesToResponsesRequest(t *testing.T) {
+	t.Run("basic conversion", func(t *testing.T) {
+		temp := 0.7
+		req := &types.AnthropicMessagesRequest{
+			Model:     "claude-3",
+			MaxTokens: 1024,
+			System:    json.RawMessage(`"Be helpful"`),
+			Messages: []types.AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"Hello"`)},
+				{Role: "assistant", Content: json.RawMessage(`"Hi"`)},
+				{Role: "user", Content: json.RawMessage(`"How are you?"`)},
+			},
+			Temperature: &temp,
+		}
+		respReq, err := messagesToResponsesRequest(req, "claude-3")
+		require.NoError(t, err)
+		assert.Equal(t, "claude-3", respReq.Model)
+		assert.NotNil(t, respReq.MaxOutputTokens)
+		assert.Equal(t, 1024, *respReq.MaxOutputTokens)
+		assert.NotNil(t, respReq.Temperature)
+		assert.Equal(t, 0.7, *respReq.Temperature)
+
+		// Check instructions
+		var instrStr string
+		require.NoError(t, json.Unmarshal(respReq.Instructions, &instrStr))
+		assert.Equal(t, "Be helpful", instrStr)
+
+		// Check input items
+		var items []map[string]any
+		require.NoError(t, json.Unmarshal(respReq.Input, &items))
+		require.Len(t, items, 3)
+	})
+
+	t.Run("with tools", func(t *testing.T) {
+		req := &types.AnthropicMessagesRequest{
+			Model:     "claude-3",
+			MaxTokens: 1024,
+			Messages: []types.AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"What's the weather?"`)},
+			},
+			Tools: []types.AnthropicTool{
+				{Name: "get_weather", Description: "Get weather", InputSchema: json.RawMessage(`{"type":"object"}`)},
+			},
+		}
+		respReq, err := messagesToResponsesRequest(req, "claude-3")
+		require.NoError(t, err)
+		require.NotNil(t, respReq.Tools)
+
+		var tools []map[string]any
+		require.NoError(t, json.Unmarshal(respReq.Tools, &tools))
+		require.Len(t, tools, 1)
+		assert.Equal(t, "function", tools[0]["type"])
+		assert.Equal(t, "get_weather", tools[0]["name"])
+	})
+
+	t.Run("with thinking", func(t *testing.T) {
+		req := &types.AnthropicMessagesRequest{
+			Model:     "claude-3",
+			MaxTokens: 1024,
+			Messages: []types.AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"Think carefully"`)},
+			},
+			Thinking: &types.AnthropicThinking{Type: "enabled", BudgetTokens: 10000},
+		}
+		respReq, err := messagesToResponsesRequest(req, "claude-3")
+		require.NoError(t, err)
+		require.NotNil(t, respReq.Reasoning)
+
+		var reasoning map[string]any
+		require.NoError(t, json.Unmarshal(respReq.Reasoning, &reasoning))
+		assert.Equal(t, "medium", reasoning["effort"])
+	})
+
+	t.Run("tool use and result in messages", func(t *testing.T) {
+		req := &types.AnthropicMessagesRequest{
+			Model:     "claude-3",
+			MaxTokens: 1024,
+			Messages: []types.AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"Weather?"`)},
+				{
+					Role:    "assistant",
+					Content: json.RawMessage(`[{"type":"tool_use","id":"tool_1","name":"get_weather","input":{"city":"SF"}}]`),
+				},
+				{
+					Role:    "user",
+					Content: json.RawMessage(`[{"type":"tool_result","tool_use_id":"tool_1","content":"72F"}]`),
+				},
+			},
+		}
+		respReq, err := messagesToResponsesRequest(req, "claude-3")
+		require.NoError(t, err)
+
+		var items []map[string]any
+		require.NoError(t, json.Unmarshal(respReq.Input, &items))
+		require.Len(t, items, 3)
+
+		// The third item should be function_call_output
+		assert.Equal(t, "function_call_output", items[2]["type"])
+		assert.Equal(t, "tool_1", items[2]["call_id"])
+	})
+}
+
+func TestChatFinishReasonToStopReason(t *testing.T) {
+	tests := []struct {
+		finishReason string
+		expected     string
+	}{
+		{"stop", "end_turn"},
+		{"length", "max_tokens"},
+		{"tool_calls", "tool_use"},
+		{"function_call", "tool_use"},
+		{"stop_sequence", "stop_sequence"},
+		{"unknown", "end_turn"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.finishReason, func(t *testing.T) {
+			assert.Equal(t, tt.expected, chatFinishReasonToStopReason(tt.finishReason))
+		})
+	}
+}
+
+func TestBudgetToEffort(t *testing.T) {
+	tests := []struct {
+		budget   int
+		expected string
+	}{
+		{1000, "low"},
+		{5000, "low"},
+		{10000, "medium"},
+		{20000, "medium"},
+		{50000, "high"},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, tt.expected, budgetToEffort(tt.budget))
+		})
+	}
+}
+
+func TestNewMessagesResponseID(t *testing.T) {
+	id1 := newMessagesResponseID()
+	id2 := newMessagesResponseID()
+	assert.NotEmpty(t, id1)
+	assert.NotEqual(t, id1, id2)
+	assert.Contains(t, id1, "msg_agw_")
+}
+
+func TestConvertToolChoiceForChat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"auto", `{"type":"auto"}`, `"auto"`},
+		{"any → required", `{"type":"any"}`, `"required"`},
+		{"tool → function", `{"type":"tool","name":"get_weather"}`, `{"type":"function","function":{"name":"get_weather"}}`},
+		{"unknown defaults to auto", `{"type":"weird"}`, `"auto"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := convertToolChoiceForChat(json.RawMessage(tt.input))
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestConvertToolChoiceForResponses(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"auto", `{"type":"auto"}`, `"auto"`},
+		{"any → required", `{"type":"any"}`, `"required"`},
+		{"tool → function (flat)", `{"type":"tool","name":"get_weather"}`, `{"type":"function","name":"get_weather"}`},
+		{"unknown defaults to auto", `{"type":"weird"}`, `"auto"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := convertToolChoiceForResponses(json.RawMessage(tt.input))
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(result))
+		})
+	}
+}

--- a/aigateway/handler/anthropic/deps.go
+++ b/aigateway/handler/anthropic/deps.go
@@ -1,0 +1,303 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/shared"
+	"opencsg.com/csghub-server/aigateway/types"
+	commontypes "opencsg.com/csghub-server/common/types"
+)
+
+// Deps bundles all dependencies required by the anthropic Handler.
+//
+// The Handler owns its Execute-phase logic (proxy, auth headers, SSE
+// headers, usage recording, metrics, usage-limit commit, preflight tracing,
+// LLM trace, and LLM log publishing).  Each dependency is an explicit
+// interface so the Handler has no compile-time dependency on the handler
+// package — the handler package provides concrete adapters.
+type Deps struct {
+	// ProxyExecutor executes a reverse proxy request to the upstream.
+	ProxyExecutor ProxyExecutor
+	// UsageRecorder records token usage for billing/metering.
+	UsageRecorder UsageRecorder
+	// UsageLimiter commits usage quota after the upstream response.
+	UsageLimiter UsageLimiter
+	// MetricsRecorder records request-level metrics.
+	MetricsRecorder MetricsRecorder
+
+	// LLMTracer is optional. When set, the Handler starts an LLM generation
+	// trace before proxying and records completion/error after.
+	LLMTracer LLMTracer
+	// LLMLogRecorderFactory creates an LLM log recorder for capturing
+	// input/output messages for training log publishing.
+	LLMLogRecorderFactory LLMLogRecorderFactory
+	// LLMLogPublisher is optional. When set, the Handler publishes the
+	// captured LLM log record asynchronously after the response completes.
+	LLMLogPublisher LLMLogPublisher
+}
+
+// ProxyExecutor executes a reverse proxy request to the upstream and writes
+// the response through the provided writer.
+type ProxyExecutor interface {
+	ServeProxy(c *gin.Context, backendURL, host string, responseWriter types.HTTPResponseWriter)
+}
+
+// UsageRecorder records token usage for billing/metering.
+type UsageRecorder interface {
+	RecordUsage(ctx context.Context, nsUUID string, model *types.Model, targetModelName string, inputTokens, outputTokens, cachedPromptTokens, cacheCreationPromptTokens int64, apikey string) error
+}
+
+// UsageLimiter commits usage quota limits after the upstream response.
+type UsageLimiter interface {
+	CommitUsageLimitFromUsage(ctx context.Context, nsUUID string, model *types.Model, inputTokens, outputTokens, cachedPromptTokens, cacheCreationPromptTokens int64) error
+}
+
+// MetricsRecorder records request-level metrics (model, provider, token usage).
+type MetricsRecorder interface {
+	SetModelTarget(c *gin.Context, modelID string, target *types.ModelTarget, isStream bool)
+	RecordTokenUsage(c *gin.Context, inputTokens, outputTokens, cachedPromptTokens int64)
+}
+
+// PreflightTracer records a preflight span that covers the full request
+// lifecycle.  The span is started by the entry-point handler (e.g.
+// AnthropicHandlerImpl.Messages) and stored in the gin.Context so the
+// protocol handler can record model-resolution attributes and errors
+// during Execute and HandlePlanError.
+type PreflightTracer interface {
+	// RecordError records an error on the preflight span and ends it.
+	RecordError(err error, errorType string)
+	// SetTargetModel records the resolved model target attributes.
+	SetTargetModel(requestModel string, target *types.ModelTarget)
+	// End ends the preflight span.
+	End()
+}
+
+// preflightTracerCtxKey is the gin.Context key for the per-request PreflightTracer.
+const preflightTracerCtxKey = "anthropic.preflight_tracer"
+
+// SetPreflightTracer stores a PreflightTracer in the gin.Context so that
+// Execute and HandlePlanError can access it.  Called by the entry-point
+// handler (AnthropicHandlerImpl.Messages) before Dispatch.
+func SetPreflightTracer(c *gin.Context, t PreflightTracer) {
+	c.Set(preflightTracerCtxKey, t)
+}
+
+// GetPreflightTracer retrieves the PreflightTracer from the gin.Context.
+// Returns nil if none was set.
+func GetPreflightTracer(c *gin.Context) PreflightTracer {
+	v, exists := c.Get(preflightTracerCtxKey)
+	if !exists {
+		return nil
+	}
+	t, _ := v.(PreflightTracer)
+	return t
+}
+
+// LLMTracer starts an LLM generation trace.  The returned GenerationRecorder
+// captures usage, response, and error information for the trace.
+type LLMTracer interface {
+	StartGeneration(ctx context.Context, input types.GenerationStart) (context.Context, GenerationRecorder)
+}
+
+// GenerationRecorder records an LLM generation trace.
+type GenerationRecorder interface {
+	SetUsage(usage types.TokenUsage)
+	SetResponse(response types.GenerationResponse)
+	SetFirstChunk(firstChunk types.GenerationFirstChunk)
+	SetError(err error, code string)
+	End()
+}
+
+// LLMLogRecorder captures input/output messages for training log publishing.
+type LLMLogRecorder interface {
+	Completion(resp types.ChatCompletion)
+	AppendCompletionChunk(chunk types.ChatCompletionChunk)
+	Record() (*commontypes.LLMLogRecord, error)
+	Messages() (input, output []commontypes.LLMLogMessage)
+	TraceInfo() commontypes.LLMLogTraceInfo
+}
+
+// LLMLogRecorderFactory creates an LLM log recorder for a request.
+type LLMLogRecorderFactory interface {
+	NewLLMLogRecorder(requestID, modelID, userUUID string, req commontypes.LLMLogRequest, metadata map[string]any) (LLMLogRecorder, error)
+}
+
+// LLMLogPublisher publishes training log records.
+type LLMLogPublisher interface {
+	PublishTrainingLog(message []byte) error
+}
+
+// SensitiveResult is a protocol-agnostic representation of a sensitive
+// check result.
+type SensitiveResult struct {
+	IsSensitive bool
+	Message     string
+}
+
+// postProcessInput holds the data needed for async post-processing after
+// the upstream response completes.  It mirrors handler.runChatPostProcessAsync.
+type postProcessInput struct {
+	NSUUID          string
+	ApiKey          string
+	Model           *types.Model
+	TargetModelName string
+	Usage           *tokenUsage
+	LogCapture      LLMLogRecorder
+	Trace           tracePostProcessInput
+	StatusCode      int
+}
+
+type tracePostProcessInput struct {
+	Recorder     GenerationRecorder
+	Completion   bool
+	Stream       bool
+	FirstWriteAt time.Time
+	StatusCode   int
+}
+
+// tokenUsage is the local usage struct used by the anthropic package.
+type tokenUsage struct {
+	PromptTokens              int64
+	CompletionTokens          int64
+	TotalTokens               int64
+	CachedPromptTokens        int64
+	CacheCreationPromptTokens int64
+}
+
+// anthropicRequestToLLMLogRequest converts an AnthropicMessagesRequest into
+// the OpenAI-typed LLMLogRequest expected by the LLM log recorder.
+// The recorder's normalizeLogMessages does a JSON round-trip, so the messages
+// just need to serialize to valid OpenAI Chat message structures.
+func anthropicRequestToLLMLogRequest(req *types.AnthropicMessagesRequest) (commontypes.LLMLogRequest, error) {
+	chatMsgs, err := messagesToChatMessages(req, true)
+	if err != nil {
+		return commontypes.LLMLogRequest{}, err
+	}
+
+	messages := make([]openai.ChatCompletionMessageParamUnion, 0, len(chatMsgs))
+	for _, m := range chatMsgs {
+		role, _ := m["role"].(string)
+		switch role {
+		case "system":
+			systemText := jsonStringFromAny(m["content"])
+			messages = append(messages, openai.SystemMessage(systemText))
+		case "tool":
+			toolCallID, _ := m["tool_call_id"].(string)
+			toolText := jsonStringFromAny(m["content"])
+			messages = append(messages, openai.ToolMessage(toolText, toolCallID))
+		case "assistant":
+			msg := buildAssistantMessageParam(m)
+			messages = append(messages, msg)
+		default: // "user" and anything else
+			userText := jsonStringFromAny(m["content"])
+			messages = append(messages, openai.UserMessage(userText))
+		}
+	}
+
+	var tools []openai.ChatCompletionToolUnionParam
+	if len(req.Tools) > 0 {
+		tools = make([]openai.ChatCompletionToolUnionParam, 0, len(req.Tools))
+		for _, tool := range req.Tools {
+			schema := tool.InputSchema
+			if len(schema) == 0 {
+				schema = json.RawMessage(`{"type":"object"}`)
+			}
+			var params shared.FunctionParameters
+			if err := json.Unmarshal(schema, &params); err != nil {
+				params = shared.FunctionParameters{"type": "object"}
+			}
+			fn := shared.FunctionDefinitionParam{
+				Name:       tool.Name,
+				Parameters: params,
+			}
+			if tool.Description != "" {
+				fn.Description = param.NewOpt(tool.Description)
+			}
+			tools = append(tools, openai.ChatCompletionFunctionTool(fn))
+		}
+	}
+
+	return commontypes.LLMLogRequest{
+		Messages: messages,
+		Tools:    tools,
+		Stream:   req.Stream,
+	}, nil
+}
+
+// jsonStringFromAny converts a content value (string or []any of text parts)
+// to a plain string, mirroring normalizeMessageContent in llmlog_capture_ee.go.
+func jsonStringFromAny(content any) string {
+	switch v := content.(type) {
+	case string:
+		return v
+	case []any:
+		var parts []string
+		for _, item := range v {
+			part, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if partType, _ := part["type"].(string); partType == "text" {
+				if text, _ := part["text"].(string); text != "" {
+					parts = append(parts, text)
+				}
+			}
+		}
+		return joinStrings(parts, "")
+	case map[string]any:
+		data, err := json.Marshal(v)
+		if err != nil {
+			return ""
+		}
+		return string(data)
+	default:
+		return ""
+	}
+}
+
+// buildAssistantMessageParam builds an assistant ChatCompletionMessageParamUnion
+// from a converted chat message map, including tool_calls.
+//
+// Note: reasoning_content is not set because the openai-go v3 SDK's
+// ChatCompletionAssistantMessageParam does not expose a reasoning_content
+// field.  This only affects LLM training log capture (not the client-facing
+// response), and is consistent with the SDK's own limitations.
+func buildAssistantMessageParam(m map[string]any) openai.ChatCompletionMessageParamUnion {
+	content, _ := m["content"].(string)
+	msg := openai.ChatCompletionMessageParamUnion{}
+	assistant := &openai.ChatCompletionAssistantMessageParam{}
+	if content != "" {
+		assistant.Content = openai.ChatCompletionAssistantMessageParamContentUnion{
+			OfString: param.NewOpt(content),
+		}
+	}
+	if toolCalls, ok := m["tool_calls"].([]any); ok && len(toolCalls) > 0 {
+		for _, tc := range toolCalls {
+			tcMap, ok := tc.(map[string]any)
+			if !ok {
+				continue
+			}
+			fn, _ := tcMap["function"].(map[string]any)
+			id, _ := tcMap["id"].(string)
+			name, _ := fn["name"].(string)
+			args, _ := fn["arguments"].(string)
+			assistant.ToolCalls = append(assistant.ToolCalls, openai.ChatCompletionMessageToolCallUnionParam{
+				OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+					ID:   id,
+					Type: "function",
+					Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+						Name:      name,
+						Arguments: args,
+					},
+				},
+			})
+		}
+	}
+	msg.OfAssistant = assistant
+	return msg
+}

--- a/aigateway/handler/anthropic/e2e_test.go
+++ b/aigateway/handler/anthropic/e2e_test.go
@@ -1,0 +1,1667 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/handler/plan"
+	"opencsg.com/csghub-server/aigateway/handler/protocol"
+	"opencsg.com/csghub-server/aigateway/types"
+	commonType "opencsg.com/csghub-server/common/types"
+)
+
+// --- Test doubles ---
+
+// fakePlanner implements plan.Planner.  It mimics the real Planner by running
+// protocol.ResolveRouting on the provided ModelTarget, but skips balance,
+// usage-limit, and sensitive checks unless explicitly configured.
+type fakePlanner struct {
+	target     *types.ModelTarget
+	planErr    error
+	errorCode  types.PlanErrorCategory
+	sensitive  *types.SafetyDecision
+	balanceErr error
+	usageErr   error
+}
+
+func (f *fakePlanner) Plan(ctx context.Context, meta *types.RequestMetadata) (*types.RequestPlan, error) {
+	if f.target == nil && f.planErr != nil {
+		p := &types.RequestPlan{ErrorCode: f.errorCode}
+		return p, f.planErr
+	}
+
+	pl := &types.RequestPlan{ModelTarget: f.target}
+
+	// Run routing just like the real planner.
+	decision, err := protocol.ResolveRouting(types.Protocol(meta.Protocol), protocol.RoutingTarget{
+		ModelID:          f.target.Model.ID,
+		Target:           f.target.Target,
+		CSGHubHosted:     isTestCSGHubHosted(f.target),
+		RuntimeFramework: f.target.Model.RuntimeFramework,
+		ImageID:          f.target.Model.ImageID,
+		UpstreamMetadata: f.target.Upstream.Metadata,
+	})
+	if err != nil {
+		pl.ErrorCode = types.PlanErrUnknown
+		return pl, err
+	}
+	pl.RouteMode = string(decision.Mode)
+	pl.AdapterKind = string(decision.AdapterKind)
+	pl.UpstreamProtocol = string(decision.UpstreamProtocol)
+	if decision.Mode == protocol.ModeAdapter {
+		pl.UpstreamCap = types.CapabilityFor(decision.UpstreamProtocol)
+	}
+	if decision.Mode == protocol.ModeDisabled {
+		pl.ErrorCode = types.PlanErrDisabled
+		pl.BackendURL = f.target.Target
+		return pl, fmt.Errorf("protocol not available for this model")
+	}
+
+	// Balance check.
+	if f.balanceErr != nil {
+		pl.ErrorCode = types.PlanErrInsufficientBalance
+		return pl, f.balanceErr
+	}
+	pl.BalanceOK = true
+
+	// Backend URL.
+	pl.BackendURL = decision.BackendURL
+	if pl.BackendURL == "" {
+		pl.BackendURL = f.target.Target
+	}
+
+	// Usage-limit check.
+	if f.usageErr != nil {
+		pl.ErrorCode = types.PlanErrUsageLimitExceeded
+		return pl, f.usageErr
+	}
+	pl.UsageLimitOK = true
+
+	// Sensitive check.
+	if f.sensitive != nil && f.sensitive.IsSensitive {
+		pl.Safety = f.sensitive
+		pl.ErrorCode = types.PlanErrSensitive
+		return pl, fmt.Errorf("content blocked due to safety policy")
+	}
+
+	return pl, nil
+}
+
+func isTestCSGHubHosted(mt *types.ModelTarget) bool {
+	return mt != nil && mt.Model != nil && mt.Model.SvcName != ""
+}
+
+type fakeProxyExecutor struct{}
+
+func (f *fakeProxyExecutor) ServeProxy(c *gin.Context, backendURL, host string, responseWriter types.HTTPResponseWriter) {
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, backendURL, c.Request.Body)
+	if err != nil {
+		responseWriter.WriteHeader(http.StatusBadGateway)
+		return
+	}
+	req.Header = c.Request.Header.Clone()
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		responseWriter.WriteHeader(http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			responseWriter.Header().Add(k, v)
+		}
+	}
+	responseWriter.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(responseWriter, resp.Body)
+	responseWriter.Flush()
+}
+
+type fakeUsageRecorder struct {
+	recorded               bool
+	inputTokens            int64
+	outputTokens           int64
+	cachedPromptTokens     int64
+	cacheCreationTokens    int64
+	targetModelName        string
+}
+
+func (f *fakeUsageRecorder) RecordUsage(ctx context.Context, nsUUID string, model *types.Model, targetModelName string, inputTokens, outputTokens, cachedPromptTokens, cacheCreationPromptTokens int64, apikey string) error {
+	f.recorded = true
+	f.inputTokens = inputTokens
+	f.outputTokens = outputTokens
+	f.cachedPromptTokens = cachedPromptTokens
+	f.cacheCreationTokens = cacheCreationPromptTokens
+	f.targetModelName = targetModelName
+	return nil
+}
+
+type fakeUsageLimiter struct {
+	committed            bool
+	inputTokens          int64
+	outputTokens         int64
+	cachedPromptTokens   int64
+	cacheCreationTokens  int64
+}
+
+func (f *fakeUsageLimiter) CommitUsageLimitFromUsage(ctx context.Context, nsUUID string, model *types.Model, inputTokens, outputTokens, cachedPromptTokens, cacheCreationPromptTokens int64) error {
+	f.committed = true
+	f.inputTokens = inputTokens
+	f.outputTokens = outputTokens
+	f.cachedPromptTokens = cachedPromptTokens
+	f.cacheCreationTokens = cacheCreationPromptTokens
+	return nil
+}
+
+type fakeMetricsRecorder struct {
+	modelSet            bool
+	modelID             string
+	usageRecorded       bool
+	inputTokens         int64
+	outputTokens        int64
+	cachedPromptTokens  int64
+}
+
+func (f *fakeMetricsRecorder) SetModelTarget(c *gin.Context, modelID string, target *types.ModelTarget, isStream bool) {
+	f.modelSet = true
+	f.modelID = modelID
+}
+
+func (f *fakeMetricsRecorder) RecordTokenUsage(c *gin.Context, inputTokens, outputTokens, cachedPromptTokens int64) {
+	f.usageRecorded = true
+	f.inputTokens = inputTokens
+	f.outputTokens = outputTokens
+	f.cachedPromptTokens = cachedPromptTokens
+}
+
+// --- Test helpers ---
+
+func makeTestHandlerWithPlanner(planner *fakePlanner) *Handler {
+	h, _, _, _ := makeTestHandlerWithPlannerAndFakes(planner)
+	return h
+}
+
+func makeTestHandlerWithPlannerAndFakes(planner *fakePlanner) (*Handler, *fakeUsageRecorder, *fakeUsageLimiter, *fakeMetricsRecorder) {
+	recorder := &fakeUsageRecorder{}
+	limiter := &fakeUsageLimiter{}
+	metrics := &fakeMetricsRecorder{}
+	h := New(Deps{
+		ProxyExecutor:   &fakeProxyExecutor{},
+		UsageRecorder:   recorder,
+		UsageLimiter:    limiter,
+		MetricsRecorder: metrics,
+	})
+	return h, recorder, limiter, metrics
+}
+
+func makeMessagesTarget(upstreamURL, protocol string) *types.ModelTarget {
+	meta := map[string]any{}
+	if protocol != "" {
+		meta["protocol"] = protocol
+	}
+	return &types.ModelTarget{
+		Model: &types.Model{
+			BaseModel: types.BaseModel{ID: "test-model"},
+		},
+		Upstream: commonType.UpstreamConfig{
+			URL:      upstreamURL,
+			Provider: "test",
+			Metadata: meta,
+		},
+		Target:    upstreamURL,
+		ModelName: "test-model",
+	}
+}
+
+func validMessagesBody(model string) string {
+	return fmt.Sprintf(`{
+		"model": "%s",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`, model)
+}
+
+// dispatchWithTarget runs the handler through the production Orchestrator with
+// a fake Planner configured for the given target.
+func dispatchWithTarget(t *testing.T, handler *Handler, body string, planner *fakePlanner) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/v1/messages", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	orch := plan.NewOrchestrator(planner)
+	orch.Dispatch(c, handler, handler)
+	return w
+}
+
+// --- Native passthrough tests ---
+
+func TestE2E_Native_NonStream_200(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/messages", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{
+			"id": "msg_123",
+			"type": "message",
+			"role": "assistant",
+			"content": [{"type": "text", "text": "Hello from native!"}],
+			"model": "test-model",
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 10, "output_tokens": 5}
+		}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/messages", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	require.Equal(t, 200, w.Code)
+	var resp types.AnthropicMessagesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "message", resp.Type)
+	assert.Equal(t, "assistant", resp.Role)
+	require.Len(t, resp.Content, 1)
+	assert.Equal(t, "Hello from native!", resp.Content[0].Text)
+	assert.Equal(t, "end_turn", *resp.StopReason)
+	assert.Equal(t, 10, resp.Usage.InputTokens)
+	assert.Equal(t, 5, resp.Usage.OutputTokens)
+}
+
+func TestE2E_Native_Stream_200(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher := w.(http.Flusher)
+		fmt.Fprint(w, "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"test\",\"content\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi!\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	body := strings.Replace(validMessagesBody("test-model"), `"max_tokens": 1024`, `"max_tokens": 1024, "stream": true`, 1)
+	target := makeMessagesTarget(upstream.URL+"/v1/messages", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	require.Equal(t, 200, w.Code)
+	bodyStr := w.Body.String()
+	assert.Contains(t, bodyStr, "message_start")
+	assert.Contains(t, bodyStr, "content_block_delta")
+	assert.Contains(t, bodyStr, "Hi!")
+	assert.Contains(t, bodyStr, "message_stop")
+}
+
+// --- Messages → Chat adapter tests ---
+
+func TestE2E_ToChat_NonStream_200(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		var req map[string]any
+		require.NoError(t, json.Unmarshal(readBody(r.Body), &req))
+		assert.Equal(t, "test-model", req["model"])
+		assert.Equal(t, float64(1024), req["max_tokens"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{
+			"id": "chatcmpl-1",
+			"object": "chat.completion",
+			"created": 1234567890,
+			"model": "test-model",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "Hello via chat adapter!"},
+				"finish_reason": "stop"
+			}],
+			"usage": {"prompt_tokens": 10, "completion_tokens": 8, "total_tokens": 18}
+		}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	require.Equal(t, 200, w.Code)
+	var resp types.AnthropicMessagesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "message", resp.Type)
+	require.Len(t, resp.Content, 1)
+	assert.Equal(t, "text", resp.Content[0].Type)
+	assert.Equal(t, "Hello via chat adapter!", resp.Content[0].Text)
+	assert.Equal(t, "end_turn", *resp.StopReason)
+	assert.Equal(t, 10, resp.Usage.InputTokens)
+	assert.Equal(t, 8, resp.Usage.OutputTokens)
+}
+
+func TestE2E_ToChat_Stream_200(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher := w.(http.Flusher)
+		chunks := []string{
+			`data: {"id":"1","object":"chat.completion.chunk","model":"test","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}`,
+			`data: {"id":"1","object":"chat.completion.chunk","model":"test","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`,
+			`data: {"id":"1","object":"chat.completion.chunk","model":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`,
+			`data: [DONE]`,
+		}
+		for _, chunk := range chunks {
+			fmt.Fprintf(w, "%s\n\n", chunk)
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	body := strings.Replace(validMessagesBody("test-model"), `"max_tokens": 1024`, `"max_tokens": 1024, "stream": true`, 1)
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	require.Equal(t, 200, w.Code)
+	bodyStr := w.Body.String()
+	assert.Contains(t, bodyStr, "message_start")
+	assert.Contains(t, bodyStr, "content_block_start")
+	assert.Contains(t, bodyStr, "text_delta")
+	assert.Contains(t, bodyStr, "Hello")
+	assert.Contains(t, bodyStr, "world")
+	assert.Contains(t, bodyStr, "content_block_stop")
+	assert.Contains(t, bodyStr, "message_delta")
+	assert.Contains(t, bodyStr, "message_stop")
+}
+
+func TestE2E_ToChat_ToolUse_200(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{
+			"id": "chatcmpl-2",
+			"object": "chat.completion",
+			"created": 1234567890,
+			"model": "test-model",
+			"choices": [{
+				"index": 0,
+				"message": {
+					"role": "assistant",
+					"content": "",
+					"tool_calls": [{
+						"id": "call_1",
+						"type": "function",
+						"function": {"name": "get_weather", "arguments": "{\"city\":\"SF\"}"}
+					}]
+				},
+				"finish_reason": "tool_calls"
+			}],
+			"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+		}`)
+	}))
+	defer upstream.Close()
+
+	body := `{
+		"model": "test-model",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "What's the weather in SF?"}],
+		"tools": [{"name": "get_weather", "description": "Get weather", "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}}}]
+	}`
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	require.Equal(t, 200, w.Code)
+	var resp types.AnthropicMessagesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Content, 1)
+	assert.Equal(t, "tool_use", resp.Content[0].Type)
+	assert.Equal(t, "call_1", resp.Content[0].ID)
+	assert.Equal(t, "get_weather", resp.Content[0].Name)
+	assert.Equal(t, "tool_use", *resp.StopReason)
+}
+
+// --- Messages → Responses adapter tests ---
+
+func TestE2E_ToResponses_NonStream_200(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/responses", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{
+			"id": "resp_1",
+			"object": "response",
+			"created_at": 1234567890,
+			"status": "completed",
+			"model": "test-model",
+			"output": [{
+				"type": "message",
+				"role": "assistant",
+				"content": [{"type": "output_text", "text": "Hello via responses adapter!"}]
+			}],
+			"usage": {"input_tokens": 10, "output_tokens": 7, "total_tokens": 17}
+		}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/responses", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	require.Equal(t, 200, w.Code)
+	var resp types.AnthropicMessagesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "message", resp.Type)
+	require.Len(t, resp.Content, 1)
+	assert.Equal(t, "Hello via responses adapter!", resp.Content[0].Text)
+	assert.Equal(t, "end_turn", *resp.StopReason)
+	assert.Equal(t, 10, resp.Usage.InputTokens)
+	assert.Equal(t, 7, resp.Usage.OutputTokens)
+}
+
+func TestE2E_ToResponses_Stream_200(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher := w.(http.Flusher)
+		events := []string{
+			`event: response.created\ndata: {"type":"response.created","response":{"id":"resp_1","status":"in_progress","model":"test"}}`,
+			`event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"Hello"}`,
+			`event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"!"}`,
+			`event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_1","status":"completed","model":"test","usage":{"input_tokens":5,"output_tokens":2}}}`,
+		}
+		for _, e := range events {
+			e = strings.ReplaceAll(e, `\n`, "\n")
+			fmt.Fprint(w, e+"\n\n")
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	body := strings.Replace(validMessagesBody("test-model"), `"max_tokens": 1024`, `"max_tokens": 1024, "stream": true`, 1)
+	target := makeMessagesTarget(upstream.URL+"/v1/responses", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	require.Equal(t, 200, w.Code)
+	bodyStr := w.Body.String()
+	assert.Contains(t, bodyStr, "message_start")
+	assert.Contains(t, bodyStr, "text_delta")
+	assert.Contains(t, bodyStr, "Hello")
+	assert.Contains(t, bodyStr, "message_stop")
+}
+
+// --- Error status code tests ---
+
+func TestE2E_Native_404(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
+		fmt.Fprint(w, `{"type":"error","error":{"type":"not_found_error","message":"model not found"}}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/messages", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	assert.Equal(t, 404, w.Code)
+}
+
+func TestE2E_Native_429(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(429)
+		fmt.Fprint(w, `{"type":"error","error":{"type":"rate_limit_error","message":"rate limited"}}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/messages", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	assert.Equal(t, 429, w.Code)
+}
+
+func TestE2E_ToChat_502(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(502)
+		fmt.Fprint(w, `{"error":{"message":"bad gateway"}}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	// 502 is mapped to 529 overloaded_error in Anthropic format.
+	assert.Equal(t, 529, w.Code)
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	assert.Equal(t, "error", errResp["type"])
+	errObj, ok := errResp["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "overloaded_error", errObj["type"])
+	assert.Contains(t, errObj["message"], "bad gateway")
+}
+
+func TestE2E_ToChat_503(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(503)
+		fmt.Fprint(w, `{"error":{"message":"service unavailable"}}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	assert.Equal(t, 529, w.Code)
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	assert.Equal(t, "error", errResp["type"])
+}
+
+func TestE2E_ToResponses_504(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(504)
+		fmt.Fprint(w, `{"error":{"message":"gateway timeout"}}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/responses", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	assert.Equal(t, 529, w.Code)
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	assert.Equal(t, "error", errResp["type"])
+}
+
+func TestE2E_ToChat_500(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		fmt.Fprint(w, `{"error":{"message":"internal server error"}}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	assert.Equal(t, 529, w.Code)
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	assert.Equal(t, "error", errResp["type"])
+}
+
+// --- Validation and routing error tests ---
+
+func TestE2E_InvalidRequest_NoModel(t *testing.T) {
+	target := makeMessagesTarget("http://upstream/v1/messages", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, `{"max_tokens": 1024, "messages": [{"role": "user", "content": "hi"}]}`, planner)
+
+	assert.Equal(t, 400, w.Code)
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	assert.Equal(t, "error", errResp["type"])
+}
+
+func TestE2E_InvalidRequest_NoMaxTokens(t *testing.T) {
+	target := makeMessagesTarget("http://upstream/v1/messages", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, `{"model": "test", "messages": [{"role": "user", "content": "hi"}]}`, planner)
+
+	assert.Equal(t, 400, w.Code)
+}
+
+func TestE2E_Disabled_NoAdapter(t *testing.T) {
+	// Unknown protocol falls back to chat, so adapter mode is selected.
+	// The upstream is unreachable, so we get a 502 from the proxy.
+	target := &types.ModelTarget{
+		Model: &types.Model{
+			BaseModel: types.BaseModel{ID: "test-model"},
+		},
+		Upstream: commonType.UpstreamConfig{
+			URL:      "http://127.0.0.1:1/v1/unknown",
+			Provider: "test",
+			Metadata: map[string]any{"protocol": "unknown"},
+		},
+		Target:    "http://127.0.0.1:1/v1/unknown",
+		ModelName: "test-model",
+	}
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	assert.True(t, w.Code >= 400)
+}
+
+func TestE2E_UnsupportedCapability_CacheControl(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("upstream should not be called")
+	}))
+	defer upstream.Close()
+
+	body := `{
+		"model": "test-model",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "hello", "cache_control": {"type": "ephemeral"}}]}]
+	}`
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	assert.Equal(t, 400, w.Code)
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	errObj, ok := errResp["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "unsupported_capability", errObj["type"])
+	assert.Contains(t, errObj["message"], "prompt_caching")
+}
+
+func TestE2E_UnsupportedCapability_Thinking(t *testing.T) {
+	// Chat protocol now supports thinking via reasoning_effort translation.
+	// The adapter should accept the request and proxy it to the upstream.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify reasoning_effort was sent to the upstream.
+		var req map[string]any
+		require.NoError(t, json.Unmarshal(readBody(r.Body), &req))
+		assert.Equal(t, "low", req["reasoning_effort"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{
+			"id": "chatcmpl-1",
+			"object": "chat.completion",
+			"created": 1234567890,
+			"model": "test-model",
+			"choices": [{"index": 0, "message": {"role": "assistant", "content": "I thought about this."}, "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 5, "completion_tokens": 4, "total_tokens": 9}
+		}`)
+	}))
+	defer upstream.Close()
+
+	body := `{
+		"model": "test-model",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "think carefully"}],
+		"thinking": {"type": "enabled", "budget_tokens": 5000}
+	}`
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	require.Equal(t, 200, w.Code)
+	var resp types.AnthropicMessagesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "I thought about this.", resp.Content[0].Text)
+}
+
+// --- Model target resolution error tests ---
+
+func TestE2E_ModelNotFound(t *testing.T) {
+	planner := &fakePlanner{
+		planErr:   fmt.Errorf("model 'unknown' not found"),
+		errorCode: types.PlanErrModelNotFound,
+	}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("unknown"), planner)
+
+	assert.Equal(t, 404, w.Code)
+}
+
+// --- Balance check error test ---
+
+func TestE2E_InsufficientBalance(t *testing.T) {
+	planner := &fakePlanner{
+		target:     makeMessagesTarget("http://upstream/v1/messages", ""),
+		balanceErr: fmt.Errorf("insufficient balance"),
+	}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	assert.Equal(t, 402, w.Code)
+}
+
+// --- Sensitive content test ---
+
+func TestE2E_SensitiveContent(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("upstream should not be called for sensitive content")
+	}))
+	defer upstream.Close()
+
+	planner := &fakePlanner{
+		target:    makeMessagesTarget(upstream.URL+"/v1/messages", ""),
+		sensitive: &types.SafetyDecision{IsSensitive: true, Message: "content blocked"},
+	}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	assert.Equal(t, 200, w.Code)
+	var resp types.AnthropicMessagesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Content, 1)
+	assert.Contains(t, resp.Content[0].Text, "content blocked")
+}
+
+// --- CSGHub hosted test ---
+
+func TestE2E_CSGHubHosted_ToChat(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{
+			"id": "chatcmpl-1",
+			"object": "chat.completion",
+			"created": 1234567890,
+			"model": "test-model",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "Hello from CSGHub!"},
+				"finish_reason": "stop"
+			}],
+			"usage": {"prompt_tokens": 5, "completion_tokens": 4, "total_tokens": 9}
+		}`)
+	}))
+	defer upstream.Close()
+
+	target := &types.ModelTarget{
+		Model: &types.Model{
+			BaseModel: types.BaseModel{ID: "test-model"},
+			InternalModelInfo: types.InternalModelInfo{
+				SvcName: "test-svc",
+			},
+		},
+		Upstream: commonType.UpstreamConfig{
+			URL:      upstream.URL,
+			Provider: "test",
+		},
+		Target:    upstream.URL,
+		ModelName: "test-model",
+	}
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	require.Equal(t, 200, w.Code)
+	var resp types.AnthropicMessagesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "Hello from CSGHub!", resp.Content[0].Text)
+}
+
+// --- Helper: read request body ---
+
+func readBody(r io.Reader) []byte {
+	data, _ := io.ReadAll(r)
+	return data
+}
+
+// --- New tests for review fixes ---
+
+// TestE2E_UsageLimitExceeded verifies that a usage limit error is returned
+// as a 429 rate_limit_error in Anthropic format.
+func TestE2E_UsageLimitExceeded(t *testing.T) {
+	planner := &fakePlanner{
+		target:   makeMessagesTarget("http://upstream/v1/messages", ""),
+		usageErr: fmt.Errorf("quota exceeded"),
+	}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	assert.Equal(t, 429, w.Code)
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	assert.Equal(t, "error", errResp["type"])
+	errObj, ok := errResp["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "rate_limit_error", errObj["type"])
+}
+
+// TestE2E_StopSequences_MappedInResponsesAdapter verifies that stop_sequences
+// are mapped to the Responses API "stop" field (via ExtraFields) rather than
+// being silently dropped or rejected.
+func TestE2E_StopSequences_MappedInResponsesAdapter(t *testing.T) {
+	var capturedBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"id": "resp_1",
+			"object": "response",
+			"created_at": 1234567890,
+			"status": "completed",
+			"model": "test-upstream",
+			"output": [{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "Hello"}]}],
+			"usage": {"input_tokens": 5, "output_tokens": 3}
+		}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/responses", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	body := `{
+		"model": "test-model",
+		"max_tokens": 1024,
+		"stop_sequences": ["END"],
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	assert.Equal(t, 200, w.Code)
+
+	var upstreamReq map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(capturedBody, &upstreamReq))
+	stopRaw, ok := upstreamReq["stop"]
+	require.True(t, ok, "stop field should be present in upstream request")
+	var stopArr []string
+	require.NoError(t, json.Unmarshal(stopRaw, &stopArr))
+	assert.Contains(t, stopArr, "END")
+}
+
+// TestE2E_ToChat_400_BadRequest verifies that a 400 from upstream is converted
+// to Anthropic error format.
+func TestE2E_ToChat_400_BadRequest(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		fmt.Fprint(w, `{"error":{"message":"invalid model"}}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	assert.Equal(t, 400, w.Code)
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	assert.Equal(t, "error", errResp["type"])
+	errObj, ok := errResp["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "invalid_request_error", errObj["type"])
+	assert.Contains(t, errObj["message"], "invalid model")
+}
+
+// TestE2E_StreamError_ToChat verifies that when a streaming upstream returns
+// an error status before any SSE data is sent, the client receives a proper
+// HTTP error status with a JSON body (not a 200 with an SSE error event).
+func TestE2E_StreamError_ToChat(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		fmt.Fprint(w, `{"error":{"message":"internal error"}}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	body := `{
+		"model": "test-model",
+		"max_tokens": 1024,
+		"stream": true,
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	// Pre-stream error: should return HTTP 529 with JSON body, not SSE.
+	assert.Equal(t, 529, w.Code)
+	bodyStr := w.Body.String()
+	assert.NotContains(t, bodyStr, "event: error")
+	assert.NotContains(t, bodyStr, "message_stop")
+	var errResp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	assert.Equal(t, "error", errResp["type"])
+	errObj, ok := errResp["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "overloaded_error", errObj["type"])
+	assert.Contains(t, errObj["message"], "internal error")
+}
+
+// TestE2E_ToResponses_ToolUse_Stream verifies that function_call arguments
+// are correctly forwarded in streaming mode (item_id vs call_id fix).
+func TestE2E_ToResponses_ToolUse_Stream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher, _ := w.(http.Flusher)
+		fmt.Fprint(w, "event: response.created\ndata: {\"response\":{\"id\":\"resp_1\",\"status\":\"in_progress\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: response.output_item.added\ndata: {\"item\":{\"id\":\"item_abc\",\"type\":\"function_call\",\"call_id\":\"call_xyz\",\"name\":\"get_weather\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: response.function_call_arguments.delta\ndata: {\"item_id\":\"item_abc\",\"delta\":\"{\\\"city\\\":\\\"SF\\\"}\"}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: response.completed\ndata: {\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/responses", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	body := `{
+		"model": "test-model",
+		"max_tokens": 1024,
+		"stream": true,
+		"messages": [{"role": "user", "content": "What's the weather in SF?"}],
+		"tools": [{"name": "get_weather", "description": "Get weather", "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}}}]
+	}`
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	bodyStr := w.Body.String()
+	assert.Contains(t, bodyStr, "tool_use")
+	assert.Contains(t, bodyStr, "call_xyz")
+	assert.Contains(t, bodyStr, "get_weather")
+	assert.Contains(t, bodyStr, "input_json_delta")
+	assert.Contains(t, bodyStr, "city")
+}
+
+// --- Table-driven error status matrix ---
+
+// expectedAnthropicStatus maps an upstream HTTP status code to the expected
+// client-facing status and Anthropic error type, per mapUpstreamStatusToAnthropic.
+func expectedAnthropicStatus(upstreamStatus int) (int, string) {
+	switch upstreamStatus {
+	case 400:
+		return 400, ErrTypeInvalidRequest
+	case 401:
+		return 401, ErrTypeAuthentication
+	case 403:
+		return 403, ErrTypePermission
+	case 404:
+		return 404, ErrTypeNotFound
+	case 429:
+		return 429, ErrTypeRateLimit
+	case 500, 502, 503, 504, 529:
+		return 529, ErrTypeOverloaded
+	default:
+		if upstreamStatus >= 500 {
+			return 529, ErrTypeOverloaded
+		}
+		return upstreamStatus, ErrTypeAPI
+	}
+}
+
+func TestE2E_UpstreamErrors(t *testing.T) {
+	statusCodes := []int{400, 401, 403, 404, 429, 500, 502, 503, 504, 529}
+
+	protocols := []struct {
+		name string
+		path string // upstream URL path suffix
+	}{
+		{"native", "/v1/messages"},
+		{"to_chat", "/v1/chat/completions"},
+		{"to_responses", "/v1/responses"},
+	}
+
+	modes := []struct {
+		name   string
+		stream bool
+	}{
+		{"non_stream", false},
+		{"stream", true},
+	}
+
+	for _, proto := range protocols {
+		for _, mode := range modes {
+			for _, code := range statusCodes {
+				t.Run(fmt.Sprintf("%s_%s_%d", proto.name, mode.name, code), func(t *testing.T) {
+					upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(code)
+						fmt.Fprintf(w, `{"error":{"message":"upstream error %d"}}`, code)
+					}))
+					defer upstream.Close()
+
+					target := makeMessagesTarget(upstream.URL+proto.path, "")
+					planner := &fakePlanner{target: target}
+					handler := makeTestHandlerWithPlanner(planner)
+
+					body := validMessagesBody("test-model")
+					if mode.stream {
+						body = strings.Replace(body, `"max_tokens": 1024`, `"max_tokens": 1024, "stream": true`, 1)
+					}
+					w := dispatchWithTarget(t, handler, body, planner)
+
+					expectedStatus, expectedErrType := expectedAnthropicStatus(code)
+					assert.Equal(t, expectedStatus, w.Code, "upstream %d should map to %d", code, expectedStatus)
+
+					bodyStr := w.Body.String()
+					assert.NotContains(t, bodyStr, "message_stop", "error response must not contain message_stop")
+
+					var errResp map[string]any
+					require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp), "body: %s", bodyStr)
+					assert.Equal(t, "error", errResp["type"])
+					errObj, ok := errResp["error"].(map[string]any)
+					require.True(t, ok)
+					assert.Equal(t, expectedErrType, errObj["type"])
+				})
+			}
+		}
+	}
+}
+
+// --- Mid-stream error tests (SSE already started, then error) ---
+
+func TestE2E_MidStreamError_ToChat(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher := w.(http.Flusher)
+		// Send valid chunks first.
+		fmt.Fprintf(w, "data: {\"id\":\"1\",\"object\":\"chat.completion.chunk\",\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":null}]}\n\n")
+		flusher.Flush()
+		// Then send an SSE error event.
+		fmt.Fprintf(w, "event: error\ndata: {\"error\":{\"message\":\"mid-stream failure\"}}\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	body := `{
+		"model": "test-model",
+		"max_tokens": 1024,
+		"stream": true,
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	// Mid-stream error: SSE already started, so status is 200 and error is
+	// delivered as an SSE error event.
+	assert.Equal(t, 200, w.Code)
+	bodyStr := w.Body.String()
+	assert.Contains(t, bodyStr, "event: error")
+	assert.Contains(t, bodyStr, "overloaded_error")
+	assert.NotContains(t, bodyStr, "message_stop")
+}
+
+func TestE2E_MidStreamError_ToResponses(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher := w.(http.Flusher)
+		// Send valid events first.
+		fmt.Fprintf(w, "event: response.created\ndata: {\"response\":{\"id\":\"resp_1\",\"status\":\"in_progress\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprintf(w, "event: response.output_text.delta\ndata: {\"delta\":\"Hi\"}\n\n")
+		flusher.Flush()
+		// Then send a response.failed event.
+		fmt.Fprintf(w, "event: response.failed\ndata: {\"error\":{\"message\":\"mid-stream failure\"}}\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/responses", "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+	body := `{
+		"model": "test-model",
+		"max_tokens": 1024,
+		"stream": true,
+		"messages": [{"role": "user", "content": "Hello"}]
+	}`
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	// Mid-stream error: SSE already started, so status is 200 and error is
+	// delivered as an SSE error event.
+	assert.Equal(t, 200, w.Code)
+	bodyStr := w.Body.String()
+	assert.Contains(t, bodyStr, "event: error")
+	assert.Contains(t, bodyStr, "overloaded_error")
+	assert.NotContains(t, bodyStr, "message_stop")
+}
+
+// --- Billing verification tests ---
+
+func TestE2E_Billing_TokensRecorded_Native_NonStream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{
+			"id": "msg_123",
+			"type": "message",
+			"role": "assistant",
+			"content": [{"type": "text", "text": "Hello!"}],
+			"model": "test-model",
+			"stop_reason": "end_turn",
+			"usage": {
+				"input_tokens": 10,
+				"output_tokens": 5,
+				"cache_read_input_tokens": 3,
+				"cache_creation_input_tokens": 2
+			}
+		}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/messages", "")
+	planner := &fakePlanner{target: target}
+	handler, recorder, limiter, metrics := makeTestHandlerWithPlannerAndFakes(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	require.Equal(t, 200, w.Code)
+
+	// Billing runs in a goroutine; wait for it.
+	// Since runPostProcessAsync is async, we need to poll for a short time.
+	require.Eventually(t, func() bool {
+		return recorder.recorded && limiter.committed
+	}, 2*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, int64(10), recorder.inputTokens)
+	assert.Equal(t, int64(5), recorder.outputTokens)
+	assert.Equal(t, int64(3), recorder.cachedPromptTokens)
+	assert.Equal(t, int64(2), recorder.cacheCreationTokens)
+
+	assert.Equal(t, int64(10), limiter.inputTokens)
+	assert.Equal(t, int64(5), limiter.outputTokens)
+	assert.Equal(t, int64(3), limiter.cachedPromptTokens)
+	assert.Equal(t, int64(2), limiter.cacheCreationTokens)
+
+	assert.True(t, metrics.usageRecorded)
+	assert.Equal(t, int64(10), metrics.inputTokens)
+	assert.Equal(t, int64(5), metrics.outputTokens)
+	assert.Equal(t, int64(3), metrics.cachedPromptTokens)
+}
+
+func TestE2E_Billing_TokensRecorded_Native_Stream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher := w.(http.Flusher)
+		fmt.Fprint(w, "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"test\",\"content\":[],\"usage\":{\"input_tokens\":10,\"output_tokens\":0,\"cache_read_input_tokens\":4,\"cache_creation_input_tokens\":1}}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi!\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	body := strings.Replace(validMessagesBody("test-model"), `"max_tokens": 1024`, `"max_tokens": 1024, "stream": true`, 1)
+	target := makeMessagesTarget(upstream.URL+"/v1/messages", "")
+	planner := &fakePlanner{target: target}
+	handler, recorder, limiter, _ := makeTestHandlerWithPlannerAndFakes(planner)
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	require.Equal(t, 200, w.Code)
+
+	require.Eventually(t, func() bool {
+		return recorder.recorded && limiter.committed
+	}, 2*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, int64(10), recorder.inputTokens)
+	assert.Equal(t, int64(5), recorder.outputTokens)
+	assert.Equal(t, int64(4), recorder.cachedPromptTokens)
+	assert.Equal(t, int64(1), recorder.cacheCreationTokens)
+
+	assert.Equal(t, int64(4), limiter.cachedPromptTokens)
+	assert.Equal(t, int64(1), limiter.cacheCreationTokens)
+}
+
+func TestE2E_Billing_TokensRecorded_ToChat_NonStream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{
+			"id": "chatcmpl-1",
+			"object": "chat.completion",
+			"created": 1234567890,
+			"model": "test-model",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "Hello via chat!"},
+				"finish_reason": "stop"
+			}],
+			"usage": {
+				"prompt_tokens": 10,
+				"completion_tokens": 8,
+				"total_tokens": 18,
+				"prompt_tokens_details": {"cached_tokens": 3}
+			}
+		}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler, recorder, limiter, _ := makeTestHandlerWithPlannerAndFakes(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	require.Equal(t, 200, w.Code)
+
+	require.Eventually(t, func() bool {
+		return recorder.recorded && limiter.committed
+	}, 2*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, int64(10), recorder.inputTokens)
+	assert.Equal(t, int64(8), recorder.outputTokens)
+	assert.Equal(t, int64(3), recorder.cachedPromptTokens)
+	// Chat adapter doesn't track cache creation tokens.
+	assert.Equal(t, int64(0), recorder.cacheCreationTokens)
+
+	assert.Equal(t, int64(3), limiter.cachedPromptTokens)
+}
+
+func TestE2E_Billing_TokensRecorded_ToChat_Stream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher := w.(http.Flusher)
+		chunks := []string{
+			`data: {"id":"1","object":"chat.completion.chunk","model":"test","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}`,
+			`data: {"id":"1","object":"chat.completion.chunk","model":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":3,"total_tokens":13,"prompt_tokens_details":{"cached_tokens":5}}}`,
+			`data: [DONE]`,
+		}
+		for _, chunk := range chunks {
+			fmt.Fprintf(w, "%s\n\n", chunk)
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	body := strings.Replace(validMessagesBody("test-model"), `"max_tokens": 1024`, `"max_tokens": 1024, "stream": true`, 1)
+	target := makeMessagesTarget(upstream.URL+"/v1/chat/completions", "")
+	planner := &fakePlanner{target: target}
+	handler, recorder, limiter, _ := makeTestHandlerWithPlannerAndFakes(planner)
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	require.Equal(t, 200, w.Code)
+
+	require.Eventually(t, func() bool {
+		return recorder.recorded && limiter.committed
+	}, 2*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, int64(10), recorder.inputTokens)
+	assert.Equal(t, int64(3), recorder.outputTokens)
+	assert.Equal(t, int64(5), recorder.cachedPromptTokens)
+
+	assert.Equal(t, int64(5), limiter.cachedPromptTokens)
+}
+
+func TestE2E_Billing_TokensRecorded_ToResponses_NonStream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{
+			"id": "resp_1",
+			"object": "response",
+			"created_at": 1234567890,
+			"status": "completed",
+			"model": "test-model",
+			"output": [{
+				"type": "message",
+				"role": "assistant",
+				"content": [{"type": "output_text", "text": "Hello via responses!"}]
+			}],
+			"usage": {
+				"input_tokens": 10,
+				"output_tokens": 7,
+				"total_tokens": 17,
+				"input_tokens_details": {
+					"cached_tokens": 3,
+					"cached_creation_tokens": 2
+				}
+			}
+		}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/responses", "")
+	planner := &fakePlanner{target: target}
+	handler, recorder, limiter, _ := makeTestHandlerWithPlannerAndFakes(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	require.Equal(t, 200, w.Code)
+
+	require.Eventually(t, func() bool {
+		return recorder.recorded && limiter.committed
+	}, 2*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, int64(10), recorder.inputTokens)
+	assert.Equal(t, int64(7), recorder.outputTokens)
+	assert.Equal(t, int64(3), recorder.cachedPromptTokens)
+	assert.Equal(t, int64(2), recorder.cacheCreationTokens)
+
+	assert.Equal(t, int64(3), limiter.cachedPromptTokens)
+	assert.Equal(t, int64(2), limiter.cacheCreationTokens)
+}
+
+func TestE2E_Billing_TokensRecorded_ToResponses_Stream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher := w.(http.Flusher)
+		events := []string{
+			`event: response.created\ndata: {"type":"response.created","response":{"id":"resp_1","status":"in_progress","model":"test"}}`,
+			`event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"Hello"}`,
+			`event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_1","status":"completed","model":"test","usage":{"input_tokens":10,"output_tokens":2,"input_tokens_details":{"cached_tokens":6,"cached_creation_tokens":1}}}}`,
+		}
+		for _, e := range events {
+			e = strings.ReplaceAll(e, `\n`, "\n")
+			fmt.Fprint(w, e+"\n\n")
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	body := strings.Replace(validMessagesBody("test-model"), `"max_tokens": 1024`, `"max_tokens": 1024, "stream": true`, 1)
+	target := makeMessagesTarget(upstream.URL+"/v1/responses", "")
+	planner := &fakePlanner{target: target}
+	handler, recorder, limiter, _ := makeTestHandlerWithPlannerAndFakes(planner)
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	require.Equal(t, 200, w.Code)
+
+	require.Eventually(t, func() bool {
+		return recorder.recorded && limiter.committed
+	}, 2*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, int64(10), recorder.inputTokens)
+	assert.Equal(t, int64(2), recorder.outputTokens)
+	assert.Equal(t, int64(6), recorder.cachedPromptTokens)
+	assert.Equal(t, int64(1), recorder.cacheCreationTokens)
+
+	assert.Equal(t, int64(6), limiter.cachedPromptTokens)
+	assert.Equal(t, int64(1), limiter.cacheCreationTokens)
+}
+
+func TestE2E_Billing_NotRecorded_OnError(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		fmt.Fprint(w, `{"error":{"message":"internal error"}}`)
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL+"/v1/messages", "")
+	planner := &fakePlanner{target: target}
+	handler, recorder, limiter, _ := makeTestHandlerWithPlannerAndFakes(planner)
+	w := dispatchWithTarget(t, handler, validMessagesBody("test-model"), planner)
+
+	assert.Equal(t, 529, w.Code)
+
+	// Usage recording should NOT fire on error status.
+	// But the usage limiter DOES commit (even on error, to prevent abuse).
+	require.Eventually(t, func() bool {
+		return limiter.committed
+	}, 2*time.Second, 10*time.Millisecond)
+	assert.False(t, recorder.recorded, "usage should not be recorded on error status")
+}
+
+// --- Claude Code compatibility tests ---
+
+// TestE2E_ClaudeCode_NativeFallback verifies that when a Messages request is
+// sent to an external (non-CSGHub-hosted) upstream whose URL does not end in a
+// recognizable protocol path (e.g. /v1/messages), the request takes the native
+// passthrough path instead of being adapted to Chat.  This is the core fix for
+// Claude Code compatibility: Claude Code sends standard Anthropic tools
+// (name/description/input_schema without a "type" field) and expects them to
+// reach the upstream unchanged.  If the request went through the chat adapter,
+// tools would get "type":"function" injected, which Anthropic-native upstreams
+// reject.
+func TestE2E_ClaudeCode_NativeFallback(t *testing.T) {
+	var receivedBody map[string]json.RawMessage
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The upstream URL has no protocol path; the gateway should still
+		// forward to it natively (no /v1/chat/completions appended).
+		bodyData := readBody(r.Body)
+		require.NoError(t, json.Unmarshal(bodyData, &receivedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{
+			"id": "msg_cc",
+			"type": "message",
+			"role": "assistant",
+			"content": [{"type": "text", "text": "Hello from Claude Code upstream!"}],
+			"model": "test-model",
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 10, "output_tokens": 5}
+		}`)
+	}))
+	defer upstream.Close()
+
+	// External upstream with a bare URL (no /v1/messages path).
+	// No protocol metadata set — the gateway must default to native Messages.
+	target := makeMessagesTarget(upstream.URL, "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+
+	body := `{
+		"model": "test-model",
+		"max_tokens": 32000,
+		"messages": [{"role": "user", "content": "hi"}],
+		"tools": [{"name": "Bash", "description": "Run a command", "input_schema": {"type": "object", "properties": {"command": {"type": "string"}}}}],
+		"thinking": {"type": "adaptive"},
+		"context_management": {"edits": [{"keep": "all", "type": "clear_thinking_20251015"}]},
+		"output_config": {"effort": "high"},
+		"metadata": {"user_id": "test-user-123"},
+		"system": [{"type": "text", "text": "You are Claude Code.", "cache_control": {"type": "ephemeral"}}]
+	}`
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	require.Equal(t, 200, w.Code, "body: %s", w.Body.String())
+
+	// Verify the request was forwarded natively — tools should NOT have
+	// "type":"function" injected by the chat adapter.
+	toolsRaw, ok := receivedBody["tools"]
+	require.True(t, ok, "tools should be present in forwarded request")
+	var tools []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(toolsRaw, &tools))
+	require.Len(t, tools, 1)
+	// The tool must NOT have a "type" field (chat adapter injects "type":"function").
+	_, hasType := tools[0]["type"]
+	assert.False(t, hasType, "tools should not have 'type' field on native path (chat adapter injects type:function)")
+
+	// Verify Claude Code-specific fields are preserved on native path.
+	_, ok = receivedBody["context_management"]
+	assert.True(t, ok, "context_management should be preserved on native path")
+	_, ok = receivedBody["output_config"]
+	assert.True(t, ok, "output_config should be preserved on native path")
+
+	// Verify thinking field preserves "adaptive" type.
+	thinkingRaw, ok := receivedBody["thinking"]
+	require.True(t, ok, "thinking should be preserved on native path")
+	var thinking struct {
+		Type string `json:"type"`
+	}
+	require.NoError(t, json.Unmarshal(thinkingRaw, &thinking))
+	assert.Equal(t, "adaptive", thinking.Type, "thinking.type should be 'adaptive'")
+}
+
+// TestE2E_ClaudeCode_NativeFallback_Stream verifies the native fallback also
+// works for streaming requests with Claude Code-style tools.
+func TestE2E_ClaudeCode_NativeFallback_Stream(t *testing.T) {
+	var receivedBody map[string]json.RawMessage
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyData := readBody(r.Body)
+		require.NoError(t, json.Unmarshal(bodyData, &receivedBody))
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher := w.(http.Flusher)
+		fmt.Fprint(w, "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"test\",\"content\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hi!\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	target := makeMessagesTarget(upstream.URL, "")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+
+	body := `{
+		"model": "test-model",
+		"max_tokens": 32000,
+		"stream": true,
+		"messages": [{"role": "user", "content": "hi"}],
+		"tools": [{"name": "Bash", "description": "Run a command", "input_schema": {"type": "object"}}],
+		"thinking": {"type": "adaptive"},
+		"system": [{"type": "text", "text": "You are Claude Code.", "cache_control": {"type": "ephemeral"}}]
+	}`
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	require.Equal(t, 200, w.Code)
+	bodyStr := w.Body.String()
+	assert.Contains(t, bodyStr, "message_start")
+	assert.Contains(t, bodyStr, "Hi!")
+	assert.Contains(t, bodyStr, "message_stop")
+
+	// Verify tools were forwarded without type:function injection.
+	toolsRaw, ok := receivedBody["tools"]
+	require.True(t, ok)
+	var tools []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(toolsRaw, &tools))
+	_, hasType := tools[0]["type"]
+	assert.False(t, hasType, "streaming tools should not have 'type' field on native path")
+}
+
+// TestE2E_ClaudeCode_CSGHubHosted_StillChat verifies that CSGHub-hosted models
+// (vLLM/SGLang) still default to Chat protocol even when the client sends a
+// Messages request.  The native fallback must NOT apply to CSGHub-hosted models.
+func TestE2E_ClaudeCode_CSGHubHosted_StillChat(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// CSGHub-hosted → must go to /v1/chat/completions, not native.
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{
+			"id": "chatcmpl-1",
+			"object": "chat.completion",
+			"created": 1234567890,
+			"model": "test-model",
+			"choices": [{"index": 0, "message": {"role": "assistant", "content": "Hello!"}, "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 5, "completion_tokens": 4, "total_tokens": 9}
+		}`)
+	}))
+	defer upstream.Close()
+
+	target := &types.ModelTarget{
+		Model: &types.Model{
+			BaseModel: types.BaseModel{ID: "test-model"},
+			InternalModelInfo: types.InternalModelInfo{
+				SvcName: "test-svc",
+			},
+		},
+		Upstream: commonType.UpstreamConfig{
+			URL:      upstream.URL,
+			Provider: "test",
+		},
+		Target:    upstream.URL,
+		ModelName: "test-model",
+	}
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+
+	body := `{
+		"model": "test-model",
+		"max_tokens": 32000,
+		"messages": [{"role": "user", "content": "hi"}],
+		"tools": [{"name": "Bash", "description": "Run a command", "input_schema": {"type": "object"}}]
+	}`
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	require.Equal(t, 200, w.Code, "body: %s", w.Body.String())
+	var resp types.AnthropicMessagesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "Hello!", resp.Content[0].Text)
+}
+
+// TestE2E_ClaudeCode_MetadataProtocol_OverridesFallback verifies that explicit
+// protocol metadata in the upstream config takes priority over the native
+// fallback.  An external upstream with metadata protocol=chat should still use
+// the chat adapter even though the URL has no recognizable protocol path.
+func TestE2E_ClaudeCode_MetadataProtocol_OverridesFallback(t *testing.T) {
+	var receivedBody map[string]json.RawMessage
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyData := readBody(r.Body)
+		require.NoError(t, json.Unmarshal(bodyData, &receivedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{
+			"id": "chatcmpl-1",
+			"object": "chat.completion",
+			"created": 1234567890,
+			"model": "test-model",
+			"choices": [{"index": 0, "message": {"role": "assistant", "content": "Hello!"}, "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 5, "completion_tokens": 4, "total_tokens": 9}
+		}`)
+	}))
+	defer upstream.Close()
+
+	// External upstream with bare URL (no protocol path), metadata declares chat.
+	// The fallback must NOT override the explicit metadata declaration.
+	target := makeMessagesTarget(upstream.URL, "chat")
+	planner := &fakePlanner{target: target}
+	handler := makeTestHandlerWithPlanner(planner)
+
+	body := `{
+		"model": "test-model",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "Hello"}],
+		"tools": [{"name": "Bash", "description": "Run a command", "input_schema": {"type": "object"}}]
+	}`
+	w := dispatchWithTarget(t, handler, body, planner)
+
+	require.Equal(t, 200, w.Code, "body: %s", w.Body.String())
+
+	// If the request went through the chat adapter, tools will have
+	// "type":"function" injected.  If native, tools keep the Anthropic format
+	// (no "type" field).  Metadata protocol=chat should force the adapter.
+	toolsRaw, ok := receivedBody["tools"]
+	require.True(t, ok, "tools should be present")
+	var tools []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(toolsRaw, &tools))
+	require.Len(t, tools, 1)
+	_, hasType := tools[0]["type"]
+	assert.True(t, hasType, "tools should have 'type' field — metadata protocol=chat should force chat adapter")
+}

--- a/aigateway/handler/anthropic/error.go
+++ b/aigateway/handler/anthropic/error.go
@@ -1,0 +1,187 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Anthropic error type constants.
+const (
+	ErrTypeInvalidRequest    = "invalid_request_error"
+	ErrTypeAuthentication    = "authentication_error"
+	ErrTypePermission        = "permission_error"
+	ErrTypeNotFound          = "not_found_error"
+	ErrTypeRateLimit         = "rate_limit_error"
+	ErrTypeOverloaded        = "overloaded_error"
+	ErrTypeAPI               = "api_error"
+	ErrTypeUnsupported       = "unsupported_capability"
+)
+
+// writeError sends an Anthropic-format error response.
+// Anthropic errors use the shape:
+//
+//	{
+//	  "type": "error",
+//	  "error": {
+//	    "type": "invalid_request_error",
+//	    "message": "..."
+//	  }
+//	}
+func writeError(c *gin.Context, status int, errType, message string) {
+	c.JSON(status, gin.H{
+		"type": "error",
+		"error": gin.H{
+			"type":    errType,
+			"message": message,
+		},
+	})
+}
+
+// writeBadRequest is a convenience wrapper for 400 errors.
+func writeBadRequest(c *gin.Context, message string) {
+	writeError(c, http.StatusBadRequest, ErrTypeInvalidRequest, message)
+}
+
+// writeUnsupportedCapability returns a 400 when the upstream cannot satisfy
+// a requested capability (e.g. prompt_caching on a Chat-only upstream).
+func writeUnsupportedCapability(c *gin.Context, missing []string) {
+	writeError(c, http.StatusBadRequest, ErrTypeUnsupported,
+		"upstream does not support: "+joinStrings(missing, ", "))
+}
+
+func joinStrings(parts []string, sep string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	result := parts[0]
+	for _, p := range parts[1:] {
+		result += sep + p
+	}
+	return result
+}
+
+// mapUpstreamStatusToAnthropic maps an upstream HTTP status code to an
+// Anthropic-compatible status code and error type.  Overloaded upstream
+// errors (502/503/504) are mapped to 529 (Anthropic overloaded_error).
+func mapUpstreamStatusToAnthropic(statusCode int) (int, string) {
+	switch statusCode {
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return 529, ErrTypeOverloaded
+	case http.StatusTooManyRequests:
+		return http.StatusTooManyRequests, ErrTypeRateLimit
+	case http.StatusUnauthorized:
+		return http.StatusUnauthorized, ErrTypeAuthentication
+	case http.StatusForbidden:
+		return http.StatusForbidden, ErrTypePermission
+	case http.StatusNotFound:
+		return http.StatusNotFound, ErrTypeNotFound
+	case http.StatusBadRequest:
+		return http.StatusBadRequest, ErrTypeInvalidRequest
+	default:
+		if statusCode >= 500 {
+			return 529, ErrTypeOverloaded
+		}
+		return statusCode, ErrTypeAPI
+	}
+}
+
+// extractUpstreamErrorMessage attempts to extract a human-readable error
+// message from an upstream error response body.  It tries OpenAI's
+// {"error":{"message":"..."}} format first, then falls back to the raw body.
+func extractUpstreamErrorMessage(body []byte) string {
+	if len(body) == 0 {
+		return "upstream returned an error with no response body"
+	}
+	// Try OpenAI error format: {"error":{"message":"..."}}
+	var openaiErr struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &openaiErr); err == nil && openaiErr.Error.Message != "" {
+		return openaiErr.Error.Message
+	}
+	// Try a plain {"error":"..."} or {"message":"..."} shape.
+	var simpleErr struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &simpleErr); err == nil {
+		if simpleErr.Error != "" {
+			return simpleErr.Error
+		}
+		if simpleErr.Message != "" {
+			return simpleErr.Message
+		}
+	}
+	// Fall back to raw body (truncated to avoid sending large error payloads).
+	if len(body) > 512 {
+		return string(body[:512])
+	}
+	return string(body)
+}
+
+// writeAnthropicErrorJSON writes an Anthropic error response with the given
+// status code, error type, and message.  Unlike writeAnthropicUpstreamError,
+// it does not map the status code — it writes the caller's values directly.
+func writeAnthropicErrorJSON(w gin.ResponseWriter, status int, errType, message string) {
+	hdr := w.Header()
+	hdr.Set("Content-Type", "application/json")
+	hdr.Del("Content-Length")
+	hdr.Del("Content-Encoding")
+	hdr.Del("Transfer-Encoding")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(gin.H{
+		"type": "error",
+		"error": gin.H{
+			"type":    errType,
+			"message": message,
+		},
+	})
+}
+
+// writeAnthropicUpstreamError converts an upstream error response to
+// Anthropic error format and writes it to the gin writer.
+func writeAnthropicUpstreamError(w gin.ResponseWriter, statusCode int, body []byte) {
+	anthropicStatus, errType := mapUpstreamStatusToAnthropic(statusCode)
+	message := extractUpstreamErrorMessage(body)
+	payload := gin.H{
+		"type": "error",
+		"error": gin.H{
+			"type":    errType,
+			"message": message,
+		},
+	}
+	// Reset headers that may have been set by the proxy or SSE setup
+	// (e.g. Content-Length: 0 from the upstream 404, or text/event-stream
+	// from the streaming prelude).  gin.ResponseWriter.Header() returns
+	// the live header map, so we can mutate it before WriteHeader.
+	hdr := w.Header()
+	hdr.Set("Content-Type", "application/json")
+	hdr.Del("Content-Length")
+	hdr.Del("Content-Encoding")
+	hdr.Del("Transfer-Encoding")
+	w.WriteHeader(anthropicStatus)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+// writeAnthropicStreamError writes an Anthropic error event into an SSE stream.
+// This is used when an upstream error occurs mid-stream.
+func writeAnthropicStreamError(w gin.ResponseWriter, statusCode int, body []byte) {
+	_, errType := mapUpstreamStatusToAnthropic(statusCode)
+	message := extractUpstreamErrorMessage(body)
+	payload := gin.H{
+		"type": "error",
+		"error": gin.H{
+			"type":    errType,
+			"message": message,
+		},
+	}
+	jsonData, _ := json.Marshal(payload)
+	_, _ = w.Write([]byte("event: error\ndata: "))
+	_, _ = w.Write(jsonData)
+	_, _ = w.Write([]byte("\n\n"))
+	w.Flush()
+}

--- a/aigateway/handler/anthropic/handler.go
+++ b/aigateway/handler/anthropic/handler.go
@@ -1,0 +1,514 @@
+// Package anthropic implements the Anthropic Messages API (/v1/messages) for the
+// AIGateway.  It follows the three-phase architecture:
+//
+//  1. Extract — parse the Anthropic Messages request and extract identity.
+//  2. Plan — (delegated to the shared Planner) resolve model target, check
+//     balance/quota/safety.
+//  3. Execute — adapt the request for the upstream protocol (native = identity,
+//     adapter = protocol transform), proxy, finalize, record metrics, usage,
+//     LLM trace, and LLM training log.
+//
+// The handler implements both MetadataExtractor and ProtocolHandler.  The
+// Orchestrator calls Extract → Plan → Execute in sequence.
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"opencsg.com/csghub-server/aigateway/handler/plan"
+	"opencsg.com/csghub-server/aigateway/handler/protocol"
+	"opencsg.com/csghub-server/aigateway/types"
+	"opencsg.com/csghub-server/api/httpbase"
+	commontypes "opencsg.com/csghub-server/common/types"
+	commontrace "opencsg.com/csghub-server/common/utils/trace"
+)
+
+// Handler handles Anthropic Messages API requests.
+// It implements both MetadataExtractor and ProtocolHandler.
+type Handler struct {
+	Deps
+}
+
+// New creates a new anthropic Handler with the given dependencies.
+func New(deps Deps) *Handler {
+	return &Handler{deps}
+}
+
+// Ensure Handler implements MetadataExtractor and ProtocolHandler.
+var (
+	_ plan.MetadataExtractor = (*Handler)(nil)
+	_ plan.ProtocolHandler   = (*Handler)(nil)
+)
+
+// --- Phase 1: Extract ---
+
+// Extract parses the Anthropic Messages request and extracts identity
+// information.  No business logic is performed here.
+func (h *Handler) Extract(c *gin.Context) (*types.RequestMetadata, error) {
+	username := httpbase.GetCurrentUser(c)
+	nsUUID := httpbase.GetCurrentNamespaceUUID(c)
+
+	req := &types.AnthropicMessagesRequest{}
+	if err := c.BindJSON(req); err != nil {
+		writeBadRequest(c, fmt.Sprintf("invalid request body: %v", err))
+		return nil, err
+	}
+	if err := req.Validate(); err != nil {
+		writeBadRequest(c, err.Error())
+		return nil, err
+	}
+
+	return &types.RequestMetadata{
+		Protocol:   string(types.ProtocolMessages),
+		Task:       "messages",
+		Model:      req.Model,
+		TenantID:   nsUUID,
+		UserID:     username,
+		APIKeyID:   httpbase.GetAccessToken(c),
+		Streaming:  req.Stream,
+		Headers:    c.Request.Header,
+		ParsedBody: req,
+	}, nil
+}
+
+// --- Phase 3: Execute ---
+
+// Execute adapts the request for the upstream protocol, then runs the
+// common execution skeleton: set body, apply auth headers, set SSE headers,
+// proxy, finalize, record usage/metrics, start/finish LLM trace, publish
+// LLM training log, and commit usage limit.
+//
+// If the adapt step fails the error is rendered inline and Execute returns nil.
+func (h *Handler) Execute(c *gin.Context, meta *types.RequestMetadata, p *types.RequestPlan) error {
+	// Record resolved model on the preflight span and end it.
+	if pt := GetPreflightTracer(c); pt != nil {
+		pt.SetTargetModel(meta.Model, p.ModelTarget)
+		pt.End()
+		SetPreflightTracer(c, nil)
+	}
+
+	// Start LLM generation trace.
+	requestID := commontrace.GetTraceIDInGinContext(c)
+	traceCtx, generationRecorder := h.startMessagesTrace(c.Request.Context(), c.Request.Header, meta, p, requestID)
+	c.Request = c.Request.WithContext(traceCtx)
+
+	// Create LLM log recorder for training log capture.
+	logCapture := h.createLogCapture(c.Request.Context(), meta, p, requestID)
+
+	adapted, err := h.adapt(c, meta, p, logCapture)
+	if err != nil {
+		finishLLMTraceWithError(generationRecorder, err, types.TraceErrUpstreamError)
+		// Check for unsupported capability errors (from checkAdapterCapabilities).
+		if missing := extractUnsupportedCapabilities(err); len(missing) > 0 {
+			writeUnsupportedCapability(c, missing)
+			return nil
+		}
+		writeError(c, http.StatusBadRequest, ErrTypeInvalidRequest, err.Error())
+		return nil
+	}
+
+	// 1. Set the request body.
+	c.Request.Body = io.NopCloser(bytes.NewReader(adapted.Body))
+	c.Request.ContentLength = int64(len(adapted.Body))
+
+	// 2. Apply auth headers.
+	if p.ModelTarget != nil && p.ModelTarget.Upstream.AuthHeader != "" {
+		if err := types.ApplyRequestAuthHeaders(c.Request.Header, p.ModelTarget.Upstream.AuthHeader); err != nil {
+			slog.WarnContext(c.Request.Context(), "invalid auth header",
+				slog.String("model", p.ModelTarget.ModelName),
+				slog.Any("error", err))
+		}
+	}
+
+	// 3. Record model target metrics (success path).
+	if h.MetricsRecorder != nil {
+		h.MetricsRecorder.SetModelTarget(c, meta.Model, p.ModelTarget, meta.Streaming)
+	}
+
+	// 4. Set SSE headers for streaming.
+	if meta.Streaming {
+		c.Header("Content-Type", "text/event-stream")
+		c.Header("Cache-Control", "no-cache")
+		c.Header("Connection", "keep-alive")
+	}
+
+	// 5. Execute the proxy request.
+	host := ""
+	if p.ModelTarget != nil {
+		host = p.ModelTarget.Host
+	}
+	h.ProxyExecutor.ServeProxy(c, p.BackendURL, host, adapted.Writer)
+
+	// 6. Finalize the writer.
+	if f, ok := adapted.Writer.(finalizer); ok {
+		if err := f.Finalize(); err != nil {
+			slog.WarnContext(c.Request.Context(), "response writer finalize error",
+				slog.Any("error", err))
+		}
+	}
+
+	// 7. Extract usage.
+	var usage tokenUsage
+	if up, ok := adapted.Writer.(usageProvider); ok {
+		usage = up.Usage()
+	}
+
+	// 8. Record token usage metrics (sync — before c.Next() returns).
+	if h.MetricsRecorder != nil {
+		h.MetricsRecorder.RecordTokenUsage(c, usage.PromptTokens, usage.CompletionTokens, usage.CachedPromptTokens)
+	}
+
+	// 9. Async post-process: usage record, usage limit commit, LLM trace
+	//    completion, and LLM training log publishing.
+	statusCode := 200
+	if sw, ok := adapted.Writer.(statusProvider); ok {
+		statusCode = sw.StatusCode()
+	}
+	h.runPostProcessAsync(c.Request.Context(), postProcessInput{
+		NSUUID:          meta.TenantID,
+		ApiKey:          httpbase.GetAccessToken(c),
+		Model:           p.ModelTarget.Model,
+		TargetModelName: p.ModelTarget.ModelName,
+		Usage:           &usage,
+		LogCapture:      logCapture,
+		Trace: tracePostProcessInput{
+			Recorder:   generationRecorder,
+			Completion: generationRecorder != nil,
+			Stream:     meta.Streaming,
+			StatusCode: statusCode,
+		},
+		StatusCode: statusCode,
+	})
+
+	return nil
+}
+
+// finalizer is implemented by response writers that need a Finalize step
+// after the proxy completes (e.g. to extract usage or convert the response
+// body).
+type finalizer interface {
+	Finalize() error
+}
+
+// usageProvider is implemented by response writers that can report token
+// usage after the response is finalized.
+type usageProvider interface {
+	Usage() tokenUsage
+}
+
+// statusProvider is implemented by response writers that can report their
+// final HTTP status code.
+type statusProvider interface {
+	StatusCode() int
+}
+
+// startMessagesTrace starts an LLM generation trace for the Messages protocol.
+// Returns (ctx, nil) when tracing is disabled.
+func (h *Handler) startMessagesTrace(ctx context.Context, headers http.Header, meta *types.RequestMetadata, p *types.RequestPlan, requestID string) (context.Context, GenerationRecorder) {
+	if h.LLMTracer == nil || p.ModelTarget == nil || p.ModelTarget.Model == nil {
+		return ctx, nil
+	}
+	mode := types.GenerationModeSync
+	if meta.Streaming {
+		mode = types.GenerationModeStream
+	}
+	req := meta.ParsedBody.(*types.AnthropicMessagesRequest)
+	return h.LLMTracer.StartGeneration(ctx, types.GenerationStart{
+		RequestID:      requestID,
+		ConversationID: extractMessagesSessionID(headers),
+		UserID:         meta.TenantID,
+		Provider:       p.ModelTarget.Model.Provider,
+		RequestModel:   meta.Model,
+		ResolvedModel:  p.ModelTarget.ModelName,
+		Mode:           mode,
+		Tools:          messagesTraceTools(req),
+		ToolCount:      len(req.Tools),
+		MaxTokens:      messagesTraceMaxTokens(req),
+		Temperature:    req.Temperature,
+		TopP:           req.TopP,
+		Metadata: map[string]any{
+			"aigateway.api":      "/v1/messages",
+			"aigateway.model_id": p.ModelTarget.Model.ID,
+		},
+	})
+}
+
+// createLogCapture creates an LLM log recorder for training log capture.
+// Returns nil when the factory is not configured.
+func (h *Handler) createLogCapture(ctx context.Context, meta *types.RequestMetadata, p *types.RequestPlan, requestID string) LLMLogRecorder {
+	if h.LLMLogRecorderFactory == nil || p.ModelTarget == nil {
+		return nil
+	}
+	req := meta.ParsedBody.(*types.AnthropicMessagesRequest)
+	logReq, err := anthropicRequestToLLMLogRequest(req)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to convert request for llmlog capture", slog.Any("error", err))
+		logReq = commontypes.LLMLogRequest{Stream: req.Stream}
+	}
+	recorder, err := h.LLMLogRecorderFactory.NewLLMLogRecorder(
+		requestID,
+		p.ModelTarget.ModelName,
+		meta.TenantID,
+		logReq,
+		map[string]any{
+			"source":   "aigateway",
+			"api":      "/v1/messages",
+			"stream":   req.Stream,
+			"provider": p.ModelTarget.Model.Provider,
+			"svc_name": p.ModelTarget.Model.SvcName,
+		},
+	)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to initialize llmlog training capture", slog.Any("error", err))
+		return nil
+	}
+	return recorder
+}
+
+// runPostProcessAsync runs the post-processing goroutine after the upstream
+// response completes.  It mirrors handler.runChatPostProcessAsync:
+//   - LLM trace completion (usage, response, error status)
+//   - Usage limit commit
+//   - Usage record (only on successful status)
+//   - LLM training log publishing
+func (h *Handler) runPostProcessAsync(ctx context.Context, input postProcessInput) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("panic in messages post-process", slog.Any("panic", r))
+				if input.Trace.Recorder != nil {
+					input.Trace.Recorder.End()
+				}
+			}
+		}()
+
+		usageCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 3*time.Second)
+		defer cancel()
+
+		// LLM trace completion.
+		if input.Trace.Recorder != nil {
+			var inputMsgs, outputMsgs []types.GenerationMessage
+			var traceInfo commontypes.LLMLogTraceInfo
+			if input.LogCapture != nil {
+				in, out := input.LogCapture.Messages()
+				inputMsgs = llmlogMessagesToGenerationMessages(in)
+				outputMsgs = llmlogMessagesToGenerationMessages(out)
+				traceInfo = input.LogCapture.TraceInfo()
+			}
+			recordMessagesTraceCompletion(input.Trace, input.Model, input.TargetModelName, input.Usage, inputMsgs, outputMsgs, traceInfo)
+			input.Trace.Recorder.End()
+		}
+
+		// Commit usage limit.
+		if h.UsageLimiter != nil && input.Model != nil {
+			if err := h.commitUsageLimitSync(usageCtx, input.NSUUID, input.Model, input.Usage); err != nil {
+				slog.ErrorContext(usageCtx, "failed to commit usage limit", slog.Any("error", err))
+			}
+		}
+
+		// Record usage (only on successful status).
+		if h.UsageRecorder != nil && input.Model != nil && input.Usage != nil && isSuccessfulStatus(input.StatusCode) {
+			if err := h.UsageRecorder.RecordUsage(usageCtx, input.NSUUID, input.Model, input.TargetModelName, input.Usage.PromptTokens, input.Usage.CompletionTokens, input.Usage.CachedPromptTokens, input.Usage.CacheCreationPromptTokens, input.ApiKey); err != nil {
+				slog.ErrorContext(usageCtx, "failed to record token usage", slog.Any("error", err))
+			}
+		}
+
+		// Publish LLM training log.
+		if h.LLMLogPublisher != nil && input.LogCapture != nil {
+			record, recordErr := input.LogCapture.Record()
+			if recordErr != nil {
+				// This can happen when the upstream returns an empty response
+				// (e.g. no SSE events).  Log as a warning rather than an error
+				// since it is not actionable.
+				slog.WarnContext(usageCtx, "no llmlog training record to publish", slog.Any("error", recordErr))
+				return
+			}
+			if record == nil {
+				return
+			}
+			payload, marshalErr := json.Marshal(record)
+			if marshalErr != nil {
+				slog.ErrorContext(usageCtx, "failed to marshal llmlog training record", slog.Any("error", marshalErr))
+				return
+			}
+			if publishErr := h.LLMLogPublisher.PublishTrainingLog(payload); publishErr != nil {
+				slog.ErrorContext(usageCtx, "failed to publish llmlog training record", slog.Any("error", publishErr))
+			}
+		}
+	}()
+}
+
+func (h *Handler) commitUsageLimitSync(ctx context.Context, nsUUID string, model *types.Model, usage *tokenUsage) error {
+	return h.UsageLimiter.CommitUsageLimitFromUsage(ctx, nsUUID, model, usage.PromptTokens, usage.CompletionTokens, usage.CachedPromptTokens, usage.CacheCreationPromptTokens)
+}
+
+// adapt transforms the request for the upstream protocol and creates the
+// response writer.  This is the protocol-specific part of Execute.
+func (h *Handler) adapt(c *gin.Context, meta *types.RequestMetadata, p *types.RequestPlan, logCapture LLMLogRecorder) (*types.AdaptResult, error) {
+	req := meta.ParsedBody.(*types.AnthropicMessagesRequest)
+
+	switch protocol.ExecutionMode(p.RouteMode) {
+	case protocol.ModeNative:
+		return h.adaptNative(c, req, p, logCapture)
+	case protocol.ModeAdapter:
+		switch protocol.AdapterKind(p.AdapterKind) {
+		case protocol.AdapterMessagesToChat:
+			return h.adaptToChat(c, req, p, logCapture)
+		case protocol.AdapterMessagesToResponses:
+			return h.adaptToResponses(c, req, p, logCapture)
+		default:
+			return nil, fmt.Errorf("unsupported adapter: %s", p.AdapterKind)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported route mode: %s", p.RouteMode)
+	}
+}
+
+// --- Error handling ---
+
+// HandlePlanError renders the protocol-specific error response for a Plan-phase
+// rejection.  The RequestPlan's ErrorCode identifies the category.
+func (h *Handler) HandlePlanError(c *gin.Context, meta *types.RequestMetadata, p *types.RequestPlan, err error) {
+	// Record preflight error if the span is still open.
+	if pt := GetPreflightTracer(c); pt != nil {
+		pt.RecordError(err, "plan_error")
+		SetPreflightTracer(c, nil)
+	}
+
+	// Record metrics for the error path so the error is still attributed
+	// to the requested model.
+	if h.MetricsRecorder != nil {
+		var mt *types.ModelTarget
+		if p != nil {
+			mt = p.ModelTarget
+		}
+		h.MetricsRecorder.SetModelTarget(c, meta.Model, mt, meta.Streaming)
+	}
+
+	if p != nil {
+		switch p.ErrorCode {
+		case types.PlanErrModelNotFound:
+			writeError(c, http.StatusNotFound, ErrTypeNotFound, err.Error())
+			return
+		case types.PlanErrModelUnavailable:
+			writeError(c, http.StatusServiceUnavailable, ErrTypeOverloaded, err.Error())
+			return
+		case types.PlanErrInsufficientBalance:
+			writeError(c, http.StatusPaymentRequired, ErrTypeInvalidRequest,
+				fmt.Sprintf("insufficient balance: %v", err))
+			return
+		case types.PlanErrUsageLimitExceeded:
+			writeError(c, http.StatusTooManyRequests, ErrTypeRateLimit,
+				"usage quota exceeded for current window")
+			return
+		case types.PlanErrDisabled:
+			writeError(c, http.StatusBadRequest, ErrTypeUnsupported,
+				fmt.Sprintf("/v1/messages is not available for this model: %v", err))
+			return
+		case types.PlanErrInternal:
+			writeError(c, http.StatusInternalServerError, ErrTypeAPI,
+				"an internal error occurred while processing the request")
+			return
+		case types.PlanErrSensitive:
+			message := "content blocked due to safety policy"
+			if p.Safety != nil && p.Safety.Message != "" {
+				message = p.Safety.Message
+			}
+			writeSensitiveResponse(c, meta.Streaming, &SensitiveResult{
+				IsSensitive: true,
+				Message:     message,
+			})
+			return
+		}
+	}
+	slog.ErrorContext(c.Request.Context(), "messages plan error",
+		slog.String("model", meta.Model), slog.Any("error", err))
+	writeError(c, http.StatusInternalServerError, ErrTypeAPI, err.Error())
+}
+
+// extractUnsupportedCapabilities checks if the error is an unsupported
+// capability error and returns the missing capabilities list.
+func extractUnsupportedCapabilities(err error) []string {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	if !strings.HasPrefix(msg, "unsupported_feature:") {
+		return nil
+	}
+	feature := strings.TrimPrefix(msg, "unsupported_feature:")
+	return []string{feature}
+}
+
+// writeSensitiveResponse writes a blocked-content response in Anthropic format.
+func writeSensitiveResponse(c *gin.Context, stream bool, result *SensitiveResult) {
+	message := "content blocked due to safety policy"
+	if result != nil && result.Message != "" {
+		message = result.Message
+	}
+	if stream {
+		c.Header("Content-Type", "text/event-stream")
+		c.Header("Cache-Control", "no-cache")
+		c.Header("Connection", "keep-alive")
+		msgID := newMessagesResponseID()
+		writeSSEEvent(c, "message_start", map[string]any{
+			"type": "message_start",
+			"message": map[string]any{
+				"id":    msgID,
+				"type":  "message",
+				"role":  "assistant",
+				"model": "",
+				"usage": map[string]any{"input_tokens": 0, "output_tokens": 0},
+			},
+		})
+		writeSSEEvent(c, "content_block_start", map[string]any{
+			"type":          "content_block_start",
+			"index":         0,
+			"content_block": map[string]any{"type": "text", "text": ""},
+		})
+		writeSSEEvent(c, "content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": 0,
+			"delta": map[string]any{"type": "text_delta", "text": message},
+		})
+		writeSSEEvent(c, "content_block_stop", map[string]any{
+			"type":  "content_block_stop",
+			"index": 0,
+		})
+		stopReason := "end_turn"
+		writeSSEEvent(c, "message_delta", map[string]any{
+			"type":  "message_delta",
+			"delta": map[string]any{"stop_reason": stopReason, "stop_sequence": nil},
+			"usage": map[string]any{"output_tokens": 0},
+		})
+		writeSSEEvent(c, "message_stop", map[string]any{"type": "message_stop"})
+		return
+	}
+	c.JSON(http.StatusOK, types.AnthropicMessagesResponse{
+		ID:      newMessagesResponseID(),
+		Type:    "message",
+		Role:    "assistant",
+		Model:   "",
+		Content: []types.AnthropicContentBlock{{Type: "text", Text: message}},
+		Usage:   types.AnthropicMessagesUsage{},
+	})
+}
+
+// writeSSEEvent marshals data as JSON and writes it as an SSE event.
+func writeSSEEvent(c *gin.Context, eventType string, data any) {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(c.Writer, "event: %s\ndata: %s\n\n", eventType, jsonData)
+	c.Writer.Flush()
+}

--- a/aigateway/handler/anthropic/id.go
+++ b/aigateway/handler/anthropic/id.go
@@ -1,0 +1,13 @@
+package anthropic
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// randomHexID generates a short random hex string for response IDs.
+func randomHexID() string {
+	b := make([]byte, 12)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/aigateway/handler/anthropic/native.go
+++ b/aigateway/handler/anthropic/native.go
@@ -1,0 +1,384 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+	"opencsg.com/csghub-server/aigateway/handler/streamdecoder"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+// adaptNative prepares the request for native passthrough to an upstream
+// that speaks the Anthropic Messages protocol.  It remaps the model name
+// and creates a nativeResponseWriter for usage extraction.
+func (h *Handler) adaptNative(c *gin.Context, req *types.AnthropicMessagesRequest, p *types.RequestPlan, logCapture LLMLogRecorder) (*types.AdaptResult, error) {
+	reqCopy := *req
+	reqCopy.Model = p.ModelTarget.ModelName
+	if reqCopy.Model == "" {
+		reqCopy.Model = req.Model
+	}
+
+	body, err := json.Marshal(&reqCopy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	writer := newNativeResponseWriter(c.Writer, req.Stream, p.ModelTarget.ModelName, logCapture)
+	return &types.AdaptResult{Body: body, Writer: writer}, nil
+}
+
+
+// nativeResponseWriter wraps the gin response writer for native passthrough.
+// For streaming responses, it passes SSE events through while extracting usage.
+// For non-streaming responses, it buffers the body and extracts usage on Finalize.
+type nativeResponseWriter struct {
+	ginWriter     gin.ResponseWriter
+	stream        bool
+	model         string // public model name (what the client sees)
+	recorder      LLMLogRecorder
+	bodyBuf       bytes.Buffer
+	decoder       streamdecoder.Decoder
+	inputTokens   int64
+	outputTokens  int64
+	// Cache token fields for billing/metering.
+	cacheReadTokens     int64
+	cacheCreationTokens int64
+	headerWritten bool
+	statusCode    int
+	header        http.Header
+	// Stream error tracking.
+	streamFailed   bool
+	streamErrStatus int
+	streamErrBody  []byte
+	// response ID for recorder chunks (captured from message_start).
+	respID string
+}
+
+func newNativeResponseWriter(w gin.ResponseWriter, stream bool, model string, recorder LLMLogRecorder) *nativeResponseWriter {
+	return &nativeResponseWriter{
+		ginWriter: w,
+		stream:    stream,
+		model:     model,
+		recorder:  recorder,
+		decoder:   streamdecoder.NewSSE(),
+		header:    make(http.Header),
+	}
+}
+
+func (w *nativeResponseWriter) Write(data []byte) (int, error) {
+	if !w.stream {
+		// Buffer non-streaming responses for usage extraction and model remap.
+		w.bodyBuf.Write(data)
+		return len(data), nil
+	}
+	// Stream: if upstream returned an error status, buffer the error body
+	// instead of passing it through as a fake success stream.
+	if w.streamFailed {
+		w.streamErrBody = append(w.streamErrBody, data...)
+		return len(data), nil
+	}
+	// Decode SSE events to extract usage (message_start.input_tokens,
+	// message_delta.output_tokens) while passing data through unchanged.
+	events, err := w.decoder.Write(data)
+	if err != nil {
+		slog.Debug("native stream decoder error", slog.Any("error", err))
+	}
+	for _, event := range events {
+		w.extractUsageFromNativeSSE(event.Type, event.Data)
+	}
+	return w.ginWriter.Write(data)
+}
+
+// extractUsageFromNativeSSE parses Anthropic SSE events to extract token usage
+// and feeds the recorder.  message_start carries input_tokens + response ID;
+// content_block_delta carries text deltas; message_delta carries output_tokens
+// and stop_reason.
+func (w *nativeResponseWriter) extractUsageFromNativeSSE(eventType string, data []byte) {
+	switch eventType {
+	case "message_start":
+		var event struct {
+			Message struct {
+				ID    string `json:"id"`
+				Usage struct {
+					InputTokens              int `json:"input_tokens"`
+					CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+					CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+				} `json:"usage"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(data, &event); err == nil {
+			w.inputTokens = int64(event.Message.Usage.InputTokens)
+			w.cacheReadTokens = int64(event.Message.Usage.CacheReadInputTokens)
+			w.cacheCreationTokens = int64(event.Message.Usage.CacheCreationInputTokens)
+			w.respID = event.Message.ID
+		}
+		if w.recorder != nil {
+			w.recorder.AppendCompletionChunk(types.ChatCompletionChunk{
+				ID:    w.respID,
+				Model: w.model,
+				Choices: []types.ChatCompletionChunkChoice{{
+					Index: 0,
+					Delta: types.ChatCompletionChunkChoiceDelta{Role: "assistant"},
+				}},
+			})
+		}
+	case "content_block_delta":
+		if w.recorder != nil {
+			var event struct {
+				Delta struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"delta"`
+			}
+			if err := json.Unmarshal(data, &event); err == nil && event.Delta.Type == "text_delta" && event.Delta.Text != "" {
+				w.recorder.AppendCompletionChunk(types.ChatCompletionChunk{
+					ID:    w.respID,
+					Model: w.model,
+					Choices: []types.ChatCompletionChunkChoice{{
+						Index: 0,
+						Delta: types.ChatCompletionChunkChoiceDelta{Content: event.Delta.Text},
+					}},
+				})
+			}
+		}
+	case "message_delta":
+		var event struct {
+			Delta struct {
+				StopReason string `json:"stop_reason"`
+			} `json:"delta"`
+			Usage struct {
+				OutputTokens int `json:"output_tokens"`
+			} `json:"usage"`
+		}
+		if err := json.Unmarshal(data, &event); err == nil {
+			w.outputTokens = int64(event.Usage.OutputTokens)
+		}
+		if w.recorder != nil {
+			finishReason := messagesStopReasonToFinishReason(event.Delta.StopReason)
+			w.recorder.AppendCompletionChunk(types.ChatCompletionChunk{
+				ID:    w.respID,
+				Model: w.model,
+				Choices: []types.ChatCompletionChunkChoice{{
+					Index:        0,
+					FinishReason: finishReason,
+				}},
+				Usage: openai.CompletionUsage{
+					PromptTokens:     w.inputTokens,
+					CompletionTokens: w.outputTokens,
+					TotalTokens:      w.inputTokens + w.outputTokens,
+				},
+			})
+		}
+	}
+}
+
+func (w *nativeResponseWriter) WriteHeader(code int) {
+	if w.stream {
+		if code >= 400 {
+			// Upstream error in stream mode: buffer the error body and let
+			// Finalize decide how to deliver it.  If no data has been written
+			// to the client yet (ginWriter.Written() == false), Finalize will
+			// send a proper HTTP error status with a JSON body.  If the SSE
+			// stream already started, Finalize will emit an error event into
+			// the stream instead.
+			slog.Warn("native stream upstream error",
+				slog.Int("status", code),
+				slog.Bool("ginWritten", w.ginWriter.Written()),
+			)
+			w.streamFailed = true
+			w.streamErrStatus = code
+			return
+		}
+		w.ginWriter.WriteHeader(code)
+		return
+	}
+	if !w.headerWritten {
+		w.statusCode = code
+		w.headerWritten = true
+	}
+}
+
+func (w *nativeResponseWriter) Header() http.Header {
+	if w.stream {
+		return w.ginWriter.Header()
+	}
+	return w.header
+}
+
+func (w *nativeResponseWriter) Flush() {
+	if w.stream {
+		// Don't flush the gin writer when the upstream failed before any
+		// data was sent — gin's Flush() calls WriteHeaderNow() which would
+		// commit a default 200 status, preventing Finalize from sending a
+		// proper HTTP error.
+		if w.streamFailed && !w.ginWriter.Written() {
+			return
+		}
+		if f, ok := w.ginWriter.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+	// Non-stream: do nothing. Calling ginWriter.Flush() would trigger
+	// WriteHeaderNow() and commit a default 200 status prematurely.
+}
+
+func (w *nativeResponseWriter) StatusCode() int {
+	if w.stream {
+		return w.ginWriter.Status()
+	}
+	if w.statusCode != 0 {
+		return w.statusCode
+	}
+	return http.StatusOK
+}
+
+// Finalize extracts usage from the response body (non-stream) or relies on
+// usage already extracted during streaming (message_start/message_delta).
+func (w *nativeResponseWriter) Finalize() error {
+	if w.stream {
+		// If the upstream failed before the SSE stream started (no data
+		// written to the client), send a proper HTTP error with a JSON body.
+		if w.streamFailed && !w.ginWriter.Written() {
+			writeAnthropicUpstreamError(w.ginWriter, w.streamErrStatus, w.streamErrBody)
+			return nil
+		}
+		// If the upstream failed mid-stream (SSE already started), emit an
+		// Anthropic error event instead of a success completion.
+		if w.streamFailed {
+			writeAnthropicStreamError(w.ginWriter, w.streamErrStatus, w.streamErrBody)
+		}
+		return nil
+	}
+	// If upstream returned an error, convert to Anthropic error format.
+	if w.statusCode >= 400 {
+		writeAnthropicUpstreamError(w.ginWriter, w.statusCode, w.bodyBuf.Bytes())
+		return nil
+	}
+	// Copy buffered headers to gin writer, skipping Content-Length and
+	// Content-Encoding since the body may have been decompressed by the proxy.
+	for k, vs := range w.header {
+		if strings.EqualFold(k, "Content-Length") || strings.EqualFold(k, "Content-Encoding") {
+			continue
+		}
+		for _, v := range vs {
+			w.ginWriter.Header().Add(k, v)
+		}
+	}
+	// Set content type and write the status code if captured.
+	w.ginWriter.Header().Set("Content-Type", "application/json")
+	if w.statusCode != 0 {
+		w.ginWriter.WriteHeader(w.statusCode)
+	} else {
+		w.ginWriter.WriteHeader(http.StatusOK)
+	}
+	// Remap the model field in the response body to the public model name
+	// and extract usage. If parsing fails, write the original body as-is.
+	bodyBytes := w.bodyBuf.Bytes()
+	var resp types.AnthropicMessagesResponse
+	if err := json.Unmarshal(bodyBytes, &resp); err == nil {
+		w.inputTokens = int64(resp.Usage.InputTokens)
+		w.outputTokens = int64(resp.Usage.OutputTokens)
+		w.cacheReadTokens = int64(resp.Usage.CacheReadInputTokens)
+		w.cacheCreationTokens = int64(resp.Usage.CacheCreationInputTokens)
+		resp.Model = w.model
+		// Feed the recorder a ChatCompletion built from the Anthropic response.
+		if w.recorder != nil {
+			w.recorder.Completion(buildChatCompletionFromAnthropicResponse(&resp))
+		}
+		remapped, err := json.Marshal(&resp)
+		if err == nil {
+			_, _ = w.ginWriter.Write(remapped)
+			return nil
+		}
+		slog.Warn("failed to remarshal native messages response", slog.Any("error", err))
+	}
+	// Fallback: write the original body unchanged.  This path is reached
+	// when the upstream response is not valid JSON or cannot be remarshaled
+	// after model remapping.  Return an api_error instead of leaking a
+	// potentially malformed body to the Messages client.
+	if w.bodyBuf.Len() > 0 {
+		w.ginWriter.Header().Set("Content-Type", "application/json")
+		writeAnthropicErrorJSON(w.ginWriter, http.StatusBadGateway, ErrTypeAPI,
+			"failed to convert upstream response")
+	} else {
+		// Force gin to commit the status code (gin's WriteHeader is lazy;
+		// it only commits on Write/WriteHeaderNow).
+		_, _ = w.ginWriter.Write(nil)
+	}
+	return nil
+}
+
+func (w *nativeResponseWriter) Usage() tokenUsage {
+	return tokenUsage{
+		PromptTokens:              w.inputTokens,
+		CompletionTokens:          w.outputTokens,
+		TotalTokens:               w.inputTokens + w.outputTokens,
+		CachedPromptTokens:        w.cacheReadTokens,
+		CacheCreationPromptTokens: w.cacheCreationTokens,
+	}
+}
+
+// buildChatCompletionFromAnthropicResponse constructs a types.ChatCompletion
+// from an AnthropicMessagesResponse for the LLM log recorder.
+func buildChatCompletionFromAnthropicResponse(resp *types.AnthropicMessagesResponse) types.ChatCompletion {
+	var finishReason string
+	if resp.StopReason != nil {
+		finishReason = messagesStopReasonToFinishReason(*resp.StopReason)
+	} else {
+		finishReason = "stop"
+	}
+	var content string
+	var toolCalls []openai.ChatCompletionMessageToolCallUnion
+	for _, block := range resp.Content {
+		switch block.Type {
+		case "text":
+			if content != "" {
+				content += "\n"
+			}
+			content += block.Text
+		case "tool_use":
+			args := string(block.Input)
+			if args == "" {
+				args = "{}"
+			}
+			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnion{
+				ID:   block.ID,
+				Type: "function",
+				Function: openai.ChatCompletionMessageFunctionToolCallFunction{
+					Name:      block.Name,
+					Arguments: args,
+				},
+			})
+		}
+	}
+	msg := openai.ChatCompletionMessage{
+		Role:    "assistant",
+		Content: content,
+	}
+	if len(toolCalls) > 0 {
+		msg.ToolCalls = toolCalls
+	}
+	return types.ChatCompletion{
+		ChatCompletion: openai.ChatCompletion{
+			ID:    resp.ID,
+			Model: resp.Model,
+			Choices: []openai.ChatCompletionChoice{{
+				Index:        0,
+				Message:      msg,
+				FinishReason: finishReason,
+			}},
+			Usage: openai.CompletionUsage{
+				PromptTokens:     int64(resp.Usage.InputTokens),
+				CompletionTokens: int64(resp.Usage.OutputTokens),
+				TotalTokens:      int64(resp.Usage.InputTokens + resp.Usage.OutputTokens),
+			},
+		},
+	}
+}
+

--- a/aigateway/handler/anthropic/to_chat_adapter.go
+++ b/aigateway/handler/anthropic/to_chat_adapter.go
@@ -1,0 +1,659 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+	"opencsg.com/csghub-server/aigateway/handler/streamdecoder"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+// adaptToChat converts the Anthropic Messages request to an OpenAI Chat
+// Completions request and creates a toChatResponseWriter that will convert
+// the Chat response back to Anthropic Messages format.
+func (h *Handler) adaptToChat(c *gin.Context, req *types.AnthropicMessagesRequest, p *types.RequestPlan, logCapture LLMLogRecorder) (*types.AdaptResult, error) {
+	// Check adapter capabilities before transforming.
+	missing := checkAdapterCapabilities(req, p.UpstreamCap)
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("unsupported_feature:%s", missing[0])
+	}
+
+	// Convert request.
+	chatReq, err := messagesToChatRequest(req, p.ModelTarget.ModelName, p.UpstreamCap.Thinking)
+	if err != nil {
+		return nil, err
+	}
+
+	// Marshal the chat request body.
+	body, err := json.Marshal(chatReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal chat request: %w", err)
+	}
+
+	// Create the response writer.
+	writer := newToChatResponseWriter(c.Writer, req.Stream, req.Model, p.ModelTarget.ModelName, logCapture)
+	return &types.AdaptResult{Body: body, Writer: writer}, nil
+}
+
+// messagesToChatRequest builds a ChatCompletionRequest-compatible map from
+// an Anthropic Messages request.  We use a map[string]any approach for
+// flexibility with unknown fields and tool schemas.
+func messagesToChatRequest(req *types.AnthropicMessagesRequest, modelName string, includeReasoning bool) (map[string]any, error) {
+	messages, err := messagesToChatMessages(req, includeReasoning)
+	if err != nil {
+		return nil, err
+	}
+	chatReq := map[string]any{
+		"model":    modelName,
+		"messages": messages,
+		"stream":   req.Stream,
+	}
+	if req.MaxTokens > 0 {
+		chatReq["max_tokens"] = req.MaxTokens
+	}
+	if req.Temperature != nil {
+		chatReq["temperature"] = *req.Temperature
+	}
+	if req.TopP != nil {
+		chatReq["top_p"] = *req.TopP
+	}
+	if len(req.StopSequences) > 0 {
+		chatReq["stop"] = req.StopSequences
+	}
+	if len(req.Tools) > 0 {
+		chatReq["tools"] = messagesToolsToChatTools(req.Tools)
+	}
+	if len(req.ToolChoice) > 0 {
+		converted, err := convertToolChoiceForChat(req.ToolChoice)
+		if err != nil {
+			return nil, fmt.Errorf("convert tool_choice: %w", err)
+		}
+		chatReq["tool_choice"] = converted
+	}
+	// top_k is not a standard OpenAI Chat Completions parameter; it is
+	// intentionally dropped (the Responses adapter does the same).
+	if req.Metadata != nil && req.Metadata.UserID != "" {
+		chatReq["user"] = req.Metadata.UserID
+	}
+	if req.Stream {
+		chatReq["stream_options"] = map[string]any{"include_usage": true}
+	}
+	// Thinking → reasoning_effort.  When extended thinking is enabled
+	// (HasThinking() returns true for "enabled" or "adaptive"), always set
+	// reasoning_effort so the upstream reasoning model actually produces
+	// reasoning_content.  If BudgetTokens is 0 (e.g. thinking: {type:"enabled"}
+	// without an explicit budget), default to "medium".
+	//
+	// When the client does not set the top-level thinking field, also check
+	// extra_body.reasoning_effort as a compatibility fallback — some clients
+	// (Litellm, OpenAI SDK) pass reasoning_effort that way.
+	effort := ""
+	if req.HasThinking() {
+		if req.Thinking.BudgetTokens > 0 {
+			effort = budgetToEffort(req.Thinking.BudgetTokens)
+		}
+	} else {
+		effort = extraBodyReasoningEffort(req)
+	}
+	if effort != "" || req.HasThinking() {
+		if effort == "" {
+			effort = "medium"
+		}
+		chatReq["reasoning_effort"] = effort
+	}
+
+	return chatReq, nil
+}
+
+// toChatResponseWriter converts Chat Completions responses (stream and
+// non-stream) to Anthropic Messages format on the fly.
+type toChatResponseWriter struct {
+	ginWriter    gin.ResponseWriter
+	stream       bool
+	publicModel  string // the model name the client sees
+	upstreamModel string
+	recorder     LLMLogRecorder
+	decoder      streamdecoder.Decoder
+
+	// Non-stream buffering.
+	bodyBuf       bytes.Buffer
+	statusCode    int
+	headerWritten bool
+	header        http.Header
+
+	// Stream state machine.
+	msgID          string
+	started        bool
+	textBlockIdx   int
+	textStarted    bool
+	textDone       bool
+	thinkingBlockIdx int
+	thinkingStarted  bool
+	toolCallStates map[int]*toChatToolCallState
+	nextBlockIdx   int
+	inputTokens    int64
+	outputTokens   int64
+	cacheReadTokens int64
+	stopReason     string
+
+	// Stream error tracking.
+	streamFailed    bool
+	streamErrStatus int
+	streamErrBody   []byte
+}
+
+type toChatToolCallState struct {
+	blockIdx int
+	id       string
+	name     string
+	started  bool
+}
+
+func newToChatResponseWriter(w gin.ResponseWriter, stream bool, publicModel, upstreamModel string, recorder LLMLogRecorder) *toChatResponseWriter {
+	return &toChatResponseWriter{
+		ginWriter:      w,
+		stream:         stream,
+		publicModel:    publicModel,
+		upstreamModel:  upstreamModel,
+		recorder:       recorder,
+		decoder:        streamdecoder.NewSSE(),
+		toolCallStates: make(map[int]*toChatToolCallState),
+		msgID:          newMessagesResponseID(),
+		stopReason:     "end_turn",
+		header:         make(http.Header),
+	}
+}
+
+func (w *toChatResponseWriter) Write(data []byte) (int, error) {
+	if !w.stream {
+		// Buffer non-streaming responses; Finalize() will convert and write.
+		w.bodyBuf.Write(data)
+		return len(data), nil
+	}
+	// Stream: if upstream returned an error status, buffer the error body.
+	if w.streamFailed {
+		w.streamErrBody = append(w.streamErrBody, data...)
+		return len(data), nil
+	}
+	// Stream: decode SSE chunks and convert.
+	events, err := w.decoder.Write(data)
+	if err != nil {
+		slog.Debug("chat stream decoder error", slog.Any("error", err))
+		return len(data), nil
+	}
+	for _, event := range events {
+		if event.Type == "error" {
+			// Upstream sent an SSE error event mid-stream.
+			w.streamFailed = true
+			w.streamErrStatus = http.StatusInternalServerError
+			w.streamErrBody = event.Data
+			return len(data), nil
+		}
+		if len(event.Data) == 0 || string(event.Data) == "[DONE]" {
+			continue
+		}
+		w.handleChatStreamChunk(event.Data)
+	}
+	return len(data), nil
+}
+
+func (w *toChatResponseWriter) WriteHeader(code int) {
+	if w.stream {
+		if code >= 400 {
+			// Upstream error in stream mode: mark as failed.
+			w.streamFailed = true
+			w.streamErrStatus = code
+			return
+		}
+		w.ginWriter.WriteHeader(code)
+		return
+	}
+	// Non-stream: capture status code, write it in Finalize.
+	if !w.headerWritten {
+		w.statusCode = code
+		w.headerWritten = true
+	}
+}
+
+func (w *toChatResponseWriter) Header() http.Header {
+	if w.stream {
+		return w.ginWriter.Header()
+	}
+	return w.header
+}
+
+func (w *toChatResponseWriter) Flush() {
+	if w.stream {
+		if w.streamFailed && !w.ginWriter.Written() {
+			return
+		}
+		if f, ok := w.ginWriter.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+	// Non-stream: do nothing. Calling ginWriter.Flush() would trigger
+	// WriteHeaderNow() and commit a default 200 status prematurely.
+}
+
+func (w *toChatResponseWriter) StatusCode() int {
+	if w.stream {
+		return w.ginWriter.Status()
+	}
+	if w.statusCode != 0 {
+		return w.statusCode
+	}
+	return http.StatusOK
+}
+
+func (w *toChatResponseWriter) copyHeadersToGin() {
+	for k, vs := range w.header {
+		// Skip Content-Length and Content-Encoding: the body is transformed
+		// during conversion, so the upstream values are invalid and would
+		// cause "wrote more than the declared Content-Length" errors.
+		if strings.EqualFold(k, "Content-Length") || strings.EqualFold(k, "Content-Encoding") {
+			continue
+		}
+		for _, v := range vs {
+			w.ginWriter.Header().Add(k, v)
+		}
+	}
+}
+
+func (w *toChatResponseWriter) Finalize() error {
+	if w.stream {
+		// If the upstream failed before the SSE stream started (no data
+		// written to the client), send a proper HTTP error with a JSON body.
+		if w.streamFailed && !w.ginWriter.Written() {
+			writeAnthropicUpstreamError(w.ginWriter, w.streamErrStatus, w.streamErrBody)
+			return nil
+		}
+		// If the upstream failed mid-stream (SSE already started), emit an
+		// Anthropic error event instead of a success completion.
+		if w.streamFailed {
+			writeAnthropicStreamError(w.ginWriter, w.streamErrStatus, w.streamErrBody)
+			return nil
+		}
+		// Emit final events if streaming started.
+		if w.started {
+			// Close any open thinking block.
+			if w.thinkingStarted {
+				writeSSEEventRaw(w.ginWriter, "content_block_stop", map[string]any{
+					"type": "content_block_stop", "index": w.thinkingBlockIdx,
+				})
+			}
+			// Close any open text block.
+			if w.textStarted && !w.textDone {
+				writeSSEEventRaw(w.ginWriter, "content_block_stop", map[string]any{
+					"type": "content_block_stop", "index": w.textBlockIdx,
+				})
+			}
+// Close any open tool call blocks in deterministic order.
+				// toolCallStates is a map — iteration order is random.
+				// Sort by blockIdx so content_block_stop events are emitted
+				// in the same order as content_block_start events.
+				var sortedToolCalls []*toChatToolCallState
+				for _, tc := range w.toolCallStates {
+					if tc.started {
+						sortedToolCalls = append(sortedToolCalls, tc)
+					}
+				}
+				sort.Slice(sortedToolCalls, func(i, j int) bool {
+					return sortedToolCalls[i].blockIdx < sortedToolCalls[j].blockIdx
+				})
+				for _, tc := range sortedToolCalls {
+					writeSSEEventRaw(w.ginWriter, "content_block_stop", map[string]any{
+						"type": "content_block_stop", "index": tc.blockIdx,
+					})
+				}
+			// message_delta with stop_reason and usage.
+			usageMap := map[string]any{
+				"input_tokens":  w.inputTokens,
+				"output_tokens": w.outputTokens,
+			}
+			if w.cacheReadTokens > 0 {
+				usageMap["cache_read_input_tokens"] = w.cacheReadTokens
+			}
+			writeSSEEventRaw(w.ginWriter, "message_delta", map[string]any{
+				"type":  "message_delta",
+				"delta": map[string]any{"stop_reason": w.stopReason, "stop_sequence": nil},
+				"usage": usageMap,
+			})
+			writeSSEEventRaw(w.ginWriter, "message_stop", map[string]any{"type": "message_stop"})
+		}
+		return nil
+	}
+	// Non-stream: convert the buffered Chat response to Messages format.
+	if w.bodyBuf.Len() == 0 {
+		// No body — likely a connection error.
+		if w.statusCode >= 400 {
+			writeAnthropicUpstreamError(w.ginWriter, w.statusCode, nil)
+		} else {
+			if w.statusCode != 0 {
+				w.ginWriter.WriteHeader(w.statusCode)
+			} else {
+				w.ginWriter.WriteHeader(http.StatusOK)
+			}
+			// Force gin to commit the status code (gin's WriteHeader is lazy;
+			// it only commits on Write/WriteHeaderNow).
+			_, _ = w.ginWriter.Write(nil)
+		}
+		return nil
+	}
+	// If upstream returned an error status, convert to Anthropic error format.
+	// Do not copy upstream headers for error responses.
+	if w.statusCode >= 400 {
+		writeAnthropicUpstreamError(w.ginWriter, w.statusCode, w.bodyBuf.Bytes())
+		return nil
+	}
+	// Success path: copy upstream headers (minus Content-Length/Encoding).
+	w.copyHeadersToGin()
+	resp, err := chatResponseToMessagesResponse(w.bodyBuf.Bytes(), w.publicModel)
+	if err != nil {
+		// Conversion failure: the upstream returned a 2xx but the body is
+		// not a valid Chat response (e.g. HTML, empty, or malformed JSON).
+		// Return an Anthropic api_error instead of leaking the raw body.
+		w.ginWriter.Header().Set("Content-Type", "application/json")
+		writeAnthropicErrorJSON(w.ginWriter, http.StatusBadGateway, ErrTypeAPI,
+			"failed to convert upstream response")
+		return nil
+	}
+	w.inputTokens = int64(resp.Usage.InputTokens)
+	w.outputTokens = int64(resp.Usage.OutputTokens)
+	w.cacheReadTokens = int64(resp.Usage.CacheReadInputTokens)
+	// Feed the recorder with the full ChatCompletion before conversion.
+	if w.recorder != nil {
+		var chatResp types.ChatCompletion
+		if jsonErr := json.Unmarshal(w.bodyBuf.Bytes(), &chatResp); jsonErr == nil {
+			w.recorder.Completion(chatResp)
+		}
+	}
+	w.ginWriter.Header().Set("Content-Type", "application/json")
+	if w.statusCode != 0 {
+		w.ginWriter.WriteHeader(w.statusCode)
+	} else {
+		w.ginWriter.WriteHeader(http.StatusOK)
+	}
+	output, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+	_, _ = w.ginWriter.Write(output)
+	return nil
+}
+
+func (w *toChatResponseWriter) Usage() tokenUsage {
+	return tokenUsage{
+		PromptTokens:              w.inputTokens,
+		CompletionTokens:          w.outputTokens,
+		TotalTokens:               w.inputTokens + w.outputTokens,
+		CachedPromptTokens:        w.cacheReadTokens,
+		CacheCreationPromptTokens: 0,
+	}
+}
+
+// handleChatStreamChunk processes a single Chat SSE chunk and emits
+// corresponding Anthropic Messages SSE events.
+func (w *toChatResponseWriter) handleChatStreamChunk(data []byte) {
+	var chunk struct {
+		ID      string `json:"id"`
+		Choices []struct {
+			Index        int                    `json:"index"`
+			Delta        map[string]interface{} `json:"delta"`
+			FinishReason *string                `json:"finish_reason"`
+		} `json:"choices"`
+		Usage *struct {
+			PromptTokens     int64 `json:"prompt_tokens"`
+			CompletionTokens int64 `json:"completion_tokens"`
+			PromptTokensDetails *struct {
+				CachedTokens int64 `json:"cached_tokens"`
+			} `json:"prompt_tokens_details"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(data, &chunk); err != nil {
+		slog.Debug("chat stream chunk parse error", slog.String("error", err.Error()), slog.String("data", string(data)))
+		return
+	}
+
+	// Feed the recorder a ChatCompletionChunk built from the parsed data.
+	if w.recorder != nil {
+		w.recorder.AppendCompletionChunk(buildChunkFromChatStreamData(chunk.ID, chunk.Choices, chunk.Usage))
+	}
+
+	// Emit message_start on first chunk.
+	if !w.started {
+		w.started = true
+		writeSSEEventRaw(w.ginWriter, "message_start", map[string]any{
+			"type": "message_start",
+			"message": map[string]any{
+				"id":    w.msgID,
+				"type":  "message",
+				"role":  "assistant",
+				"model": w.publicModel,
+				"content": []any{},
+				"stop_reason":   nil,
+				"stop_sequence": nil,
+				"usage": map[string]any{"input_tokens": 0, "output_tokens": 0},
+			},
+		})
+	}
+
+	// Extract usage if present.
+	if chunk.Usage != nil {
+		w.inputTokens = chunk.Usage.PromptTokens
+		w.outputTokens = chunk.Usage.CompletionTokens
+		if chunk.Usage.PromptTokensDetails != nil {
+			w.cacheReadTokens = chunk.Usage.PromptTokensDetails.CachedTokens
+		}
+	}
+
+	if len(chunk.Choices) == 0 {
+		return
+	}
+
+	choice := chunk.Choices[0]
+	delta := choice.Delta
+
+	// Handle finish_reason.  Some upstreams send the final content delta
+	// and finish_reason in the same chunk; we record the stop reason but
+	// continue processing (content/tool_calls below) so the tail delta is
+	// not silently dropped.  The message_stop and message_delta events are
+	// emitted later in Finalize().
+	if choice.FinishReason != nil {
+		w.stopReason = chatFinishReasonToStopReason(*choice.FinishReason)
+	}
+
+	// Handle text content.
+	if content, ok := delta["content"].(string); ok && content != "" {
+		if !w.textStarted {
+			w.textStarted = true
+			w.textBlockIdx = w.nextBlockIdx
+			w.nextBlockIdx++
+			writeSSEEventRaw(w.ginWriter, "content_block_start", map[string]any{
+				"type":  "content_block_start",
+				"index": w.textBlockIdx,
+				"content_block": map[string]any{"type": "text", "text": ""},
+			})
+		}
+		writeSSEEventRaw(w.ginWriter, "content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": w.textBlockIdx,
+			"delta": map[string]any{"type": "text_delta", "text": content},
+		})
+	}
+
+	// Handle reasoning content — emit as thinking blocks.
+	if reasoning, ok := delta["reasoning_content"].(string); ok && reasoning != "" {
+		if !w.thinkingStarted {
+			w.thinkingStarted = true
+			w.thinkingBlockIdx = w.nextBlockIdx
+			w.nextBlockIdx++
+			writeSSEEventRaw(w.ginWriter, "content_block_start", map[string]any{
+				"type":          "content_block_start",
+				"index":         w.thinkingBlockIdx,
+				"content_block": map[string]any{"type": "thinking", "thinking": ""},
+			})
+		}
+		writeSSEEventRaw(w.ginWriter, "content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": w.thinkingBlockIdx,
+			"delta": map[string]any{"type": "thinking_delta", "thinking": reasoning},
+		})
+	}
+
+	// Handle tool calls.
+	if toolCalls, ok := delta["tool_calls"].([]any); ok {
+		for _, tc := range toolCalls {
+			tcMap, ok := tc.(map[string]any)
+			if !ok {
+				continue
+			}
+			idxFloat, _ := tcMap["index"].(float64)
+			idx := int(idxFloat)
+			state, exists := w.toolCallStates[idx]
+			if !exists {
+				state = &toChatToolCallState{
+					blockIdx: w.nextBlockIdx,
+				}
+				w.nextBlockIdx++
+				w.toolCallStates[idx] = state
+			}
+			if !state.started {
+				state.started = true
+				if fn, ok := tcMap["function"].(map[string]any); ok {
+					if id, ok := tcMap["id"].(string); ok {
+						state.id = id
+					}
+					if name, ok := fn["name"].(string); ok {
+						state.name = name
+					}
+				}
+				writeSSEEventRaw(w.ginWriter, "content_block_start", map[string]any{
+					"type":  "content_block_start",
+					"index": state.blockIdx,
+					"content_block": map[string]any{
+						"type": "tool_use",
+						"id":   state.id,
+						"name": state.name,
+						"input": map[string]any{},
+					},
+				})
+			}
+			if fn, ok := tcMap["function"].(map[string]any); ok {
+				if args, ok := fn["arguments"].(string); ok && args != "" {
+					writeSSEEventRaw(w.ginWriter, "content_block_delta", map[string]any{
+						"type":  "content_block_delta",
+						"index": state.blockIdx,
+						"delta": map[string]any{"type": "input_json_delta", "partial_json": args},
+					})
+				}
+			}
+		}
+	}
+}
+
+// buildChunkFromChatStreamData constructs a types.ChatCompletionChunk from
+// the loosely-typed parsed SSE data for the LLM log recorder.
+func buildChunkFromChatStreamData(id string, choices []struct {
+	Index        int                    `json:"index"`
+	Delta        map[string]interface{} `json:"delta"`
+	FinishReason *string                `json:"finish_reason"`
+}, usage *struct {
+	PromptTokens     int64 `json:"prompt_tokens"`
+	CompletionTokens int64 `json:"completion_tokens"`
+	PromptTokensDetails *struct {
+		CachedTokens int64 `json:"cached_tokens"`
+	} `json:"prompt_tokens_details"`
+}) types.ChatCompletionChunk {
+	c := types.ChatCompletionChunk{
+		ID: id,
+	}
+	if len(choices) > 0 {
+		ch := choices[0]
+		delta := types.ChatCompletionChunkChoiceDelta{}
+		if content, ok := ch.Delta["content"].(string); ok {
+			delta.Content = content
+		}
+		if reasoning, ok := ch.Delta["reasoning_content"].(string); ok {
+			delta.ReasoningContent = reasoning
+		}
+		if toolCalls, ok := ch.Delta["tool_calls"].([]any); ok {
+			for _, tc := range toolCalls {
+				tcMap, ok := tc.(map[string]any)
+				if !ok {
+					continue
+				}
+				idxFloat, _ := tcMap["index"].(float64)
+				fn, _ := tcMap["function"].(map[string]any)
+				fnName, _ := fn["name"].(string)
+				fnArgs, _ := fn["arguments"].(string)
+				tcID, _ := tcMap["id"].(string)
+				delta.ToolCalls = append(delta.ToolCalls, openai.ChatCompletionChunkChoiceDeltaToolCall{
+					Index: int64(idxFloat),
+					ID:    tcID,
+					Type:  "function",
+					Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
+						Name:      fnName,
+						Arguments: fnArgs,
+					},
+				})
+			}
+		}
+		finishReason := ""
+		if ch.FinishReason != nil {
+			finishReason = *ch.FinishReason
+		}
+		c.Choices = []types.ChatCompletionChunkChoice{{
+			Index:        int64(ch.Index),
+			Delta:        delta,
+			FinishReason: finishReason,
+		}}
+	}
+	if usage != nil {
+		c.Usage = openai.CompletionUsage{
+			PromptTokens:     usage.PromptTokens,
+			CompletionTokens: usage.CompletionTokens,
+			TotalTokens:      usage.PromptTokens + usage.CompletionTokens,
+		}
+	}
+	return c
+}
+
+// writeSSEEventRaw writes an SSE event directly to the gin writer.
+func writeSSEEventRaw(w gin.ResponseWriter, eventType string, data any) {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, jsonData)
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// extraBodyReasoningEffort extracts reasoning_effort from extra_body in
+// ExtraFields.  This is a compatibility fallback for clients that nest
+// reasoning_effort inside extra_body (Litellm, OpenAI SDK pattern).
+// Returns "" when not present.
+func extraBodyReasoningEffort(req *types.AnthropicMessagesRequest) string {
+	if req.ExtraFields == nil {
+		return ""
+	}
+	eb, ok := req.ExtraFields["extra_body"]
+	if !ok {
+		return ""
+	}
+	var extraBody struct {
+		ReasoningEffort string `json:"reasoning_effort"`
+	}
+	if err := json.Unmarshal(eb, &extraBody); err != nil {
+		return ""
+	}
+	return extraBody.ReasoningEffort
+}

--- a/aigateway/handler/anthropic/to_responses_adapter.go
+++ b/aigateway/handler/anthropic/to_responses_adapter.go
@@ -1,0 +1,638 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+	"opencsg.com/csghub-server/aigateway/handler/streamdecoder"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+// adaptToResponses converts the Anthropic Messages request to an OpenAI
+// Responses API request and creates a toResponsesResponseWriter that will
+// convert the Responses response back to Anthropic Messages format.
+func (h *Handler) adaptToResponses(c *gin.Context, req *types.AnthropicMessagesRequest, p *types.RequestPlan, logCapture LLMLogRecorder) (*types.AdaptResult, error) {
+	// Check adapter capabilities before transforming.
+	missing := checkAdapterCapabilities(req, p.UpstreamCap)
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("unsupported_feature:%s", missing[0])
+	}
+
+	// Convert request.
+	respReq, err := messagesToResponsesRequest(req, p.ModelTarget.ModelName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Marshal the responses request body.
+	body, err := json.Marshal(respReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal responses request: %w", err)
+	}
+
+	// Create the response writer.
+	writer := newToResponsesResponseWriter(c.Writer, req.Stream, req.Model, p.ModelTarget.ModelName, logCapture)
+	return &types.AdaptResult{Body: body, Writer: writer}, nil
+}
+
+// toResponsesResponseWriter converts Responses API responses (stream and
+// non-stream) to Anthropic Messages format on the fly.
+type toResponsesResponseWriter struct {
+	ginWriter     gin.ResponseWriter
+	stream        bool
+	publicModel   string
+	upstreamModel string
+	recorder      LLMLogRecorder
+	decoder       streamdecoder.Decoder
+
+	// Non-stream buffering.
+	bodyBuf       []byte
+	statusCode    int
+	headerWritten bool
+	header        http.Header
+
+	// Stream state machine.
+	msgID          string
+	started        bool
+	nextBlockIdx   int
+	textBlockIdx   int
+	textStarted    bool
+	thinkingBlockIdx int
+	thinkingStarted  bool
+	toolCallStates map[string]*toResponsesToolCallState
+	inputTokens     int64
+	outputTokens    int64
+	cacheReadTokens int64
+	cacheCreationTokens int64
+	stopReason      string
+
+	// Stream error tracking.
+	streamFailed    bool
+	streamErrStatus int
+	streamErrBody   []byte
+}
+
+type toResponsesToolCallState struct {
+	blockIdx int
+	itemID   string
+	callID   string
+	name     string
+	started  bool
+}
+
+func newToResponsesResponseWriter(w gin.ResponseWriter, stream bool, publicModel, upstreamModel string, recorder LLMLogRecorder) *toResponsesResponseWriter {
+	return &toResponsesResponseWriter{
+		ginWriter:      w,
+		stream:         stream,
+		publicModel:    publicModel,
+		upstreamModel:  upstreamModel,
+		recorder:       recorder,
+		decoder:        streamdecoder.NewSSE(),
+		toolCallStates: make(map[string]*toResponsesToolCallState),
+		msgID:          newMessagesResponseID(),
+		stopReason:     "end_turn",
+		header:         make(http.Header),
+	}
+}
+
+func (w *toResponsesResponseWriter) Write(data []byte) (int, error) {
+	if !w.stream {
+		// Buffer non-streaming responses; Finalize() will convert and write.
+		w.bodyBuf = append(w.bodyBuf, data...)
+		return len(data), nil
+	}
+	// Stream: if upstream returned an error status, buffer the error body.
+	if w.streamFailed {
+		w.streamErrBody = append(w.streamErrBody, data...)
+		return len(data), nil
+	}
+	// Stream: decode SSE chunks and convert.
+	events, err := w.decoder.Write(data)
+	if err != nil {
+		slog.Debug("responses stream decoder error", slog.Any("error", err))
+		return len(data), nil
+	}
+	for _, event := range events {
+		if event.Type == "error" {
+			// Upstream sent an SSE error event mid-stream.
+			w.streamFailed = true
+			w.streamErrStatus = http.StatusInternalServerError
+			w.streamErrBody = event.Data
+			return len(data), nil
+		}
+		if event.Type == "response.failed" {
+			// Upstream reported a failure event.
+			w.streamFailed = true
+			w.streamErrStatus = http.StatusInternalServerError
+			w.streamErrBody = event.Data
+			return len(data), nil
+		}
+		if len(event.Data) == 0 || string(event.Data) == "[DONE]" {
+			continue
+		}
+		w.handleResponsesStreamEvent(event.Type, event.Data)
+	}
+	return len(data), nil
+}
+
+func (w *toResponsesResponseWriter) WriteHeader(code int) {
+	if w.stream {
+		if code >= 400 {
+			// Upstream error in stream mode: mark as failed.
+			w.streamFailed = true
+			w.streamErrStatus = code
+			return
+		}
+		w.ginWriter.WriteHeader(code)
+		return
+	}
+	// Non-stream: capture status code, write it in Finalize.
+	if !w.headerWritten {
+		w.statusCode = code
+		w.headerWritten = true
+	}
+}
+
+func (w *toResponsesResponseWriter) Header() http.Header {
+	if w.stream {
+		return w.ginWriter.Header()
+	}
+	return w.header
+}
+
+func (w *toResponsesResponseWriter) Flush() {
+	if w.stream {
+		if w.streamFailed && !w.ginWriter.Written() {
+			return
+		}
+		if f, ok := w.ginWriter.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+	// Non-stream: do nothing. Calling ginWriter.Flush() would trigger
+	// WriteHeaderNow() and commit a default 200 status prematurely.
+}
+
+func (w *toResponsesResponseWriter) StatusCode() int {
+	if w.stream {
+		return w.ginWriter.Status()
+	}
+	if w.statusCode != 0 {
+		return w.statusCode
+	}
+	return http.StatusOK
+}
+
+func (w *toResponsesResponseWriter) copyHeadersToGin() {
+	for k, vs := range w.header {
+		// Skip Content-Length and Content-Encoding: the body is transformed
+		// during conversion, so the upstream values are invalid and would
+		// cause "wrote more than the declared Content-Length" errors.
+		if strings.EqualFold(k, "Content-Length") || strings.EqualFold(k, "Content-Encoding") {
+			continue
+		}
+		for _, v := range vs {
+			w.ginWriter.Header().Add(k, v)
+		}
+	}
+}
+
+func (w *toResponsesResponseWriter) Finalize() error {
+	if w.stream {
+		// If the upstream failed before the SSE stream started (no data
+		// written to the client), send a proper HTTP error with a JSON body.
+		if w.streamFailed && !w.ginWriter.Written() {
+			writeAnthropicUpstreamError(w.ginWriter, w.streamErrStatus, w.streamErrBody)
+			return nil
+		}
+		// If the upstream failed mid-stream (SSE already started), emit an
+		// Anthropic error event instead of a success completion.
+		if w.streamFailed {
+			writeAnthropicStreamError(w.ginWriter, w.streamErrStatus, w.streamErrBody)
+			return nil
+		}
+		// Emit final events if streaming started.
+		if w.started {
+			// Close any open thinking block.
+			if w.thinkingStarted {
+				writeSSEEventRaw(w.ginWriter, "content_block_stop", map[string]any{
+					"type": "content_block_stop", "index": w.thinkingBlockIdx,
+				})
+			}
+			// Close any open text block.
+			if w.textStarted {
+				writeSSEEventRaw(w.ginWriter, "content_block_stop", map[string]any{
+					"type": "content_block_stop", "index": w.textBlockIdx,
+				})
+			}
+			// Close any open tool call blocks in deterministic order.
+			// toolCallStates is a map — iteration order is random.
+			// Sort by blockIdx so content_block_stop events are emitted
+			// in the same order as content_block_start events.
+			var sortedToolCalls []*toResponsesToolCallState
+			for _, tc := range w.toolCallStates {
+				if tc.started {
+					sortedToolCalls = append(sortedToolCalls, tc)
+				}
+			}
+			sort.Slice(sortedToolCalls, func(i, j int) bool {
+				return sortedToolCalls[i].blockIdx < sortedToolCalls[j].blockIdx
+			})
+			for _, tc := range sortedToolCalls {
+				writeSSEEventRaw(w.ginWriter, "content_block_stop", map[string]any{
+					"type": "content_block_stop", "index": tc.blockIdx,
+				})
+			}
+			usageMap := map[string]any{
+				"input_tokens":  w.inputTokens,
+				"output_tokens": w.outputTokens,
+			}
+			if w.cacheReadTokens > 0 {
+				usageMap["cache_read_input_tokens"] = w.cacheReadTokens
+			}
+			if w.cacheCreationTokens > 0 {
+				usageMap["cache_creation_input_tokens"] = w.cacheCreationTokens
+			}
+			writeSSEEventRaw(w.ginWriter, "message_delta", map[string]any{
+				"type":  "message_delta",
+				"delta": map[string]any{"stop_reason": w.stopReason, "stop_sequence": nil},
+				"usage": usageMap,
+			})
+			writeSSEEventRaw(w.ginWriter, "message_stop", map[string]any{"type": "message_stop"})
+		}
+		return nil
+	}
+	// Non-stream: convert the buffered Responses response to Messages format.
+	if len(w.bodyBuf) == 0 {
+		if w.statusCode >= 400 {
+			writeAnthropicUpstreamError(w.ginWriter, w.statusCode, nil)
+		} else {
+			if w.statusCode != 0 {
+				w.ginWriter.WriteHeader(w.statusCode)
+			} else {
+				w.ginWriter.WriteHeader(http.StatusOK)
+			}
+			// Force gin to commit the status code (gin's WriteHeader is lazy;
+			// it only commits on Write/WriteHeaderNow).
+			_, _ = w.ginWriter.Write(nil)
+		}
+		return nil
+	}
+	// If upstream returned an error status, convert to Anthropic error format.
+	// Do not copy upstream headers for error responses.
+	if w.statusCode >= 400 {
+		writeAnthropicUpstreamError(w.ginWriter, w.statusCode, w.bodyBuf)
+		return nil
+	}
+	// Success path: copy upstream headers (minus Content-Length/Encoding).
+	w.copyHeadersToGin()
+	var resp types.ResponsesResponse
+	if err := json.Unmarshal(w.bodyBuf, &resp); err != nil {
+		// Conversion failure: the upstream returned a 2xx but the body is
+		// not a valid Responses response (e.g. HTML, empty, or malformed
+		// JSON).  Return an Anthropic api_error instead of leaking the raw
+		// body to the Messages client.
+		w.ginWriter.Header().Set("Content-Type", "application/json")
+		writeAnthropicErrorJSON(w.ginWriter, http.StatusBadGateway, ErrTypeAPI,
+			"failed to convert upstream response")
+		return nil
+	}
+	result, err := responsesResponseToMessagesResponse(&resp, w.publicModel)
+	if err != nil {
+		w.ginWriter.Header().Set("Content-Type", "application/json")
+		writeAnthropicErrorJSON(w.ginWriter, http.StatusBadGateway, ErrTypeAPI,
+			"failed to convert upstream response")
+		return nil
+	}
+	w.inputTokens = int64(result.Usage.InputTokens)
+	w.outputTokens = int64(result.Usage.OutputTokens)
+	w.cacheReadTokens = int64(result.Usage.CacheReadInputTokens)
+	w.cacheCreationTokens = int64(result.Usage.CacheCreationInputTokens)
+	// Feed the recorder with a ChatCompletion built from the Responses response.
+	if w.recorder != nil {
+		w.recorder.Completion(buildChatCompletionFromResponsesResponse(&resp, w.upstreamModel))
+	}
+	w.ginWriter.Header().Set("Content-Type", "application/json")
+	if w.statusCode != 0 {
+		w.ginWriter.WriteHeader(w.statusCode)
+	} else {
+		w.ginWriter.WriteHeader(http.StatusOK)
+	}
+	output, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	_, _ = w.ginWriter.Write(output)
+	return nil
+}
+
+func (w *toResponsesResponseWriter) Usage() tokenUsage {
+	return tokenUsage{
+		PromptTokens:              w.inputTokens,
+		CompletionTokens:          w.outputTokens,
+		TotalTokens:               w.inputTokens + w.outputTokens,
+		CachedPromptTokens:        w.cacheReadTokens,
+		CacheCreationPromptTokens: w.cacheCreationTokens,
+	}
+}
+
+// handleResponsesStreamEvent processes a single Responses SSE event and emits
+// corresponding Anthropic Messages SSE events.
+func (w *toResponsesResponseWriter) handleResponsesStreamEvent(eventType string, data []byte) {
+	switch eventType {
+	case "response.created", "response.in_progress":
+		if !w.started {
+			w.started = true
+			writeSSEEventRaw(w.ginWriter, "message_start", map[string]any{
+				"type": "message_start",
+				"message": map[string]any{
+					"id":            w.msgID,
+					"type":          "message",
+					"role":          "assistant",
+					"model":         w.publicModel,
+					"content":       []any{},
+					"stop_reason":   nil,
+					"stop_sequence": nil,
+					"usage":         map[string]any{"input_tokens": 0, "output_tokens": 0},
+				},
+			})
+		}
+
+	case "response.output_item.added":
+		var event struct {
+			Item struct {
+				ID     string `json:"id"`
+				Type   string `json:"type"`
+				CallID string `json:"call_id"`
+				Name   string `json:"name"`
+			} `json:"item"`
+		}
+		if err := json.Unmarshal(data, &event); err != nil {
+			slog.Debug("responses stream output_item.added parse error", slog.String("error", err.Error()))
+			return
+		}
+		switch event.Item.Type {
+		case "message":
+			// Text block will be started by content_part.added / output_text.delta.
+		case "function_call":
+			state := &toResponsesToolCallState{
+				blockIdx: w.nextBlockIdx,
+				itemID:   event.Item.ID,
+				callID:   event.Item.CallID,
+				name:     event.Item.Name,
+				started:  true,
+			}
+			w.nextBlockIdx++
+			// Index by item_id so function_call_arguments.delta can find it.
+			w.toolCallStates[event.Item.ID] = state
+			writeSSEEventRaw(w.ginWriter, "content_block_start", map[string]any{
+				"type":  "content_block_start",
+				"index": state.blockIdx,
+				"content_block": map[string]any{
+					"type":  "tool_use",
+					"id":    state.callID,
+					"name":  state.name,
+					"input": map[string]any{},
+				},
+			})
+		}
+
+	case "response.reasoning_text.delta":
+		var event struct {
+			Delta string `json:"delta"`
+		}
+		if err := json.Unmarshal(data, &event); err != nil {
+			slog.Debug("responses stream reasoning_text.delta parse error", slog.String("error", err.Error()))
+			return
+		}
+		if event.Delta == "" {
+			return
+		}
+		if w.recorder != nil {
+			w.recorder.AppendCompletionChunk(types.ChatCompletionChunk{
+				Model: w.upstreamModel,
+				Choices: []types.ChatCompletionChunkChoice{{
+					Index: 0,
+					Delta: types.ChatCompletionChunkChoiceDelta{ReasoningContent: event.Delta},
+				}},
+			})
+		}
+		if !w.thinkingStarted {
+			w.thinkingStarted = true
+			w.thinkingBlockIdx = w.nextBlockIdx
+			w.nextBlockIdx++
+			writeSSEEventRaw(w.ginWriter, "content_block_start", map[string]any{
+				"type":          "content_block_start",
+				"index":         w.thinkingBlockIdx,
+				"content_block": map[string]any{"type": "thinking", "thinking": ""},
+			})
+		}
+		writeSSEEventRaw(w.ginWriter, "content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": w.thinkingBlockIdx,
+			"delta": map[string]any{"type": "thinking_delta", "thinking": event.Delta},
+		})
+
+	case "response.output_text.delta":
+		var event struct {
+			Delta string `json:"delta"`
+		}
+		if err := json.Unmarshal(data, &event); err != nil {
+			slog.Debug("responses stream output_text.delta parse error", slog.String("error", err.Error()))
+			return
+		}
+		if event.Delta == "" {
+			return
+		}
+		if w.recorder != nil {
+			w.recorder.AppendCompletionChunk(types.ChatCompletionChunk{
+				Model: w.upstreamModel,
+				Choices: []types.ChatCompletionChunkChoice{{
+					Index: 0,
+					Delta: types.ChatCompletionChunkChoiceDelta{Content: event.Delta},
+				}},
+			})
+		}
+		if !w.textStarted {
+			w.textStarted = true
+			w.textBlockIdx = w.nextBlockIdx
+			w.nextBlockIdx++
+			writeSSEEventRaw(w.ginWriter, "content_block_start", map[string]any{
+				"type":          "content_block_start",
+				"index":         w.textBlockIdx,
+				"content_block": map[string]any{"type": "text", "text": ""},
+			})
+		}
+		writeSSEEventRaw(w.ginWriter, "content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": w.textBlockIdx,
+			"delta": map[string]any{"type": "text_delta", "text": event.Delta},
+		})
+
+	case "response.function_call_arguments.delta":
+		var event struct {
+			ItemID string `json:"item_id"`
+			Delta  string `json:"delta"`
+		}
+		if err := json.Unmarshal(data, &event); err != nil {
+			slog.Debug("responses stream function_call_arguments.delta parse error", slog.String("error", err.Error()))
+			return
+		}
+		if w.recorder != nil && event.Delta != "" {
+			w.recorder.AppendCompletionChunk(types.ChatCompletionChunk{
+				Model: w.upstreamModel,
+				Choices: []types.ChatCompletionChunkChoice{{
+					Index: 0,
+					Delta: types.ChatCompletionChunkChoiceDelta{
+						ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{{
+							Index: 0,
+							Type:  "function",
+							Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
+								Arguments: event.Delta,
+							},
+						}},
+					},
+				}},
+			})
+		}
+		if state, ok := w.toolCallStates[event.ItemID]; ok && event.Delta != "" {
+			writeSSEEventRaw(w.ginWriter, "content_block_delta", map[string]any{
+				"type":  "content_block_delta",
+				"index": state.blockIdx,
+				"delta": map[string]any{"type": "input_json_delta", "partial_json": event.Delta},
+			})
+		}
+
+	case "response.completed":
+		var event struct {
+			Response struct {
+				Status string `json:"status"`
+				Usage  *struct {
+					InputTokens  int64 `json:"input_tokens"`
+					OutputTokens int64 `json:"output_tokens"`
+					InputTokensDetails *struct {
+						CachedTokens         int64 `json:"cached_tokens"`
+						CachedCreationTokens int64 `json:"cached_creation_tokens"`
+					} `json:"input_tokens_details"`
+				} `json:"usage"`
+			} `json:"response"`
+		}
+		if err := json.Unmarshal(data, &event); err == nil {
+			if event.Response.Usage != nil {
+				w.inputTokens = event.Response.Usage.InputTokens
+				w.outputTokens = event.Response.Usage.OutputTokens
+				if event.Response.Usage.InputTokensDetails != nil {
+					w.cacheReadTokens = event.Response.Usage.InputTokensDetails.CachedTokens
+					w.cacheCreationTokens = event.Response.Usage.InputTokensDetails.CachedCreationTokens
+				}
+			}
+			w.stopReason = responsesStatusToStopReason(event.Response.Status)
+		}
+		if w.recorder != nil {
+			finishReason := messagesStopReasonToFinishReason(w.stopReason)
+			w.recorder.AppendCompletionChunk(types.ChatCompletionChunk{
+				Model: w.upstreamModel,
+				Choices: []types.ChatCompletionChunkChoice{{
+					Index:        0,
+					FinishReason: finishReason,
+				}},
+				Usage: openai.CompletionUsage{
+					PromptTokens:     w.inputTokens,
+					CompletionTokens: w.outputTokens,
+					TotalTokens:      w.inputTokens + w.outputTokens,
+				},
+			})
+		}
+		// The Finalize() method will emit message_delta and message_stop.
+	}
+}
+
+// buildChatCompletionFromResponsesResponse constructs a types.ChatCompletion
+// from a ResponsesResponse for the LLM log recorder.
+func buildChatCompletionFromResponsesResponse(resp *types.ResponsesResponse, model string) types.ChatCompletion {
+	var content string
+	var toolCalls []openai.ChatCompletionMessageToolCallUnion
+	for _, item := range resp.Output {
+		switch item.Type {
+		case "message":
+			for _, part := range item.Content {
+				switch part.Type {
+				case "output_text":
+					if content != "" {
+						content += "\n"
+					}
+					content += part.Text
+				case "refusal":
+					if content != "" {
+						content += "\n"
+					}
+					content += part.Refusal
+				}
+			}
+		case "function_call":
+			args := item.Arguments
+			if args == "" {
+				args = "{}"
+			}
+			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnion{
+				ID:   item.CallID,
+				Type: "function",
+				Function: openai.ChatCompletionMessageFunctionToolCallFunction{
+					Name:      item.Name,
+					Arguments: args,
+				},
+			})
+		}
+	}
+
+	finishReason := responsesStatusToFinishReason(resp.Status)
+	msg := openai.ChatCompletionMessage{
+		Role:    "assistant",
+		Content: content,
+	}
+	if len(toolCalls) > 0 {
+		msg.ToolCalls = toolCalls
+	}
+
+	var promptTokens, completionTokens int64
+	if resp.Usage != nil {
+		promptTokens = resp.Usage.InputTokens
+		completionTokens = resp.Usage.OutputTokens
+	}
+
+	return types.ChatCompletion{
+		ChatCompletion: openai.ChatCompletion{
+			ID:    resp.ID,
+			Model: model,
+			Choices: []openai.ChatCompletionChoice{{
+				Index:        0,
+				Message:      msg,
+				FinishReason: finishReason,
+			}},
+			Usage: openai.CompletionUsage{
+				PromptTokens:     promptTokens,
+				CompletionTokens: completionTokens,
+				TotalTokens:      promptTokens + completionTokens,
+			},
+		},
+	}
+}
+
+// responsesStatusToFinishReason maps a Responses API status to an OpenAI
+// Chat finish_reason for the LLM log recorder.
+func responsesStatusToFinishReason(status string) string {
+	switch status {
+	case "completed":
+		return "stop"
+	case "incomplete":
+		return "length"
+	default:
+		return "stop"
+	}
+}

--- a/aigateway/handler/anthropic/trace.go
+++ b/aigateway/handler/anthropic/trace.go
@@ -1,0 +1,219 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"opencsg.com/csghub-server/aigateway/types"
+	commontypes "opencsg.com/csghub-server/common/types"
+)
+
+// extractMessagesSessionID extracts the conversation/session ID from request
+// headers for trace correlation.  Mirrors handler.extractChatSessionID.
+func extractMessagesSessionID(headers http.Header) string {
+	for _, header := range []string{"X-Claude-Code-Session-Id", "X-Session-ID", "X-Conversation-ID"} {
+		if value := strings.TrimSpace(headers.Get(header)); value != "" {
+			if len(value) > messagesSessionKeyMaxLen {
+				return value[:messagesSessionKeyMaxLen]
+			}
+			return value
+		}
+	}
+	return ""
+}
+
+const messagesSessionKeyMaxLen = 256
+
+// messagesTraceTools converts Anthropic tools to GenerationToolDefinition
+// for LLM trace.
+func messagesTraceTools(req *types.AnthropicMessagesRequest) []types.GenerationToolDefinition {
+	if req == nil || len(req.Tools) == 0 {
+		return nil
+	}
+	tools := make([]types.GenerationToolDefinition, 0, len(req.Tools))
+	for _, tool := range req.Tools {
+		schema := tool.InputSchema
+		if len(schema) == 0 {
+			schema = json.RawMessage(`{"type":"object"}`)
+		}
+		tools = append(tools, types.GenerationToolDefinition{
+			Name:        tool.Name,
+			Description: tool.Description,
+			Type:        "function",
+			InputSchema: schema,
+		})
+	}
+	return tools
+}
+
+// messagesTraceMaxTokens returns the max_tokens from the request as *int64
+// for LLM trace.
+func messagesTraceMaxTokens(req *types.AnthropicMessagesRequest) *int64 {
+	if req == nil || req.MaxTokens == 0 {
+		return nil
+	}
+	value := int64(req.MaxTokens)
+	return &value
+}
+
+// finishLLMTraceWithError records an error on the generation recorder and
+// ends it.  Mirrors handler.finishLLMTraceWithError.
+func finishLLMTraceWithError(recorder GenerationRecorder, err error, code string) {
+	if recorder == nil || err == nil {
+		return
+	}
+	recorder.SetError(err, code)
+	recorder.End()
+}
+
+// recordMessagesTraceCompletion records the generation response and usage on
+// the trace recorder.  Mirrors handler.recordChatTraceCompletion.
+func recordMessagesTraceCompletion(input tracePostProcessInput, model *types.Model, targetModelName string, usage *tokenUsage, inputMsgs []types.GenerationMessage, outputMsgs []types.GenerationMessage, traceInfo commontypes.LLMLogTraceInfo) {
+	if input.Recorder == nil {
+		return
+	}
+	provider := ""
+	if model != nil {
+		provider = model.Provider
+	}
+	firstChunkAt := time.Time{}
+	if input.Stream {
+		firstChunkAt = input.FirstWriteAt
+	}
+	input.Recorder.SetFirstChunk(types.GenerationFirstChunk{At: firstChunkAt})
+	input.Recorder.SetResponse(types.GenerationResponse{
+		Provider:      provider,
+		Model:         targetModelName,
+		ResponseModel: targetModelName,
+		Input:         inputMsgs,
+		Output:        outputMsgs,
+		ResponseID:    traceInfo.ResponseID,
+		FinishReasons: traceInfo.FinishReasons,
+	})
+	if input.StatusCode >= http.StatusBadRequest {
+		input.Recorder.SetError(httpStatusTraceError(input.StatusCode), types.TraceErrUpstreamError)
+	}
+	if usage != nil {
+		input.Recorder.SetUsage(types.TokenUsage{
+			InputTokens:           usage.PromptTokens,
+			OutputTokens:          usage.CompletionTokens,
+			TotalTokens:           usage.TotalTokens,
+			CacheReadInputTokens:  usage.CachedPromptTokens,
+			CacheWriteInputTokens: usage.CacheCreationPromptTokens,
+		})
+	}
+}
+
+func httpStatusTraceError(statusCode int) error {
+	return fmt.Errorf("HTTP %d", statusCode)
+}
+
+// llmlogMessagesToGenerationMessages converts LLMLogMessage slices to
+// GenerationMessage slices for trace.  Mirrors handler.llmlogMessagesToGenerationMessages.
+func llmlogMessagesToGenerationMessages(msgs []commontypes.LLMLogMessage) []types.GenerationMessage {
+	if len(msgs) == 0 {
+		return nil
+	}
+	result := make([]types.GenerationMessage, 0, len(msgs))
+	for _, msg := range msgs {
+		gm := convertLLMLogMessage(msg)
+		if len(gm.Parts) > 0 {
+			result = append(result, gm)
+		}
+	}
+	return result
+}
+
+func convertLLMLogMessage(msg commontypes.LLMLogMessage) types.GenerationMessage {
+	switch msg.Role {
+	case "tool_call":
+		return convertToolCallMessage(msg)
+	case "tool_response":
+		return types.GenerationMessage{
+			Role: "tool",
+			Parts: []types.GenerationPart{{
+				Kind: "text",
+				Text: msg.Content,
+			}},
+		}
+	default:
+		return convertRegularMessage(msg)
+	}
+}
+
+func convertToolCallMessage(msg commontypes.LLMLogMessage) types.GenerationMessage {
+	var tc struct {
+		Name      string `json:"name"`
+		Arguments any    `json:"arguments"`
+	}
+	if err := json.Unmarshal([]byte(msg.Content), &tc); err != nil {
+		return types.GenerationMessage{
+			Role: "assistant",
+			Parts: []types.GenerationPart{{
+				Kind: "text",
+				Text: msg.Content,
+			}},
+		}
+	}
+	return types.GenerationMessage{
+		Role: "assistant",
+		Parts: []types.GenerationPart{{
+			Kind: "tool_call",
+			ToolCall: &types.GenerationToolCall{
+				Name:      tc.Name,
+				InputJSON: llmlogToolCallInputJSON(tc.Arguments),
+			},
+		}},
+	}
+}
+
+func llmlogToolCallInputJSON(arguments any) []byte {
+	switch v := arguments.(type) {
+	case nil:
+		return nil
+	case string:
+		if v == "" {
+			return nil
+		}
+		var compacted bytes.Buffer
+		if err := json.Compact(&compacted, []byte(v)); err == nil {
+			return compacted.Bytes()
+		}
+		return []byte(v)
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			return nil
+		}
+		return data
+	}
+}
+
+func convertRegularMessage(msg commontypes.LLMLogMessage) types.GenerationMessage {
+	parts := make([]types.GenerationPart, 0, 2)
+	if msg.ReasoningContent != "" {
+		parts = append(parts, types.GenerationPart{
+			Kind:     "thinking",
+			Thinking: msg.ReasoningContent,
+		})
+	}
+	if msg.Content != "" {
+		parts = append(parts, types.GenerationPart{
+			Kind: "text",
+			Text: msg.Content,
+		})
+	}
+	return types.GenerationMessage{
+		Role:  msg.Role,
+		Parts: parts,
+	}
+}
+
+// isSuccessfulStatus returns true for HTTP 2xx status codes.
+func isSuccessfulStatus(statusCode int) bool {
+	return statusCode >= 200 && statusCode < 300
+}

--- a/aigateway/handler/anthropic_handler.go
+++ b/aigateway/handler/anthropic_handler.go
@@ -1,0 +1,84 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"opencsg.com/csghub-server/aigateway/handler/anthropic"
+	"opencsg.com/csghub-server/aigateway/handler/plan"
+	"opencsg.com/csghub-server/api/httpbase"
+	commontrace "opencsg.com/csghub-server/common/utils/trace"
+)
+
+// AnthropicHandlerImpl extends OpenAIHandlerImpl to serve the Anthropic
+// Messages API (/v1/messages).  It embeds *OpenAIHandlerImpl so it inherits
+// all OpenAI protocol infrastructure (model resolution, balance, usage limit,
+// sensitive policy, metrics, usage recording, LLM tracing, LLM log publishing)
+// without duplicating it, and adds the Anthropic-specific handler + Orchestrator
+// wiring.
+//
+// The embedded Orchestrator runs the shared three-phase flow
+// (Extract → Plan → Execute).  Future protocols (e.g. Gemini) can follow
+// the same pattern: embed *OpenAIHandlerImpl, create a protocol-specific
+// handler, and dispatch through the Orchestrator.
+type AnthropicHandlerImpl struct {
+	*OpenAIHandlerImpl
+	messagesHandler *anthropic.Handler
+	orchestrator    *plan.Orchestrator
+}
+
+// NewAnthropicHandler creates an AnthropicHandlerImpl from an existing
+// OpenAIHandlerImpl.  The OpenAI handler is embedded, so all shared
+// infrastructure (model resolution, balance, sensitive policy, metrics,
+// usage recording, LLM tracing, LLM log publishing) is reused.
+func NewAnthropicHandler(openai *OpenAIHandlerImpl) *AnthropicHandlerImpl {
+	h := &AnthropicHandlerImpl{OpenAIHandlerImpl: openai}
+
+	bridge := newMessagesHandlerBridge(openai)
+	h.messagesHandler = anthropic.New(bridge.toMessagesDeps())
+
+	mr, bc, ulc, cs := newPlannerDeps(openai)
+	h.orchestrator = plan.NewOrchestrator(plan.NewPlanner(mr, bc, ulc, cs))
+
+	return h
+}
+
+// Messages handles POST /v1/messages (Anthropic Messages API).
+// @Summary      Anthropic Messages API
+// @Description  Create a message using the Anthropic Messages API format. Supports streaming and non-streaming responses, multi-turn conversations, tool use, vision, and thinking/reasoning. Requests are routed through the shared three-phase pipeline (Extract → Plan → Execute) with preflight tracing, LLM generation tracing, and LLM training log capture.
+// @Tags         AIGateway
+// @Accept       json
+// @Produce      json
+// @Param        request  body      types.AnthropicMessagesRequest  true  "Anthropic Messages request"
+// @Success      200      {object}  types.AnthropicMessagesResponse
+// @Failure      400      {object}  types.Error
+// @Failure      402      {object}  types.Error
+// @Failure      404      {object}  types.Error
+// @Failure      429      {object}  types.Error
+// @Failure      500      {object}  types.Error
+// @Failure      503      {object}  types.Error
+// @Router       /v1/messages [post]
+func (h *AnthropicHandlerImpl) Messages(c *gin.Context) {
+	ctx := c.Request.Context()
+	nsUUID := httpbase.GetCurrentNamespaceUUID(c)
+	requestID := commontrace.GetTraceIDInGinContext(c)
+
+	// Start preflight trace span — covers Extract → Plan → Execute.
+	ctx, preflight := startPreflightTrace(ctx, preflightTraceStart{
+		API:       c.FullPath(),
+		RequestID: requestID,
+		UserID:    nsUUID,
+	})
+	c.Request = c.Request.WithContext(ctx)
+
+	// Store the preflight tracer in the gin context so the anthropic Handler
+	// can record model-resolution attributes (Execute) and errors
+	// (HandlePlanError) on the same span.
+	anthropic.SetPreflightTracer(c, &preflightTracerAdapter{trace: preflight})
+
+	// Ensure the preflight span is always ended, even if Extract fails
+	// (Orchestrator.Dispatch returns early on Extract error without calling
+	// Execute or HandlePlanError).  End() uses sync.Once so it's safe to call
+	// again if Execute or HandlePlanError already ended it.
+	defer preflight.End()
+
+	h.orchestrator.Dispatch(c, h.messagesHandler, h.messagesHandler)
+}

--- a/aigateway/handler/messages_bridge.go
+++ b/aigateway/handler/messages_bridge.go
@@ -1,0 +1,274 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"opencsg.com/csghub-server/aigateway/component"
+	"opencsg.com/csghub-server/aigateway/handler/anthropic"
+	llmtrace "opencsg.com/csghub-server/aigateway/component/trace"
+	"opencsg.com/csghub-server/aigateway/token"
+	"opencsg.com/csghub-server/aigateway/types"
+	commontypes "opencsg.com/csghub-server/common/types"
+	"opencsg.com/csghub-server/builder/proxy"
+)
+
+// messagesHandlerBridge adapts OpenAIHandlerImpl to the anthropic.Handler
+// dependency interfaces.  It delegates proxy execution, usage recording,
+// metrics recording, LLM tracing, and LLM log publishing to the existing
+// handler infrastructure.
+//
+// The Planner is constructed directly from OpenAIHandlerImpl and does not
+// go through the bridge.
+type messagesHandlerBridge struct {
+	handler *OpenAIHandlerImpl
+}
+
+// newMessagesHandlerBridge creates a bridge from an OpenAIHandlerImpl.
+func newMessagesHandlerBridge(h *OpenAIHandlerImpl) *messagesHandlerBridge {
+	return &messagesHandlerBridge{handler: h}
+}
+
+// toMessagesDeps converts the bridge into the Deps struct expected by
+// anthropic.New.  The bridge implements all required interfaces.
+func (b *messagesHandlerBridge) toMessagesDeps() anthropic.Deps {
+	deps := anthropic.Deps{
+		ProxyExecutor:   b,
+		UsageRecorder:   b,
+		UsageLimiter:    b,
+		MetricsRecorder: b,
+	}
+	if b.handler.llmTracer != nil {
+		deps.LLMTracer = &llmTracerAdapter{tracer: b.handler.llmTracer}
+	}
+	deps.LLMLogRecorderFactory = &llmLogRecorderFactoryAdapter{}
+	if b.handler.llmLogPublisher != nil {
+		deps.LLMLogPublisher = &llmLogPublisherAdapter{publisher: b.handler.llmLogPublisher}
+	}
+	return deps
+}
+
+// --- ProxyExecutor ---
+
+func (b *messagesHandlerBridge) ServeProxy(c *gin.Context, backendURL, host string, responseWriter types.HTTPResponseWriter) {
+	rp, err := proxy.NewReverseProxy(backendURL, proxy.WithoutAcceptEncoding())
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{
+			"type": "error",
+			"error": gin.H{
+				"type":    "api_error",
+				"message": "failed to create reverse proxy: " + err.Error(),
+			},
+		})
+		return
+	}
+	// Extract the path from backendURL so the reverse proxy director
+	// overrides the client's request path (e.g. /v1/messages) with the
+	// correct upstream path (e.g. /v1/chat/completions).
+	apiPath := ""
+	if parsed, perr := url.Parse(backendURL); perr == nil && parsed.Path != "" {
+		apiPath = parsed.Path
+	}
+	rp.ServeHTTP(responseWriter, c.Request, apiPath, host)
+}
+
+// --- UsageRecorder ---
+
+func (b *messagesHandlerBridge) RecordUsage(ctx context.Context, nsUUID string, model *types.Model, targetModelName string, inputTokens, outputTokens, cachedPromptTokens, cacheCreationPromptTokens int64, apikey string) error {
+	usage := &token.Usage{
+		PromptTokens:              inputTokens,
+		CompletionTokens:          outputTokens,
+		TotalTokens:               inputTokens + outputTokens,
+		CachedPromptTokens:        cachedPromptTokens,
+		CacheCreationPromptTokens: cacheCreationPromptTokens,
+	}
+	return b.handler.openaiComponent.RecordUsageFromTokenUsage(ctx, nsUUID, model, targetModelName, usage, apikey)
+}
+
+// --- UsageLimiter (commit only) ---
+
+func (b *messagesHandlerBridge) CommitUsageLimitFromUsage(ctx context.Context, nsUUID string, model *types.Model, inputTokens, outputTokens, cachedPromptTokens, cacheCreationPromptTokens int64) error {
+	usage := &token.Usage{
+		PromptTokens:              inputTokens,
+		CompletionTokens:          outputTokens,
+		TotalTokens:               inputTokens + outputTokens,
+		CachedPromptTokens:        cachedPromptTokens,
+		CacheCreationPromptTokens: cacheCreationPromptTokens,
+	}
+	return b.handler.openaiComponent.CommitUsageLimitFromUsage(ctx, nsUUID, model, usage)
+}
+
+// --- MetricsRecorder ---
+
+func (b *messagesHandlerBridge) SetModelTarget(c *gin.Context, modelID string, target *types.ModelTarget, isStream bool) {
+	var rt *resolvedModelTarget
+	if target != nil {
+		rt = &resolvedModelTarget{
+			Model:     target.Model,
+			Upstream:  target.Upstream,
+			Target:    target.Target,
+			Host:      target.Host,
+			ModelName: target.ModelName,
+		}
+	}
+	SetMetricsModelTarget(SetMetricsModelParams{
+		C:           c,
+		ModelID:     modelID,
+		ModelTarget: rt,
+		IsStream:    isStream,
+	})
+}
+
+func (b *messagesHandlerBridge) RecordTokenUsage(c *gin.Context, inputTokens, outputTokens, cachedPromptTokens int64) {
+	if inputTokens == 0 && outputTokens == 0 {
+		return
+	}
+	usage := &token.Usage{
+		PromptTokens:       inputTokens,
+		CompletionTokens:   outputTokens,
+		TotalTokens:        inputTokens + outputTokens,
+		CachedPromptTokens: cachedPromptTokens,
+	}
+	RecordMetrics(RecordMetricsParams{
+		C:     c,
+		Ctx:   c.Request.Context(),
+		Usage: usage,
+	})
+}
+
+// --- LLMTracer ---
+
+// llmTracerAdapter wraps the handler's llmtrace.LLMTracer to satisfy
+// anthropic.LLMTracer.  It selects StartGeneration or StartStreamingGeneration
+// based on the GenerationStart.Mode.
+type llmTracerAdapter struct {
+	tracer llmtrace.LLMTracer
+}
+
+func (a *llmTracerAdapter) StartGeneration(ctx context.Context, input types.GenerationStart) (context.Context, anthropic.GenerationRecorder) {
+	var start func(ctx context.Context, input types.GenerationStart) (context.Context, llmtrace.GenerationRecorder)
+	if input.Mode == types.GenerationModeStream {
+		start = a.tracer.StartStreamingGeneration
+	} else {
+		start = a.tracer.StartGeneration
+	}
+	traceCtx, recorder := start(ctx, input)
+	if traceCtx == nil {
+		traceCtx = ctx
+	}
+	if recorder == nil {
+		return traceCtx, nil
+	}
+	return traceCtx, &generationRecorderWrapper{recorder: recorder}
+}
+
+// generationRecorderWrapper adapts trace.GenerationRecorder to
+// anthropic.GenerationRecorder.
+type generationRecorderWrapper struct {
+	recorder llmtrace.GenerationRecorder
+}
+
+func (w *generationRecorderWrapper) SetUsage(usage types.TokenUsage) {
+	w.recorder.SetUsage(usage)
+}
+
+func (w *generationRecorderWrapper) SetResponse(response types.GenerationResponse) {
+	w.recorder.SetResponse(response)
+}
+
+func (w *generationRecorderWrapper) SetFirstChunk(firstChunk types.GenerationFirstChunk) {
+	w.recorder.SetFirstChunk(firstChunk)
+}
+
+func (w *generationRecorderWrapper) SetError(err error, code string) {
+	w.recorder.SetError(err, code)
+}
+
+func (w *generationRecorderWrapper) End() {
+	w.recorder.End()
+}
+
+// --- LLMLogRecorderFactory ---
+
+// llmLogRecorderFactoryAdapter wraps component.NewLLMLogRecorder to satisfy
+// anthropic.LLMLogRecorderFactory.
+type llmLogRecorderFactoryAdapter struct{}
+
+func (a *llmLogRecorderFactoryAdapter) NewLLMLogRecorder(requestID, modelID, userUUID string, req commontypes.LLMLogRequest, metadata map[string]any) (anthropic.LLMLogRecorder, error) {
+	recorder, err := component.NewLLMLogRecorder(requestID, modelID, userUUID, req, metadata)
+	if err != nil {
+		return nil, err
+	}
+	return &llmLogRecorderWrapper{recorder: recorder}, nil
+}
+
+// llmLogRecorderWrapper adapts component.LLMLogRecorder to
+// anthropic.LLMLogRecorder.
+type llmLogRecorderWrapper struct {
+	recorder component.LLMLogRecorder
+}
+
+func (w *llmLogRecorderWrapper) Completion(resp types.ChatCompletion) {
+	w.recorder.Completion(resp)
+}
+
+func (w *llmLogRecorderWrapper) AppendCompletionChunk(chunk types.ChatCompletionChunk) {
+	w.recorder.AppendCompletionChunk(chunk)
+}
+
+func (w *llmLogRecorderWrapper) Record() (*commontypes.LLMLogRecord, error) {
+	return w.recorder.Record()
+}
+
+func (w *llmLogRecorderWrapper) Messages() ([]commontypes.LLMLogMessage, []commontypes.LLMLogMessage) {
+	return w.recorder.Messages()
+}
+
+func (w *llmLogRecorderWrapper) TraceInfo() commontypes.LLMLogTraceInfo {
+	return w.recorder.TraceInfo()
+}
+
+// --- LLMLogPublisher ---
+
+// llmLogPublisherAdapter wraps component.LLMLogPublisher to satisfy
+// anthropic.LLMLogPublisher.
+type llmLogPublisherAdapter struct {
+	publisher component.LLMLogPublisher
+}
+
+func (a *llmLogPublisherAdapter) PublishTrainingLog(message []byte) error {
+	return a.publisher.PublishTrainingLog(message)
+}
+
+// --- PreflightTracer ---
+
+// preflightTracerAdapter wraps the handler's *preflightTrace to satisfy
+// anthropic.PreflightTracer.  It converts *types.ModelTarget back to
+// *resolvedModelTarget for SetTargetModel.
+type preflightTracerAdapter struct {
+	trace *preflightTrace
+}
+
+func (a *preflightTracerAdapter) RecordError(err error, errorType string) {
+	a.trace.RecordError(err, errorType)
+}
+
+func (a *preflightTracerAdapter) SetTargetModel(requestModel string, target *types.ModelTarget) {
+	var rt *resolvedModelTarget
+	if target != nil {
+		rt = &resolvedModelTarget{
+			Model:     target.Model,
+			Upstream:  target.Upstream,
+			Target:    target.Target,
+			Host:      target.Host,
+			ModelName: target.ModelName,
+		}
+	}
+	a.trace.SetTargetModel(requestModel, rt)
+}
+
+func (a *preflightTracerAdapter) End() {
+	a.trace.End()
+}

--- a/aigateway/handler/model_target.go
+++ b/aigateway/handler/model_target.go
@@ -56,6 +56,13 @@ func (e *modelTargetError) Error() string {
 	return e.APIError.Message
 }
 
+// ModelErrorCode returns the structured error code so the plan-package
+// Planner can categorize the error via errors.As(CodedError) without
+// depending on this private type.
+func (e *modelTargetError) ModelErrorCode() string {
+	return e.APIError.Code
+}
+
 type modelTargetErrorOptions struct {
 	Cause     error
 	Model     *types.Model

--- a/aigateway/handler/openai.go
+++ b/aigateway/handler/openai.go
@@ -94,7 +94,7 @@ type OpenAIHandler interface {
 	Shutdown(ctx context.Context) error
 }
 
-func NewOpenAIHandlerFromConfig(config *config.Config) (OpenAIHandler, error) {
+func NewOpenAIHandlerFromConfig(config *config.Config) (*OpenAIHandlerImpl, error) {
 	modelService, err := component.NewOpenAIComponentFromConfig(config)
 	if err != nil {
 		return nil, err
@@ -194,6 +194,7 @@ func (h *OpenAIHandlerImpl) Shutdown(ctx context.Context) error {
 	}
 	return h.llmTracer.Shutdown(ctx)
 }
+
 
 // handleInsufficientBalance returns an HTTP error before any upstream response
 // stream starts. Streaming requests must also receive a non-2xx status so

--- a/aigateway/handler/plan/interfaces.go
+++ b/aigateway/handler/plan/interfaces.go
@@ -1,0 +1,76 @@
+// Package plan defines the three-phase protocol handler architecture used by
+// the AIGateway:
+//
+//  1. ExtractMetadata (protocol-specific) — parse the request body and
+//     extract identity info.
+//  2. Plan (protocol-agnostic) — the shared Planner resolves the model target,
+//     checks balance/quota/safety, and produces a RequestPlan.  If the request
+//     must not proceed the Planner returns an error with an ErrorCode.
+//  3. Execute (protocol-specific) — the protocol handler adapts the request,
+//     proxies to the upstream, finalizes the response, and records
+//     metrics/usage.
+//
+// The Orchestrator wires these three phases together.  It owns no business
+// logic — it simply calls Extract → Plan → Execute in sequence and delegates
+// error rendering to the protocol handler.
+package plan
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+// MetadataExtractor is the protocol-specific first phase: it parses the HTTP
+// request body and extracts lightweight identity/metadata information.
+// On error the extractor MUST write the protocol-specific error response
+// to the gin context and return a non-nil error so the Orchestrator
+// short-circuits.
+type MetadataExtractor interface {
+	Extract(c *gin.Context) (*types.RequestMetadata, error)
+}
+
+// Planner is the protocol-agnostic second phase.  A single shared Planner
+// instance serves all protocols.  It resolves the model target, performs
+// routing, checks balance/quota/content-safety, and returns a RequestPlan.
+//
+// If the Planner decides the request must not proceed it returns a non-nil
+// error.  The returned RequestPlan is always non-nil (even on error) so the
+// protocol handler can read ErrorCode and any partially populated fields
+// (e.g. ModelTarget may be set even if a later check fails) to attribute
+// the error to the right model.
+type Planner interface {
+	Plan(ctx context.Context, meta *types.RequestMetadata) (*types.RequestPlan, error)
+}
+
+// ProtocolHandler is the protocol-specific third phase.  It receives the
+// RequestPlan and is responsible for:
+//   - Adapting the request for the upstream protocol (request body transform
+//     + response writer creation).
+//   - Executing the reverse proxy.
+//   - Finalizing the response and recording usage/metrics.
+//   - Rendering protocol-specific error responses when the Plan phase
+//     rejects the request.
+type ProtocolHandler interface {
+	// Execute adapts and proxies the request.  This method owns the full
+	// execution lifecycle: Adapt (request transform + writer creation),
+	// proxy, finalize, usage/metrics recording.
+	//
+	// The returned error is for logging only — by the time Execute returns
+	// the HTTP response may already be committed (e.g. after streaming
+	// begins), so the Orchestrator does not render an error response on
+	// Execute failure.
+	Execute(c *gin.Context, meta *types.RequestMetadata, p *types.RequestPlan) error
+
+	// HandlePlanError renders the protocol-specific error response for a
+	// Plan-phase rejection.  The RequestPlan's ErrorCode identifies the
+	// category (model not found, insufficient balance, quota exceeded,
+	// protocol disabled, sensitive content, etc.).
+	HandlePlanError(c *gin.Context, meta *types.RequestMetadata, p *types.RequestPlan, err error)
+}
+
+// OrchestratorInterface wires the three phases together.
+type OrchestratorInterface interface {
+	Dispatch(c *gin.Context, extractor MetadataExtractor, handler ProtocolHandler)
+}

--- a/aigateway/handler/plan/interfaces_test.go
+++ b/aigateway/handler/plan/interfaces_test.go
@@ -1,0 +1,40 @@
+package plan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+// TestInterfaceCompileAssertions verifies that the plan package interfaces
+// are satisfied by minimal stubs.  This catches accidental signature drift
+// early — if an interface method changes, the stubs here fail to compile.
+func TestInterfaceCompileAssertions(t *testing.T) {
+	var _ MetadataExtractor = (*stubExtractor2)(nil)
+	var _ Planner = (*stubPlanner2)(nil)
+	var _ ProtocolHandler = (*stubHandler2)(nil)
+	var _ OrchestratorInterface = (*Orchestrator)(nil)
+}
+
+type stubExtractor2 struct{}
+
+func (s *stubExtractor2) Extract(c *gin.Context) (*types.RequestMetadata, error) {
+	return nil, nil
+}
+
+type stubPlanner2 struct{}
+
+func (s *stubPlanner2) Plan(ctx context.Context, meta *types.RequestMetadata) (*types.RequestPlan, error) {
+	return nil, nil
+}
+
+type stubHandler2 struct{}
+
+func (s *stubHandler2) Execute(c *gin.Context, meta *types.RequestMetadata, p *types.RequestPlan) error {
+	return nil
+}
+
+func (s *stubHandler2) HandlePlanError(c *gin.Context, meta *types.RequestMetadata, p *types.RequestPlan, err error) {
+}

--- a/aigateway/handler/plan/orchestrator.go
+++ b/aigateway/handler/plan/orchestrator.go
@@ -1,0 +1,51 @@
+package plan
+
+import (
+	"log/slog"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Orchestrator wires the three phases together.  It owns no business logic:
+// it calls Extract → Plan → Execute in sequence and delegates error
+// rendering to the protocol handler.  All admission decisions (balance,
+// quota, safety, routing) live inside the Planner; the Orchestrator never
+// inspects plan fields.
+type Orchestrator struct {
+	planner Planner
+}
+
+// NewOrchestrator creates an Orchestrator backed by the given shared Planner.
+func NewOrchestrator(planner Planner) *Orchestrator {
+	return &Orchestrator{planner: planner}
+}
+
+// Dispatch runs the three-phase flow:
+//  1. extractor.Extract — protocol-specific metadata extraction
+//  2. planner.Plan — protocol-agnostic admission decisions
+//  3. handler.Execute — protocol-specific request execution
+//
+// If the Plan phase rejects the request (returns an error), the Orchestrator
+// calls HandlePlanError so the protocol handler can render its own error
+// response format.
+func (o *Orchestrator) Dispatch(c *gin.Context, extractor MetadataExtractor, handler ProtocolHandler) {
+	meta, err := extractor.Extract(c)
+	if err != nil {
+		return
+	}
+
+	p, err := o.planner.Plan(c.Request.Context(), meta)
+	if err != nil {
+		handler.HandlePlanError(c, meta, p, err)
+		return
+	}
+
+	if err := handler.Execute(c, meta, p); err != nil {
+		slog.WarnContext(c.Request.Context(), "protocol handler execute error",
+			slog.String("protocol", meta.Protocol),
+			slog.Any("error", err))
+	}
+}
+
+// Ensure Orchestrator satisfies the OrchestratorInterface.
+var _ OrchestratorInterface = (*Orchestrator)(nil)

--- a/aigateway/handler/plan/orchestrator_test.go
+++ b/aigateway/handler/plan/orchestrator_test.go
@@ -1,0 +1,152 @@
+package plan
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+// --- Test doubles ---
+
+type stubExtractor struct {
+	meta *types.RequestMetadata
+	err  error
+}
+
+func (s *stubExtractor) Extract(c *gin.Context) (*types.RequestMetadata, error) {
+	return s.meta, s.err
+}
+
+type stubHandler struct {
+	executed       bool
+	execErr        error
+	planErrorSeen  bool
+	planErrorErr   error
+	executeMeta    *types.RequestMetadata
+	executePlan    *types.RequestPlan
+	planErrorMeta  *types.RequestMetadata
+	planErrorPlan  *types.RequestPlan
+}
+
+func (s *stubHandler) Execute(c *gin.Context, meta *types.RequestMetadata, p *types.RequestPlan) error {
+	s.executed = true
+	s.executeMeta = meta
+	s.executePlan = p
+	return s.execErr
+}
+
+func (s *stubHandler) HandlePlanError(c *gin.Context, meta *types.RequestMetadata, p *types.RequestPlan, err error) {
+	s.planErrorSeen = true
+	s.planErrorErr = err
+	s.planErrorMeta = meta
+	s.planErrorPlan = p
+}
+
+type stubPlanner struct {
+	plan *types.RequestPlan
+	err  error
+}
+
+func (s *stubPlanner) Plan(ctx context.Context, meta *types.RequestMetadata) (*types.RequestPlan, error) {
+	return s.plan, s.err
+}
+
+// --- Tests ---
+
+func TestOrchestrator_ExtractError_ShortCircuits(t *testing.T) {
+	orch := NewOrchestrator(&stubPlanner{plan: &types.RequestPlan{}})
+	extractor := &stubExtractor{err: errors.New("bad request")}
+	handler := &stubHandler{}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+
+	orch.Dispatch(c, extractor, handler)
+
+	assert.False(t, handler.executed)
+	assert.False(t, handler.planErrorSeen)
+}
+
+func TestOrchestrator_PlanError_CallsHandlePlanError(t *testing.T) {
+	plan := &types.RequestPlan{ErrorCode: types.PlanErrInsufficientBalance}
+	orch := NewOrchestrator(&stubPlanner{plan: plan, err: errors.New("insufficient balance")})
+	extractor := &stubExtractor{meta: &types.RequestMetadata{Model: "test"}}
+	handler := &stubHandler{}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+
+	orch.Dispatch(c, extractor, handler)
+
+	assert.False(t, handler.executed)
+	assert.True(t, handler.planErrorSeen)
+	assert.Equal(t, plan, handler.planErrorPlan)
+	assert.NotNil(t, handler.planErrorMeta)
+}
+
+func TestOrchestrator_Success_CallsExecute(t *testing.T) {
+	plan := &types.RequestPlan{ModelTarget: &types.ModelTarget{ModelName: "test"}}
+	orch := NewOrchestrator(&stubPlanner{plan: plan})
+	extractor := &stubExtractor{meta: &types.RequestMetadata{Model: "test"}}
+	handler := &stubHandler{}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+
+	orch.Dispatch(c, extractor, handler)
+
+	assert.True(t, handler.executed)
+	assert.False(t, handler.planErrorSeen)
+	assert.Equal(t, plan, handler.executePlan)
+	assert.NotNil(t, handler.executeMeta)
+}
+
+func TestOrchestrator_ExecuteError_DoesNotCallHandlePlanError(t *testing.T) {
+	// Execute errors are logged but not routed to HandlePlanError —
+	// the protocol handler should handle its own execute errors inline.
+	plan := &types.RequestPlan{ModelTarget: &types.ModelTarget{ModelName: "test"}}
+	orch := NewOrchestrator(&stubPlanner{plan: plan})
+	extractor := &stubExtractor{meta: &types.RequestMetadata{Model: "test"}}
+	handler := &stubHandler{execErr: errors.New("proxy failed")}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+
+	orch.Dispatch(c, extractor, handler)
+
+	assert.True(t, handler.executed)
+	assert.False(t, handler.planErrorSeen)
+}
+
+func TestOrchestrator_PartialPlan_PassedToHandlePlanError(t *testing.T) {
+	// When Plan returns an error, the partially populated plan (e.g. with
+	// ModelTarget set) must be passed to HandlePlanError so the handler
+	// can attribute metrics.
+	partialPlan := &types.RequestPlan{
+		ModelTarget: &types.ModelTarget{ModelName: "resolved-model"},
+		ErrorCode:   types.PlanErrInsufficientBalance,
+	}
+	orch := NewOrchestrator(&stubPlanner{plan: partialPlan, err: errors.New("insufficient balance")})
+	extractor := &stubExtractor{meta: &types.RequestMetadata{Model: "test"}}
+	handler := &stubHandler{}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/", nil)
+
+	orch.Dispatch(c, extractor, handler)
+
+	require.True(t, handler.planErrorSeen)
+	assert.Equal(t, partialPlan, handler.planErrorPlan)
+	assert.NotNil(t, handler.planErrorPlan.ModelTarget)
+}

--- a/aigateway/handler/plan/planner.go
+++ b/aigateway/handler/plan/planner.go
@@ -1,0 +1,162 @@
+package plan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"opencsg.com/csghub-server/aigateway/component"
+	"opencsg.com/csghub-server/aigateway/handler/protocol"
+	"opencsg.com/csghub-server/aigateway/types"
+	"opencsg.com/csghub-server/common/errorx"
+)
+
+// plannerImpl is the protocol-agnostic request planner.  It is shared across
+// all inference protocols in the aigateway module: every request goes through
+// the same model resolution, routing, balance, quota, and content-safety
+// checks.
+//
+// If the Planner decides a request must not proceed (model not found,
+// insufficient balance, quota exceeded, protocol disabled, sensitive content),
+// it returns a non-nil error together with a partially populated RequestPlan
+// whose ErrorCode identifies the category.  The Orchestrator passes this to
+// the protocol handler's HandlePlanError so it can render the correct
+// protocol-specific error response.
+type plannerImpl struct {
+	modelResolver     ModelResolver
+	balanceChecker    BalanceChecker
+	usageLimitChecker UsageLimitChecker
+	contentSafety     ContentSafetyChecker
+}
+
+// NewPlanner constructs a Planner from its four dependency interfaces.
+// The handler package provides concrete adapters at the composition root.
+func NewPlanner(mr ModelResolver, bc BalanceChecker, ulc UsageLimitChecker, cs ContentSafetyChecker) Planner {
+	return &plannerImpl{
+		modelResolver:     mr,
+		balanceChecker:    bc,
+		usageLimitChecker: ulc,
+		contentSafety:     cs,
+	}
+}
+
+// Plan produces a RequestPlan from the RequestMetadata.
+func (p *plannerImpl) Plan(ctx context.Context, meta *types.RequestMetadata) (*types.RequestPlan, error) {
+	pl := &types.RequestPlan{}
+
+	// 1. Model Resolution.
+	mt, err := p.modelResolver.ResolveModelTarget(ctx, meta.UserID, meta.Model, meta.Headers)
+	if err != nil {
+		pl.ErrorCode = categorizePlanError(err)
+		return pl, err
+	}
+	if mt == nil {
+		pl.ErrorCode = types.PlanErrModelNotFound
+		return pl, fmt.Errorf("model '%s' not found", meta.Model)
+	}
+	pl.ModelTarget = mt
+
+	// 2. Protocol Routing.
+	decision, err := protocol.ResolveRouting(types.Protocol(meta.Protocol), protocol.RoutingTarget{
+		ModelID:          mt.Model.ID,
+		Target:           mt.Target,
+		CSGHubHosted:     mt.Model.SvcName != "",
+		RuntimeFramework: mt.Model.RuntimeFramework,
+		ImageID:          mt.Model.ImageID,
+		UpstreamMetadata: mt.Upstream.Metadata,
+	})
+	if err != nil {
+		pl.ErrorCode = types.PlanErrUnknown
+		return pl, err
+	}
+	pl.RouteMode = string(decision.Mode)
+	pl.AdapterKind = string(decision.AdapterKind)
+	pl.UpstreamProtocol = string(decision.UpstreamProtocol)
+	if decision.Mode == protocol.ModeAdapter {
+		pl.UpstreamCap = types.CapabilityFor(decision.UpstreamProtocol)
+	}
+
+	// 3. Disabled — return error so the Orchestrator routes to HandlePlanError.
+	// No need to check balance/quota/safety for a rejected request.
+	if decision.Mode == protocol.ModeDisabled {
+		pl.ErrorCode = types.PlanErrDisabled
+		pl.BackendURL = mt.Target
+		return pl, fmt.Errorf("protocol %s is not available for this model", meta.Protocol)
+	}
+
+	// 4. Balance check (respects SkipBalance).
+	if !mt.Model.SkipBalance() {
+		if err := p.balanceChecker.CheckBalance(ctx, meta.TenantID); err != nil {
+			pl.ErrorCode = categorizePlanError(err)
+			return pl, err
+		}
+	}
+	pl.BalanceOK = true
+
+	// 5. Resolve backend URL.
+	pl.BackendURL = decision.BackendURL
+	if pl.BackendURL == "" {
+		pl.BackendURL = mt.Target
+	}
+
+	// 6. Usage-limit check.
+	if err := p.usageLimitChecker.CheckUsageLimit(ctx, meta.TenantID, mt.Model, pl.BackendURL); err != nil {
+		pl.ErrorCode = categorizePlanError(err)
+		return pl, err
+	}
+	pl.UsageLimitOK = true
+
+	// 7. Content-safety check (input).
+	promptText := meta.PromptText()
+	if promptText != "" {
+		isSensitive, message, checkErr := p.contentSafety.Check(
+			ctx, mt.Model, promptText, meta.TenantID, meta.Streaming, mt.Upstream.Provider,
+		)
+		if checkErr != nil {
+			slog.WarnContext(ctx, "planner sensitive check error", slog.Any("error", checkErr))
+		} else if isSensitive {
+			pl.Safety = &types.SafetyDecision{IsSensitive: true, Message: message}
+			pl.ErrorCode = types.PlanErrSensitive
+			return pl, fmt.Errorf("content blocked due to safety policy")
+		}
+	}
+
+	return pl, nil
+}
+
+// Ensure plannerImpl satisfies the Planner interface.
+var _ Planner = (*plannerImpl)(nil)
+
+// categorizePlanError inspects a Plan-phase error and returns its category.
+// Protocol handlers use this to select the correct HTTP status and error type.
+func categorizePlanError(err error) types.PlanErrorCategory {
+	if err == nil {
+		return types.PlanErrUnknown
+	}
+
+	// Check for CodedError (model not found, not running, unavailable, etc.).
+	var ce CodedError
+	if errors.As(err, &ce) {
+		switch ce.ModelErrorCode() {
+		case "model_not_found", "model_not_running":
+			return types.PlanErrModelNotFound
+		case "model_unavailable", "required_upstream_unavailable":
+			return types.PlanErrModelUnavailable
+		case "internal_error", "cluster_not_found":
+			return types.PlanErrInternal
+		}
+	}
+
+	// Check for insufficient balance.
+	if errors.Is(err, errorx.ErrInsufficientBalance) {
+		return types.PlanErrInsufficientBalance
+	}
+
+	// Check for usage limit exceeded.
+	if component.IsUsageLimitExceeded(err) {
+		return types.PlanErrUsageLimitExceeded
+	}
+
+	return types.PlanErrUnknown
+}

--- a/aigateway/handler/plan/planner_deps.go
+++ b/aigateway/handler/plan/planner_deps.go
@@ -1,0 +1,41 @@
+package plan
+
+import (
+	"context"
+	"net/http"
+
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+// ModelResolver resolves a model ID to a concrete upstream target.
+// The handler package provides an adapter that wraps its private
+// resolveModelTarget and converts to *types.ModelTarget.
+type ModelResolver interface {
+	ResolveModelTarget(ctx context.Context, username, modelID string, headers http.Header) (*types.ModelTarget, error)
+}
+
+// BalanceChecker verifies that the tenant has sufficient balance.
+type BalanceChecker interface {
+	CheckBalance(ctx context.Context, nsUUID string) error
+}
+
+// UsageLimitChecker verifies that the tenant has not exceeded usage quota.
+type UsageLimitChecker interface {
+	CheckUsageLimit(ctx context.Context, nsUUID string, model *types.Model, endpoint string) error
+}
+
+// ContentSafetyChecker checks prompt text for sensitive content.
+// Returns (isSensitive, message, error). The handler adapter converts
+// *rpc.CheckResult to this simplified contract so the Planner never
+// depends on the rpc package.
+type ContentSafetyChecker interface {
+	Check(ctx context.Context, model *types.Model, promptText, tenantID string, streaming bool, provider string) (bool, string, error)
+}
+
+// CodedError is implemented by errors that carry a structured error code.
+// The handler package's modelTargetError implements this method so the
+// Planner can categorize errors via errors.As without depending on the
+// concrete private type.
+type CodedError interface {
+	ModelErrorCode() string
+}

--- a/aigateway/handler/plan/planner_test.go
+++ b/aigateway/handler/plan/planner_test.go
@@ -1,0 +1,437 @@
+package plan
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/component"
+	"opencsg.com/csghub-server/aigateway/handler/protocol"
+	"opencsg.com/csghub-server/aigateway/types"
+	"opencsg.com/csghub-server/common/errorx"
+	commonType "opencsg.com/csghub-server/common/types"
+)
+
+// --- Mock implementations ---
+
+type mockModelResolver struct {
+	target *types.ModelTarget
+	err    error
+}
+
+func (m *mockModelResolver) ResolveModelTarget(ctx context.Context, username, modelID string, headers http.Header) (*types.ModelTarget, error) {
+	return m.target, m.err
+}
+
+type mockBalanceChecker struct {
+	err error
+}
+
+func (m *mockBalanceChecker) CheckBalance(ctx context.Context, nsUUID string) error {
+	return m.err
+}
+
+type mockUsageLimitChecker struct {
+	err error
+}
+
+func (m *mockUsageLimitChecker) CheckUsageLimit(ctx context.Context, nsUUID string, model *types.Model, endpoint string) error {
+	return m.err
+}
+
+type mockContentSafetyChecker struct {
+	isSensitive bool
+	message     string
+	err         error
+}
+
+func (m *mockContentSafetyChecker) Check(ctx context.Context, model *types.Model, promptText, tenantID string, streaming bool, provider string) (bool, string, error) {
+	return m.isSensitive, m.message, m.err
+}
+
+// codedErrStub is a minimal CodedError implementation for categorizePlanError tests.
+type codedErrStub struct {
+	code string
+}
+
+func (e *codedErrStub) Error() string         { return e.code }
+func (e *codedErrStub) ModelErrorCode() string { return e.code }
+
+func makeResolvedTarget(targetURL, upstreamProtocol string) *types.ModelTarget {
+	meta := map[string]any{}
+	if upstreamProtocol != "" {
+		meta["protocol"] = upstreamProtocol
+	}
+	return &types.ModelTarget{
+		Model: &types.Model{
+			BaseModel: types.BaseModel{ID: "test-model"},
+		},
+		Upstream: commonType.UpstreamConfig{
+			URL:      targetURL,
+			Provider: "test",
+			Metadata: meta,
+		},
+		Target:    targetURL,
+		ModelName: "test-model",
+	}
+}
+
+type promptTextProvider struct {
+	text string
+}
+
+func (p *promptTextProvider) PromptText() string { return p.text }
+
+// --- categorizePlanError tests ---
+
+func TestCategorizePlanError_Nil(t *testing.T) {
+	assert.Equal(t, types.PlanErrUnknown, categorizePlanError(nil))
+}
+
+func TestCategorizePlanError_ModelNotFound(t *testing.T) {
+	err := &codedErrStub{code: "model_not_found"}
+	assert.Equal(t, types.PlanErrModelNotFound, categorizePlanError(err))
+}
+
+func TestCategorizePlanError_ModelNotRunning(t *testing.T) {
+	err := &codedErrStub{code: "model_not_running"}
+	assert.Equal(t, types.PlanErrModelNotFound, categorizePlanError(err))
+}
+
+func TestCategorizePlanError_ModelUnavailable(t *testing.T) {
+	err := &codedErrStub{code: "model_unavailable"}
+	assert.Equal(t, types.PlanErrModelUnavailable, categorizePlanError(err))
+}
+
+func TestCategorizePlanError_RequiredUpstreamUnavailable(t *testing.T) {
+	err := &codedErrStub{code: "required_upstream_unavailable"}
+	assert.Equal(t, types.PlanErrModelUnavailable, categorizePlanError(err))
+}
+
+func TestCategorizePlanError_InsufficientBalance(t *testing.T) {
+	err := errorx.ErrInsufficientBalance
+	assert.Equal(t, types.PlanErrInsufficientBalance, categorizePlanError(err))
+}
+
+func TestCategorizePlanError_WrappedInsufficientBalance(t *testing.T) {
+	err := errors.Join(errorx.ErrInsufficientBalance, errors.New("extra"))
+	assert.Equal(t, types.PlanErrInsufficientBalance, categorizePlanError(err))
+}
+
+func TestCategorizePlanError_UsageLimitExceeded(t *testing.T) {
+	err := &component.UsageLimitExceededError{Message: "quota exceeded"}
+	assert.Equal(t, types.PlanErrUsageLimitExceeded, categorizePlanError(err))
+}
+
+func TestCategorizePlanError_WrappedUsageLimit(t *testing.T) {
+	inner := &component.UsageLimitExceededError{Message: "quota exceeded"}
+	err := errors.Join(inner, errors.New("ctx"))
+	assert.Equal(t, types.PlanErrUsageLimitExceeded, categorizePlanError(err))
+}
+
+func TestCategorizePlanError_UnknownError(t *testing.T) {
+	err := errors.New("some random error")
+	assert.Equal(t, types.PlanErrUnknown, categorizePlanError(err))
+}
+
+func TestCategorizePlanError_UnknownCodedError(t *testing.T) {
+	err := &codedErrStub{code: "some_other_code"}
+	assert.Equal(t, types.PlanErrUnknown, categorizePlanError(err))
+}
+
+func TestCategorizePlanError_WrappedCodedError(t *testing.T) {
+	inner := &codedErrStub{code: "model_not_found"}
+	wrapped := errors.Join(inner, errors.New("additional context"))
+	assert.Equal(t, types.PlanErrModelNotFound, categorizePlanError(wrapped))
+}
+
+// --- Plan orchestration tests ---
+
+func TestPlan_Success_Native(t *testing.T) {
+	p := NewPlanner(
+		&mockModelResolver{target: makeResolvedTarget("http://upstream/v1/messages", "")},
+		&mockBalanceChecker{},
+		&mockUsageLimitChecker{},
+		&mockContentSafetyChecker{},
+	)
+
+	meta := &types.RequestMetadata{
+		Protocol:   string(types.ProtocolMessages),
+		UserID:     "user1",
+		Model:      "test-model",
+		TenantID:   "ns-123",
+		ParsedBody: &promptTextProvider{text: "hello"},
+	}
+
+	plan, err := p.Plan(context.Background(), meta)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	assert.NotNil(t, plan.ModelTarget)
+	assert.Equal(t, "test-model", plan.ModelTarget.ModelName)
+	assert.True(t, plan.BalanceOK)
+	assert.True(t, plan.UsageLimitOK)
+	assert.Nil(t, plan.Safety)
+}
+
+func TestPlan_Success_NoPromptText_SkipsSafety(t *testing.T) {
+	p := NewPlanner(
+		&mockModelResolver{target: makeResolvedTarget("http://upstream/v1/messages", "")},
+		&mockBalanceChecker{},
+		&mockUsageLimitChecker{},
+		&mockContentSafetyChecker{isSensitive: true, message: "blocked"},
+	)
+
+	meta := &types.RequestMetadata{
+		Protocol:   string(types.ProtocolMessages),
+		UserID:     "user1",
+		Model:      "test-model",
+		TenantID:   "ns-123",
+		ParsedBody: nil,
+	}
+
+	plan, err := p.Plan(context.Background(), meta)
+	require.NoError(t, err)
+	assert.Nil(t, plan.Safety)
+}
+
+func TestPlan_Sensitive_Flagged(t *testing.T) {
+	p := NewPlanner(
+		&mockModelResolver{target: makeResolvedTarget("http://upstream/v1/messages", "")},
+		&mockBalanceChecker{},
+		&mockUsageLimitChecker{},
+		&mockContentSafetyChecker{isSensitive: true, message: "blocked content"},
+	)
+
+	meta := &types.RequestMetadata{
+		Protocol:   string(types.ProtocolMessages),
+		UserID:     "user1",
+		Model:      "test-model",
+		TenantID:   "ns-123",
+		ParsedBody: &promptTextProvider{text: "sensitive text"},
+	}
+
+	plan, err := p.Plan(context.Background(), meta)
+	require.Error(t, err)
+	require.NotNil(t, plan)
+
+	assert.Equal(t, types.PlanErrSensitive, plan.ErrorCode)
+	require.NotNil(t, plan.Safety)
+	assert.True(t, plan.Safety.IsSensitive)
+	assert.Equal(t, "blocked content", plan.Safety.Message)
+}
+
+func TestPlan_SafetyCheckError_DoesNotBlock(t *testing.T) {
+	p := NewPlanner(
+		&mockModelResolver{target: makeResolvedTarget("http://upstream/v1/messages", "")},
+		&mockBalanceChecker{},
+		&mockUsageLimitChecker{},
+		&mockContentSafetyChecker{err: errors.New("moderation unavailable")},
+	)
+
+	meta := &types.RequestMetadata{
+		Protocol:   string(types.ProtocolMessages),
+		UserID:     "user1",
+		Model:      "test-model",
+		TenantID:   "ns-123",
+		ParsedBody: &promptTextProvider{text: "hello"},
+	}
+
+	plan, err := p.Plan(context.Background(), meta)
+	require.NoError(t, err)
+	assert.Nil(t, plan.Safety)
+	assert.True(t, plan.BalanceOK)
+	assert.True(t, plan.UsageLimitOK)
+}
+
+func TestPlan_ModelNotFound(t *testing.T) {
+	p := NewPlanner(
+		&mockModelResolver{err: &codedErrStub{code: "model_not_found"}},
+		&mockBalanceChecker{},
+		&mockUsageLimitChecker{},
+		&mockContentSafetyChecker{},
+	)
+
+	meta := &types.RequestMetadata{
+		Protocol: string(types.ProtocolMessages),
+		UserID:   "user1",
+		Model:    "unknown",
+		TenantID: "ns-123",
+	}
+
+	plan, err := p.Plan(context.Background(), meta)
+	require.Error(t, err)
+	assert.Equal(t, types.PlanErrModelNotFound, plan.ErrorCode)
+	assert.Nil(t, plan.ModelTarget)
+}
+
+func TestPlan_ModelNilResolution(t *testing.T) {
+	p := NewPlanner(
+		&mockModelResolver{target: nil, err: nil},
+		&mockBalanceChecker{},
+		&mockUsageLimitChecker{},
+		&mockContentSafetyChecker{},
+	)
+
+	meta := &types.RequestMetadata{
+		Protocol: string(types.ProtocolMessages),
+		UserID:   "user1",
+		Model:    "unknown",
+		TenantID: "ns-123",
+	}
+
+	plan, err := p.Plan(context.Background(), meta)
+	require.Error(t, err)
+	assert.Equal(t, types.PlanErrModelNotFound, plan.ErrorCode)
+}
+
+func TestPlan_ModelUnavailable(t *testing.T) {
+	p := NewPlanner(
+		&mockModelResolver{err: &codedErrStub{code: "model_unavailable"}},
+		&mockBalanceChecker{},
+		&mockUsageLimitChecker{},
+		&mockContentSafetyChecker{},
+	)
+
+	meta := &types.RequestMetadata{
+		Protocol: string(types.ProtocolMessages),
+		UserID:   "user1",
+		Model:    "test-model",
+		TenantID: "ns-123",
+	}
+
+	plan, err := p.Plan(context.Background(), meta)
+	require.Error(t, err)
+	assert.Equal(t, types.PlanErrModelUnavailable, plan.ErrorCode)
+}
+
+func TestPlan_InsufficientBalance(t *testing.T) {
+	p := NewPlanner(
+		&mockModelResolver{target: makeResolvedTarget("http://upstream/v1/messages", "")},
+		&mockBalanceChecker{err: errorx.ErrInsufficientBalance},
+		&mockUsageLimitChecker{},
+		&mockContentSafetyChecker{},
+	)
+
+	meta := &types.RequestMetadata{
+		Protocol: string(types.ProtocolMessages),
+		UserID:   "user1",
+		Model:    "test-model",
+		TenantID: "ns-123",
+	}
+
+	plan, err := p.Plan(context.Background(), meta)
+	require.Error(t, err)
+	assert.Equal(t, types.PlanErrInsufficientBalance, plan.ErrorCode)
+	assert.NotNil(t, plan.ModelTarget)
+	assert.False(t, plan.BalanceOK)
+}
+
+func TestPlan_UsageLimitExceeded(t *testing.T) {
+	p := NewPlanner(
+		&mockModelResolver{target: makeResolvedTarget("http://upstream/v1/messages", "")},
+		&mockBalanceChecker{},
+		&mockUsageLimitChecker{err: &component.UsageLimitExceededError{Message: "quota exceeded"}},
+		&mockContentSafetyChecker{},
+	)
+
+	meta := &types.RequestMetadata{
+		Protocol: string(types.ProtocolMessages),
+		UserID:   "user1",
+		Model:    "test-model",
+		TenantID: "ns-123",
+	}
+
+	plan, err := p.Plan(context.Background(), meta)
+	require.Error(t, err)
+	assert.Equal(t, types.PlanErrUsageLimitExceeded, plan.ErrorCode)
+	assert.True(t, plan.BalanceOK)
+	assert.False(t, plan.UsageLimitOK)
+}
+
+func TestPlan_Disabled_ReturnsError(t *testing.T) {
+	// Chat → Responses has no adapter (AdapterNone), so routing resolves
+	// to "disabled".  The Planner should return an error with PlanErrDisabled
+	// and NOT check balance/quota/safety.
+	target := &types.ModelTarget{
+		Model: &types.Model{
+			BaseModel: types.BaseModel{ID: "test-model"},
+		},
+		Upstream: commonType.UpstreamConfig{
+			URL:      "http://upstream/v1/responses",
+			Provider: "test",
+			Metadata: map[string]any{"protocol": "responses"},
+		},
+		Target:    "http://upstream/v1/responses",
+		ModelName: "test-model",
+	}
+
+	p := NewPlanner(
+		&mockModelResolver{target: target},
+		&mockBalanceChecker{err: errors.New("balance should not be checked")},
+		&mockUsageLimitChecker{},
+		&mockContentSafetyChecker{},
+	)
+
+	meta := &types.RequestMetadata{
+		Protocol: string(types.ProtocolChat),
+		UserID:   "user1",
+		Model:    "test-model",
+		TenantID: "ns-123",
+	}
+
+	plan, err := p.Plan(context.Background(), meta)
+	require.Error(t, err)
+	assert.Equal(t, types.PlanErrDisabled, plan.ErrorCode)
+	// Balance check should not have been called
+	assert.False(t, plan.BalanceOK)
+}
+
+func TestPlan_BackendURLFallback(t *testing.T) {
+	target := makeResolvedTarget("http://upstream/v1/messages", "")
+	p := NewPlanner(
+		&mockModelResolver{target: target},
+		&mockBalanceChecker{},
+		&mockUsageLimitChecker{},
+		&mockContentSafetyChecker{},
+	)
+
+	meta := &types.RequestMetadata{
+		Protocol: string(types.ProtocolMessages),
+		UserID:   "user1",
+		Model:    "test-model",
+		TenantID: "ns-123",
+	}
+
+	plan, err := p.Plan(context.Background(), meta)
+	require.NoError(t, err)
+	assert.NotEmpty(t, plan.BackendURL)
+}
+
+func TestPlan_RoutingFieldsPopulated(t *testing.T) {
+	target := makeResolvedTarget("http://upstream/v1/chat/completions", "")
+	p := NewPlanner(
+		&mockModelResolver{target: target},
+		&mockBalanceChecker{},
+		&mockUsageLimitChecker{},
+		&mockContentSafetyChecker{},
+	)
+
+	meta := &types.RequestMetadata{
+		Protocol: string(types.ProtocolMessages),
+		UserID:   "user1",
+		Model:    "test-model",
+		TenantID: "ns-123",
+	}
+
+	plan, err := p.Plan(context.Background(), meta)
+	require.NoError(t, err)
+
+	// Messages protocol with a chat upstream → adapter mode
+	assert.Equal(t, string(protocol.ModeAdapter), plan.RouteMode)
+	assert.NotEmpty(t, plan.AdapterKind)
+	assert.NotEmpty(t, plan.UpstreamProtocol)
+}

--- a/aigateway/handler/planner_adapter.go
+++ b/aigateway/handler/planner_adapter.go
@@ -1,0 +1,70 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"opencsg.com/csghub-server/aigateway/component"
+	"opencsg.com/csghub-server/aigateway/handler/plan"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+// modelResolverAdapter wraps OpenAIHandlerImpl.resolveModelTarget to satisfy
+// plan.ModelResolver.  It converts the handler-private *resolvedModelTarget
+// to the public *types.ModelTarget so the Planner never depends on handler
+// internals.
+type modelResolverAdapter struct {
+	handler *OpenAIHandlerImpl
+}
+
+func (a *modelResolverAdapter) ResolveModelTarget(ctx context.Context, username, modelID string, headers http.Header) (*types.ModelTarget, error) {
+	resolved, err := a.handler.resolveModelTarget(ctx, username, modelID, headers)
+	if err != nil {
+		return nil, err
+	}
+	return toTypesModelTarget(resolved), nil
+}
+
+// contentSafetyAdapter wraps the existing sensitive policy (which exposes the
+// Responses-named method CheckResponsesSensitive) to satisfy
+// plan.ContentSafetyChecker.  It returns a simplified (bool, string, error)
+// contract so the Planner never depends on *rpc.CheckResult.
+type contentSafetyAdapter struct {
+	policy component.SensitivePolicy
+}
+
+func (a *contentSafetyAdapter) Check(ctx context.Context, model *types.Model, promptText, tenantID string, streaming bool, provider string) (bool, string, error) {
+	shouldCheck, result, err := a.policy.CheckResponsesSensitive(ctx, model, promptText, tenantID, streaming, provider)
+	if err != nil {
+		return false, "", err
+	}
+	if result == nil {
+		return false, "", nil
+	}
+	return shouldCheck && result.IsSensitive, result.Reason, nil
+}
+
+// newPlannerDeps builds the four dependency interfaces needed by
+// plan.NewPlanner from an OpenAIHandlerImpl.
+func newPlannerDeps(h *OpenAIHandlerImpl) (plan.ModelResolver, plan.BalanceChecker, plan.UsageLimitChecker, plan.ContentSafetyChecker) {
+	return &modelResolverAdapter{handler: h},
+		h.openaiComponent,
+		h.openaiComponent,
+		&contentSafetyAdapter{policy: h.sensitivePolicy}
+}
+
+// toTypesModelTarget converts the handler-package-private resolvedModelTarget
+// to the types-package ModelTarget.
+func toTypesModelTarget(r *resolvedModelTarget) *types.ModelTarget {
+	if r == nil {
+		return nil
+	}
+	return &types.ModelTarget{
+		Model:          r.Model,
+		Upstream:       r.Upstream,
+		Target:         r.Target,
+		Host:           r.Host,
+		ModelName:      r.ModelName,
+		AttemptTargets: r.AttemptTargets,
+	}
+}

--- a/aigateway/handler/planner_adapter_test.go
+++ b/aigateway/handler/planner_adapter_test.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/types"
+	commonType "opencsg.com/csghub-server/common/types"
+)
+
+func TestToTypesModelTarget_Nil(t *testing.T) {
+	assert.Nil(t, toTypesModelTarget(nil))
+}
+
+func TestToTypesModelTarget_FullConversion(t *testing.T) {
+	model := &types.Model{BaseModel: types.BaseModel{ID: "model-1"}}
+	upstream := commonType.UpstreamConfig{URL: "http://upstream", Provider: "test"}
+	attempts := []commonType.UpstreamConfig{{URL: "http://fallback"}}
+
+	r := &resolvedModelTarget{
+		Model:          model,
+		Upstream:       upstream,
+		Target:         "http://upstream/v1/messages",
+		Host:           "upstream",
+		ModelName:      "model-1",
+		AttemptTargets: attempts,
+	}
+
+	mt := toTypesModelTarget(r)
+	require.NotNil(t, mt)
+	assert.Equal(t, model, mt.Model)
+	assert.Equal(t, upstream, mt.Upstream)
+	assert.Equal(t, "http://upstream/v1/messages", mt.Target)
+	assert.Equal(t, "upstream", mt.Host)
+	assert.Equal(t, "model-1", mt.ModelName)
+	assert.Equal(t, attempts, mt.AttemptTargets)
+}
+
+func TestModelTargetError_ImplementsCodedError(t *testing.T) {
+	// Verify that modelTargetError implements plan.CodedError via ModelErrorCode().
+	// This is checked at compile time by the errors.As call in categorizePlanError.
+	err := newInvalidRequestModelTargetError("model_not_found", "model not found", modelTargetErrorOptions{})
+	assert.Equal(t, "model_not_found", err.ModelErrorCode())
+
+	err2 := newServerModelTargetError("model_unavailable", "unavailable", modelTargetErrorOptions{})
+	assert.Equal(t, "model_unavailable", err2.ModelErrorCode())
+}

--- a/aigateway/handler/protocol/adapt.go
+++ b/aigateway/handler/protocol/adapt.go
@@ -1,0 +1,315 @@
+// Package protocol provides the unified routing resolver that decides how a
+// client request should be executed against an upstream endpoint.  The core
+// concept is a protocol matrix: when the client protocol matches the upstream
+// protocol the request is forwarded natively; otherwise an adapter is selected
+// to translate between protocols.  If no adapter exists the request is rejected
+// with a clear error rather than silently dropping parameters.
+//
+// Strategy: Native > Adapter > Reject.
+package protocol
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"opencsg.com/csghub-server/aigateway/types"
+	commonutils "opencsg.com/csghub-server/common/utils/common"
+)
+
+// ExecutionMode describes how a request should be executed.
+type ExecutionMode string
+
+const (
+	ModeNative   ExecutionMode = "native"
+	ModeAdapter  ExecutionMode = "adapter"
+	ModeDisabled ExecutionMode = "disabled"
+)
+
+// AdapterKind identifies which adapter is needed when Mode == adapter.
+type AdapterKind string
+
+const (
+	AdapterNone                AdapterKind = ""
+	AdapterResponsesToChat     AdapterKind = "responses_to_chat"
+	AdapterMessagesToChat      AdapterKind = "messages_to_chat"
+	AdapterMessagesToResponses AdapterKind = "messages_to_responses"
+	// Future adapters (not yet implemented):
+	//   AdapterChatToMessages    AdapterKind = "chat_to_messages"
+	//   AdapterResponsesToMessages AdapterKind = "responses_to_messages"
+	//   AdapterChatToResponses   AdapterKind = "chat_to_responses"
+)
+
+// RoutingDecision is the output of ResolveRouting.
+type RoutingDecision struct {
+	Mode             ExecutionMode
+	AdapterKind      AdapterKind
+	BackendURL       string       // the URL to send the upstream request to
+	UpstreamProtocol types.Protocol
+	Reason           string
+}
+
+// RoutingTarget carries the information needed to detect the upstream protocol
+// and compute the backend URL.
+type RoutingTarget struct {
+	ModelID          string
+	Target           string // upstream URL
+	CSGHubHosted     bool
+	RuntimeFramework string
+	ImageID          string
+	UpstreamMetadata map[string]any
+}
+
+// adapterMatrix defines which adapter to use for each (client, upstream) pair.
+// A zero AdapterKind means no adapter is available.
+var adapterMatrix = map[types.Protocol]map[types.Protocol]AdapterKind{
+	types.ProtocolChat: {
+		types.ProtocolResponses: AdapterNone,
+		types.ProtocolMessages:  AdapterNone,
+	},
+	types.ProtocolResponses: {
+		types.ProtocolChat:     AdapterResponsesToChat,
+		types.ProtocolMessages: AdapterNone,
+	},
+	types.ProtocolMessages: {
+		types.ProtocolChat:      AdapterMessagesToChat,
+		types.ProtocolResponses: AdapterMessagesToResponses,
+	},
+}
+
+// ResolveRouting determines how a client request should be routed to the
+// upstream endpoint.  The decision follows the Native > Adapter > Reject
+// strategy.
+func ResolveRouting(clientProtocol types.Protocol, target RoutingTarget) (RoutingDecision, error) {
+	if strings.TrimSpace(target.Target) == "" && !target.CSGHubHosted {
+		return RoutingDecision{}, fmt.Errorf("upstream target is empty")
+	}
+
+	upstreamProtocol := DetectUpstreamProtocol(target)
+
+	// When the upstream protocol cannot be determined from metadata or URL
+	// (step 4 fallback in DetectUpstreamProtocol), and the model is not
+	// CSGHub-hosted, prefer the client's own protocol so the request takes
+	// the native passthrough path.  This avoids wrongly adapting a Messages
+	// request to Chat when the upstream is actually Anthropic-native (e.g.
+	// an external endpoint whose URL does not end in /v1/messages).
+	// CSGHub-hosted models always use vLLM/SGLang which speak Chat, so they
+	// keep the Chat default regardless of the client protocol.
+	if upstreamProtocol == types.ProtocolChat && !target.CSGHubHosted &&
+		clientProtocol != types.ProtocolChat &&
+		!hasExplicitProtocolMetadata(target) {
+		if _, inferred := inferProtocolFromURL(target.Target); !inferred {
+			upstreamProtocol = clientProtocol
+		}
+	}
+
+	if clientProtocol == upstreamProtocol {
+		return RoutingDecision{
+			Mode:             ModeNative,
+			BackendURL:       adaptBackendURL(target, upstreamProtocol),
+			UpstreamProtocol: upstreamProtocol,
+			Reason:           "protocol_match",
+		}, nil
+	}
+
+	adapterKind := pickAdapter(clientProtocol, upstreamProtocol)
+	if adapterKind == AdapterNone {
+		return RoutingDecision{
+			Mode:             ModeDisabled,
+			UpstreamProtocol: upstreamProtocol,
+			Reason:           fmt.Sprintf("no_adapter_for_%s_to_%s", clientProtocol, upstreamProtocol),
+		}, nil
+	}
+
+	backendURL := adaptBackendURL(target, upstreamProtocol)
+	return RoutingDecision{
+		Mode:             ModeAdapter,
+		AdapterKind:      adapterKind,
+		BackendURL:       backendURL,
+		UpstreamProtocol: upstreamProtocol,
+		Reason:           fmt.Sprintf("adapter:%s", adapterKind),
+	}, nil
+}
+
+// DetectUpstreamProtocol determines the protocol of an upstream endpoint.
+// Priority: explicit metadata declaration > URL path inference >
+// CSGHub runtime defaults > fallback to Chat.
+//
+// Note: the Chat fallback for non-CSGHub-hosted external upstreams whose
+// protocol cannot be inferred from the URL is overridden in ResolveRouting,
+// which prefers the client protocol (native passthrough) in that case.
+func DetectUpstreamProtocol(target RoutingTarget) types.Protocol {
+	// 1. Explicit declaration in upstream metadata.
+	if target.UpstreamMetadata != nil {
+		if p, ok := target.UpstreamMetadata["protocol"].(string); ok {
+			p = strings.TrimSpace(strings.ToLower(p))
+			switch types.Protocol(p) {
+			case types.ProtocolChat, types.ProtocolResponses, types.ProtocolMessages:
+				return types.Protocol(p)
+			}
+		}
+	}
+
+	// 2. URL path inference.
+	if proto, ok := inferProtocolFromURL(target.Target); ok {
+		return proto
+	}
+
+	// 3. CSGHub-hosted models default to Chat (vLLM/SGLang).
+	if target.CSGHubHosted {
+		return types.ProtocolChat
+	}
+
+	// 4. Fallback: Chat is the most widely compatible protocol.
+	return types.ProtocolChat
+}
+
+// hasExplicitProtocolMetadata returns true when the upstream metadata contains
+// a valid "protocol" key.  This is used by ResolveRouting to distinguish an
+// explicit Chat declaration (which must be respected) from the Chat fallback
+// default (which can be overridden to prefer native passthrough).
+func hasExplicitProtocolMetadata(target RoutingTarget) bool {
+	if target.UpstreamMetadata == nil {
+		return false
+	}
+	p, ok := target.UpstreamMetadata["protocol"].(string)
+	if !ok {
+		return false
+	}
+	p = strings.TrimSpace(strings.ToLower(p))
+	switch types.Protocol(p) {
+	case types.ProtocolChat, types.ProtocolResponses, types.ProtocolMessages:
+		return true
+	}
+	return false
+}
+
+// inferProtocolFromURL inspects the URL path to guess the protocol.
+func inferProtocolFromURL(rawURL string) (types.Protocol, bool) {
+	if strings.TrimSpace(rawURL) == "" {
+		return "", false
+	}
+	// url.Parse interprets a bare host:port/path as scheme=host, so
+	// prepend a scheme when absent to ensure the path is parsed correctly.
+	if !strings.Contains(rawURL, "://") {
+		rawURL = "http://" + rawURL
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", false
+	}
+	path := strings.TrimRight(parsed.Path, "/")
+	switch {
+	case pathEndsWithSegments(path, "messages"), pathEndsWithSegments(path, "anthropic"):
+		return types.ProtocolMessages, true
+	case pathEndsWithSegments(path, "responses"):
+		return types.ProtocolResponses, true
+	case pathEndsWithSegments(path, "chat", "completions"):
+		return types.ProtocolChat, true
+	}
+	return "", false
+}
+
+// adaptBackendURL rewrites the upstream URL to point at the correct path for
+// the detected upstream protocol.  For external upstreams the URL is already
+// correct (it was configured with the right path).  For CSGHub-hosted models
+// the URL may be a bare host:port, so we append the standard path.
+func adaptBackendURL(target RoutingTarget, upstreamProtocol types.Protocol) string {
+	// If the URL already contains a recognizable path, trust it.
+	if _, ok := inferProtocolFromURL(target.Target); ok {
+		return target.Target
+	}
+
+	// CSGHub-hosted: append the standard path for the upstream protocol.
+	if target.CSGHubHosted {
+		parsed, err := url.Parse(target.Target)
+		if err != nil || parsed.Host == "" {
+			return target.Target
+		}
+		switch upstreamProtocol {
+		case types.ProtocolChat:
+			return appendEndpointPath(parsed, "v1", "chat", "completions")
+		case types.ProtocolResponses:
+			return appendEndpointPath(parsed, "v1", "responses")
+		case types.ProtocolMessages:
+			return appendEndpointPath(parsed, "v1", "messages")
+		}
+	}
+
+	return target.Target
+}
+
+func pickAdapter(clientProtocol, upstreamProtocol types.Protocol) AdapterKind {
+	row, ok := adapterMatrix[clientProtocol]
+	if !ok {
+		return AdapterNone
+	}
+	kind, ok := row[upstreamProtocol]
+	if !ok {
+		return AdapterNone
+	}
+	return kind
+}
+
+func pathEndsWithSegments(path string, segments ...string) bool {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) < len(segments) {
+		return false
+	}
+	offset := len(parts) - len(segments)
+	for idx, segment := range segments {
+		if parts[offset+idx] != segment {
+			return false
+		}
+	}
+	return true
+}
+
+func appendEndpointPath(base *url.URL, segments ...string) string {
+	u := *base
+	// Avoid duplicating path segments that are already present in the base
+	// path.  For example, if base.Path is "/v1" and segments are
+	// ["v1", "chat", "completions"], the result should be
+	// "/v1/chat/completions" not "/v1/v1/chat/completions".
+	path := strings.TrimRight(u.Path, "/")
+	pathParts := strings.Split(strings.Trim(path, "/"), "/")
+	trimmed := trimLeadingSegments(segments, pathParts)
+	u.Path = commonutils.JoinURLPath(u.Path, trimmed...)
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+// trimLeadingSegments removes leading segments from elems that already
+// match the trailing segments of base.  This prevents path duplication
+// when the base URL already contains a path prefix like /v1.
+func trimLeadingSegments(elems []string, base []string) []string {
+	if len(base) == 0 || len(elems) == 0 {
+		return elems
+	}
+	// Find the longest matching suffix of base that is also a prefix of elems.
+	// For example: base=["v1","api"], elems=["v1","chat","completions"]
+	// → matching suffix of base is ["v1"], which is prefix of elems
+	// → trim it, return ["chat","completions"]
+	// But: base=["v1"], elems=["v1","chat","completions"]
+	// → matching suffix of base is ["v1"] = prefix of elems
+	// → trim it, return ["chat","completions"]
+	// And: base=["v1"], elems=["v1","chat","completions"]
+	// → elems[0] = base[0] → trim
+	// → result: ["chat","completions"]
+	n := len(elems)
+	for n > 0 && len(base) >= n {
+		match := true
+		for i := 0; i < n; i++ {
+			if base[len(base)-n+i] != elems[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return elems[n:]
+		}
+		n--
+	}
+	return elems
+}

--- a/aigateway/handler/protocol/adapt_test.go
+++ b/aigateway/handler/protocol/adapt_test.go
@@ -1,0 +1,309 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"opencsg.com/csghub-server/aigateway/types"
+)
+
+func TestDetectUpstreamProtocol(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   RoutingTarget
+		expected types.Protocol
+	}{
+		{
+			name:     "metadata explicit messages",
+			target:   RoutingTarget{Target: "https://api.anthropic.com/v1/messages", UpstreamMetadata: map[string]any{"protocol": "messages"}},
+			expected: types.ProtocolMessages,
+		},
+		{
+			name:     "metadata explicit responses",
+			target:   RoutingTarget{Target: "https://api.openai.com/v1/responses", UpstreamMetadata: map[string]any{"protocol": "responses"}},
+			expected: types.ProtocolResponses,
+		},
+		{
+			name:     "metadata explicit chat",
+			target:   RoutingTarget{Target: "https://example.com/v1/chat/completions", UpstreamMetadata: map[string]any{"protocol": "chat"}},
+			expected: types.ProtocolChat,
+		},
+		{
+			name:     "url path messages",
+			target:   RoutingTarget{Target: "https://api.anthropic.com/v1/messages"},
+			expected: types.ProtocolMessages,
+		},
+		{
+			name:     "url path responses",
+			target:   RoutingTarget{Target: "https://api.openai.com/v1/responses"},
+			expected: types.ProtocolResponses,
+		},
+		{
+			name:     "url path chat completions",
+			target:   RoutingTarget{Target: "https://example.com/v1/chat/completions"},
+			expected: types.ProtocolChat,
+		},
+		{
+			name:     "csghub hosted defaults to chat",
+			target:   RoutingTarget{Target: "http://model-svc:8080", CSGHubHosted: true},
+			expected: types.ProtocolChat,
+		},
+		{
+			name:     "bare url defaults to chat",
+			target:   RoutingTarget{Target: "https://example.com"},
+			expected: types.ProtocolChat,
+		},
+		{
+			name:     "metadata overrides url path",
+			target:   RoutingTarget{Target: "https://example.com/v1/chat/completions", UpstreamMetadata: map[string]any{"protocol": "messages"}},
+			expected: types.ProtocolMessages,
+		},
+		{
+			name:     "metadata invalid protocol falls through to url",
+			target:   RoutingTarget{Target: "https://example.com/v1/responses", UpstreamMetadata: map[string]any{"protocol": "invalid"}},
+			expected: types.ProtocolResponses,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DetectUpstreamProtocol(tt.target)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestResolveRoutingNative(t *testing.T) {
+	tests := []struct {
+		name           string
+		clientProtocol types.Protocol
+		target         RoutingTarget
+	}{
+		{
+			name:           "messages to messages",
+			clientProtocol: types.ProtocolMessages,
+			target:         RoutingTarget{Target: "https://api.anthropic.com/v1/messages"},
+		},
+		{
+			name:           "chat to chat",
+			clientProtocol: types.ProtocolChat,
+			target:         RoutingTarget{Target: "https://example.com/v1/chat/completions"},
+		},
+		{
+			name:           "responses to responses",
+			clientProtocol: types.ProtocolResponses,
+			target:         RoutingTarget{Target: "https://example.com/v1/responses"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision, err := ResolveRouting(tt.clientProtocol, tt.target)
+			require.NoError(t, err)
+			assert.Equal(t, ModeNative, decision.Mode)
+			assert.Equal(t, AdapterNone, decision.AdapterKind)
+			assert.Equal(t, tt.target.Target, decision.BackendURL)
+			assert.Equal(t, "protocol_match", decision.Reason)
+		})
+	}
+}
+
+func TestResolveRoutingAdapter(t *testing.T) {
+	tests := []struct {
+		name           string
+		clientProtocol types.Protocol
+		target         RoutingTarget
+		expectedKind   AdapterKind
+		expectedProto  types.Protocol
+	}{
+		{
+			name:           "messages to chat adapter",
+			clientProtocol: types.ProtocolMessages,
+			target:         RoutingTarget{Target: "https://vllm.example.com/v1/chat/completions"},
+			expectedKind:   AdapterMessagesToChat,
+			expectedProto:  types.ProtocolChat,
+		},
+		{
+			name:           "messages to responses adapter",
+			clientProtocol: types.ProtocolMessages,
+			target:         RoutingTarget{Target: "https://openai.example.com/v1/responses"},
+			expectedKind:   AdapterMessagesToResponses,
+			expectedProto:  types.ProtocolResponses,
+		},
+		{
+			name:           "responses to chat adapter",
+			clientProtocol: types.ProtocolResponses,
+			target:         RoutingTarget{Target: "https://vllm.example.com/v1/chat/completions"},
+			expectedKind:   AdapterResponsesToChat,
+			expectedProto:  types.ProtocolChat,
+		},
+		{
+			name:           "messages to chat via csghub hosted",
+			clientProtocol: types.ProtocolMessages,
+			target:         RoutingTarget{Target: "http://model-svc:8080", CSGHubHosted: true},
+			expectedKind:   AdapterMessagesToChat,
+			expectedProto:  types.ProtocolChat,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision, err := ResolveRouting(tt.clientProtocol, tt.target)
+			require.NoError(t, err)
+			assert.Equal(t, ModeAdapter, decision.Mode)
+			assert.Equal(t, tt.expectedKind, decision.AdapterKind)
+			assert.Equal(t, tt.expectedProto, decision.UpstreamProtocol)
+		})
+	}
+}
+
+func TestResolveRoutingDisabled(t *testing.T) {
+	tests := []struct {
+		name           string
+		clientProtocol types.Protocol
+		target         RoutingTarget
+	}{
+		{
+			name:           "chat to messages - no adapter",
+			clientProtocol: types.ProtocolChat,
+			target:         RoutingTarget{Target: "https://api.anthropic.com/v1/messages"},
+		},
+		{
+			name:           "chat to responses - no adapter",
+			clientProtocol: types.ProtocolChat,
+			target:         RoutingTarget{Target: "https://example.com/v1/responses"},
+		},
+		{
+			name:           "responses to messages - no adapter",
+			clientProtocol: types.ProtocolResponses,
+			target:         RoutingTarget{Target: "https://api.anthropic.com/v1/messages"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision, err := ResolveRouting(tt.clientProtocol, tt.target)
+			require.NoError(t, err)
+			assert.Equal(t, ModeDisabled, decision.Mode)
+			assert.Contains(t, decision.Reason, "no_adapter")
+		})
+	}
+}
+
+func TestResolveRoutingEmptyTarget(t *testing.T) {
+	_, err := ResolveRouting(types.ProtocolMessages, RoutingTarget{Target: ""})
+	assert.Error(t, err)
+}
+
+// TestResolveRoutingNativeFallback verifies that when the upstream protocol
+// cannot be inferred from the URL or metadata, and the model is NOT
+// CSGHub-hosted, the routing falls back to the client's own protocol (native
+// passthrough) rather than forcing the Chat adapter.  This is critical for
+// Claude Code compatibility: an external Anthropic-native upstream whose URL
+// does not end in /v1/messages should receive the request natively, not through
+// the chat adapter (which injects type:"function" into tools).
+func TestResolveRoutingNativeFallback(t *testing.T) {
+	tests := []struct {
+		name           string
+		clientProtocol types.Protocol
+		target         RoutingTarget
+		expectedMode   ExecutionMode
+		expectedProto  types.Protocol
+	}{
+		{
+			name:           "messages client, bare external url → native messages",
+			clientProtocol: types.ProtocolMessages,
+			target:         RoutingTarget{Target: "https://external.example.com"},
+			expectedMode:   ModeNative,
+			expectedProto:  types.ProtocolMessages,
+		},
+		{
+			name:           "messages client, external url with generic path → native messages",
+			clientProtocol: types.ProtocolMessages,
+			target:         RoutingTarget{Target: "https://external.example.com/api"},
+			expectedMode:   ModeNative,
+			expectedProto:  types.ProtocolMessages,
+		},
+		{
+			name:           "responses client, bare external url → native responses",
+			clientProtocol: types.ProtocolResponses,
+			target:         RoutingTarget{Target: "https://external.example.com"},
+			expectedMode:   ModeNative,
+			expectedProto:  types.ProtocolResponses,
+		},
+		{
+			name:           "messages client, csghub hosted → still chat adapter (no fallback)",
+			clientProtocol: types.ProtocolMessages,
+			target:         RoutingTarget{Target: "http://model-svc:8080", CSGHubHosted: true},
+			expectedMode:   ModeAdapter,
+			expectedProto:  types.ProtocolChat,
+		},
+		{
+			name:           "messages client, external url with metadata protocol=chat → chat adapter (metadata wins)",
+			clientProtocol: types.ProtocolMessages,
+			target:         RoutingTarget{Target: "https://external.example.com", UpstreamMetadata: map[string]any{"protocol": "chat"}},
+			expectedMode:   ModeAdapter,
+			expectedProto:  types.ProtocolChat,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision, err := ResolveRouting(tt.clientProtocol, tt.target)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedMode, decision.Mode)
+			assert.Equal(t, tt.expectedProto, decision.UpstreamProtocol)
+		})
+	}
+}
+
+func TestAdaptBackendURL(t *testing.T) {
+	t.Run("url already has path - keep as is", func(t *testing.T) {
+		decision, err := ResolveRouting(types.ProtocolMessages, RoutingTarget{
+			Target: "https://vllm.example.com/v1/chat/completions",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "https://vllm.example.com/v1/chat/completions", decision.BackendURL)
+	})
+
+	t.Run("csghub hosted chat - append path", func(t *testing.T) {
+		decision, err := ResolveRouting(types.ProtocolMessages, RoutingTarget{
+			Target:       "http://model-svc:8080",
+			CSGHubHosted: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "http://model-svc:8080/v1/chat/completions", decision.BackendURL)
+	})
+
+	t.Run("csghub hosted responses - append path", func(t *testing.T) {
+		decision, err := ResolveRouting(types.ProtocolMessages, RoutingTarget{
+			Target:           "http://model-svc:8080",
+			CSGHubHosted:     true,
+			UpstreamMetadata: map[string]any{"protocol": "responses"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "http://model-svc:8080/v1/responses", decision.BackendURL)
+	})
+}
+
+func TestPathEndsWithSegments(t *testing.T) {
+	tests := []struct {
+		path     string
+		segments []string
+		expected bool
+	}{
+		{"/v1/chat/completions", []string{"chat", "completions"}, true},
+		{"/v1/responses", []string{"responses"}, true},
+		{"/v1/messages", []string{"messages"}, true},
+		{"/v1/chat", []string{"chat", "completions"}, false},
+		{"/responses", []string{"chat", "completions"}, false},
+		{"/v1/chat/completions/", []string{"chat", "completions"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.expected, pathEndsWithSegments(tt.path, tt.segments...))
+		})
+	}
+}

--- a/aigateway/router/aigateway.go
+++ b/aigateway/router/aigateway.go
@@ -70,16 +70,25 @@ func NewRouter(config *config.Config) (*gin.Engine, func(), error) {
 		return nil, nil, fmt.Errorf("error creating openai handler :%w", err)
 	}
 
+	// AnthropicHandlerImpl embeds OpenAIHandlerImpl and adds the
+	// Anthropic Messages protocol on top of the shared infrastructure.
+	anthropicHandler := handler.NewAnthropicHandler(openAIhandler)
 	// Metrics middleware: manages request lifecycle metrics for inference
 	// routes.  Each route opts in by including metricsMw in its handler chain.
 	// Returns a no-op handler + cleanup when the metrics feature is not
 	// compiled in (ce build).
 	metricsMw, metricsCleanup := newMetricsMiddleware(config)
+	// Also mount the Anthropic Messages API under /anthropic/v1 to match the
+	// official Anthropic API path layout. Both /v1/messages and
+	// /anthropic/v1/messages are supported.
+	anthropicGroup := r.Group("/anthropic/v1")
+	anthropicGroup.POST("/messages", middlewareCollection.Auth.MustUserOrgApiKey, metricsMw, anthropicHandler.Messages)
 
 	v1Group.GET("/models", openAIhandler.ListModels)
 	v1Group.GET("/models/*model", openAIhandler.GetModel)
 	v1Group.POST("/responses", middlewareCollection.Auth.MustUserOrgApiKey, metricsMw, openAIhandler.Responses)
 	v1Group.POST("/chat/completions", middlewareCollection.Auth.MustUserOrgApiKey, metricsMw, openAIhandler.Chat)
+	v1Group.POST("/messages", middlewareCollection.Auth.MustUserOrgApiKey, metricsMw, anthropicHandler.Messages)
 	v1Group.POST("/embeddings", middlewareCollection.Auth.MustUserOrgApiKey, metricsMw, openAIhandler.Embedding)
 	v1Group.POST("/rerank", middlewareCollection.Auth.MustUserOrgApiKey, metricsMw, openAIhandler.Rerank)
 	v1Group.POST("/images/generations", middlewareCollection.Auth.MustUserOrgApiKey, metricsMw, modalAPIRateLimiter, openAIhandler.GenerateImage)

--- a/aigateway/types/messages.go
+++ b/aigateway/types/messages.go
@@ -1,0 +1,348 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// AnthropicMessagesRequest represents a POST /v1/messages request
+// following the Anthropic Messages API specification.
+// Unknown fields are preserved in ExtraFields for native passthrough.
+type AnthropicMessagesRequest struct {
+	Model          string                 `json:"model"`
+	Messages       []AnthropicMessage     `json:"messages"`
+	System         json.RawMessage        `json:"system,omitempty"` // string or []AnthropicContentBlock
+	MaxTokens      int                    `json:"max_tokens"`
+	Metadata       *AnthropicMetadata     `json:"metadata,omitempty"`
+	StopSequences  []string               `json:"stop_sequences,omitempty"`
+	Stream         bool                   `json:"stream,omitempty"`
+	Temperature    *float64               `json:"temperature,omitempty"`
+	TopP           *float64               `json:"top_p,omitempty"`
+	TopK           *int                   `json:"top_k,omitempty"`
+	Tools          []AnthropicTool        `json:"tools,omitempty"`
+	ToolChoice     json.RawMessage        `json:"tool_choice,omitempty"`
+	Thinking       *AnthropicThinking     `json:"thinking,omitempty"`
+	ExtraFields    map[string]json.RawMessage `json:"-"`
+}
+
+// AnthropicMessage is a single message in the messages array.
+type AnthropicMessage struct {
+	Role    string          `json:"role"` // "user" | "assistant"
+	Content json.RawMessage `json:"content"` // string or []AnthropicContentBlock
+}
+
+// AnthropicContentBlock is a typed content block within a message.
+type AnthropicContentBlock struct {
+	Type         string                 `json:"type"`
+	Text         string                 `json:"text,omitempty"`
+	Source       *AnthropicImageSource  `json:"source,omitempty"`
+	ID           string                 `json:"id,omitempty"`
+	Name         string                 `json:"name,omitempty"`
+	Input        json.RawMessage        `json:"input,omitempty"`
+	ToolUseID    string                 `json:"tool_use_id,omitempty"`
+	Content      json.RawMessage        `json:"content,omitempty"` // for tool_result: string or []block
+	Thinking     string                 `json:"thinking,omitempty"`
+	CacheControl *AnthropicCacheControl `json:"cache_control,omitempty"`
+}
+
+// AnthropicImageSource represents an image source in an image content block.
+type AnthropicImageSource struct {
+	Type      string `json:"type"`       // "base64" | "url"
+	MediaType string `json:"media_type"` // "image/png", "image/jpeg", etc.
+	Data      string `json:"data,omitempty"`
+	URL       string `json:"url,omitempty"`
+}
+
+// AnthropicCacheControl enables prompt caching for a content block.
+type AnthropicCacheControl struct {
+	Type string `json:"type"` // "ephemeral"
+}
+
+// AnthropicMetadata is optional user-provided metadata.
+type AnthropicMetadata struct {
+	UserID string `json:"user_id,omitempty"`
+}
+
+// AnthropicThinking configures extended thinking.
+type AnthropicThinking struct {
+	Type         string `json:"type"` // "enabled" | "disabled" | "adaptive"
+	BudgetTokens int    `json:"budget_tokens,omitempty"`
+}
+
+// AnthropicTool describes a tool the model may call.
+// It supports both the native Anthropic format (name / description / input_schema)
+// and the OpenAI Chat Completions format (type: "function", function: {name, description, parameters}).
+type AnthropicTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
+	CacheControl *AnthropicCacheControl `json:"cache_control,omitempty"`
+}
+
+// UnmarshalJSON handles both Anthropic and OpenAI Chat tool formats.
+func (t *AnthropicTool) UnmarshalJSON(data []byte) error {
+	// First, try the native Anthropic format.
+	type raw AnthropicTool
+	var r raw
+	if err := json.Unmarshal(data, &r); err != nil {
+		return err
+	}
+	// If the native format has a name, use it directly.
+	if r.Name != "" {
+		*t = AnthropicTool(r)
+		return nil
+	}
+	// If name is empty, the input may be in OpenAI Chat format:
+	//   {"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}}}
+	var chatTool struct {
+		Type     string `json:"type"`
+		Function struct {
+			Name        string          `json:"name"`
+			Description string          `json:"description"`
+			Parameters  json.RawMessage `json:"parameters"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(data, &chatTool); err != nil {
+		return err
+	}
+	if chatTool.Type == "function" && chatTool.Function.Name != "" {
+		t.Name = chatTool.Function.Name
+		t.Description = chatTool.Function.Description
+		t.InputSchema = chatTool.Function.Parameters
+		return nil
+	}
+	// Fall back to the native parsed result (may have empty name).
+	*t = AnthropicTool(r)
+	return nil
+}
+
+// Validate checks required fields in a Messages request.
+func (r *AnthropicMessagesRequest) Validate() error {
+	if r.Model == "" {
+		return fmt.Errorf("model is required")
+	}
+	if r.MaxTokens <= 0 {
+		return fmt.Errorf("max_tokens is required and must be positive")
+	}
+	if len(r.Messages) == 0 {
+		return fmt.Errorf("messages is required and must not be empty")
+	}
+	return nil
+}
+
+// UnmarshalJSON preserves unknown fields in ExtraFields.
+func (r *AnthropicMessagesRequest) UnmarshalJSON(data []byte) error {
+	type alias AnthropicMessagesRequest
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	var allFields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &allFields); err != nil {
+		return err
+	}
+	for _, key := range []string{
+		"model", "messages", "system", "max_tokens", "metadata",
+		"stop_sequences", "stream", "temperature", "top_p", "top_k",
+		"tools", "tool_choice", "thinking",
+	} {
+		delete(allFields, key)
+	}
+	tmp.ExtraFields = allFields
+	*r = AnthropicMessagesRequest(tmp)
+	return nil
+}
+
+// MarshalJSON merges ExtraFields back into the output.
+func (r AnthropicMessagesRequest) MarshalJSON() ([]byte, error) {
+	type alias AnthropicMessagesRequest
+	known, err := json.Marshal(alias(r))
+	if err != nil {
+		return nil, err
+	}
+	if len(r.ExtraFields) == 0 {
+		return known, nil
+	}
+	var knownFields map[string]json.RawMessage
+	if err := json.Unmarshal(known, &knownFields); err != nil {
+		return nil, err
+	}
+	for k, v := range r.ExtraFields {
+		if _, exists := knownFields[k]; !exists {
+			knownFields[k] = v
+		}
+	}
+	return json.Marshal(knownFields)
+}
+
+// AnthropicMessagesResponse is the non-streaming response for POST /v1/messages.
+type AnthropicMessagesResponse struct {
+	ID           string                  `json:"id"` // "msg_xxx"
+	Type         string                  `json:"type"` // "message"
+	Role         string                  `json:"role"` // "assistant"
+	Content      []AnthropicContentBlock `json:"content"`
+	Model        string                  `json:"model"`
+	StopReason   *string                 `json:"stop_reason,omitempty"`
+	StopSequence *string                 `json:"stop_sequence,omitempty"`
+	Usage        AnthropicMessagesUsage  `json:"usage"`
+}
+
+// AnthropicMessagesUsage reports token usage.
+type AnthropicMessagesUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+}
+
+// AnthropicMessagesError is the error response shape for the Anthropic API.
+type AnthropicMessagesError struct {
+	Type  string `json:"type"`
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// --- Stream event types ---
+
+// AnthropicStreamEvent is a single SSE event in a streaming Messages response.
+// The Type field determines which sub-fields are populated.
+type AnthropicStreamEvent struct {
+	Type         string                  `json:"type"`
+	Message      *AnthropicStreamMessage `json:"message,omitempty"`
+	Index        *int                    `json:"index,omitempty"`
+	ContentBlock *AnthropicContentBlock  `json:"content_block,omitempty"`
+	Delta        json.RawMessage         `json:"delta,omitempty"`
+	Usage        *AnthropicMessagesUsage `json:"usage,omitempty"`
+}
+
+// AnthropicStreamMessage is the message object in a message_start event.
+type AnthropicStreamMessage struct {
+	ID           string                  `json:"id"`
+	Type         string                  `json:"type"`
+	Role         string                  `json:"role"`
+	Content      []AnthropicContentBlock `json:"content,omitempty"`
+	Model        string                  `json:"model"`
+	StopReason   *string                 `json:"stop_reason,omitempty"`
+	StopSequence *string                 `json:"stop_sequence,omitempty"`
+	Usage        AnthropicMessagesUsage  `json:"usage"`
+}
+
+// --- Helper functions ---
+
+// AnthropicMessageContentText extracts the text content from a message's content field.
+// Handles both string content and []ContentBlock content.
+func AnthropicMessageContentText(raw json.RawMessage) string {
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return asString
+	}
+	var blocks []AnthropicContentBlock
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		var parts []string
+		for _, b := range blocks {
+			switch b.Type {
+			case "text":
+				if b.Text != "" {
+					parts = append(parts, b.Text)
+				}
+			case "tool_result":
+				// tool_result content is user-supplied and should be checked
+				// by moderation.  It can be a string or an array of text blocks.
+				if text := AnthropicMessageContentText(b.Content); text != "" {
+					parts = append(parts, text)
+				}
+			case "tool_use":
+				// tool_use input is model-generated but may contain user-influenced
+				// content; include for moderation completeness.
+				if len(b.Input) > 0 && string(b.Input) != "null" {
+					parts = append(parts, string(b.Input))
+				}
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+	return ""
+}
+
+// ParseAnthropicContentBlocks parses a message content field (string or []block)
+// into a slice of AnthropicContentBlock.  A plain string becomes a single
+// text block.
+func ParseAnthropicContentBlocks(raw json.RawMessage) ([]AnthropicContentBlock, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return []AnthropicContentBlock{{Type: "text", Text: asString}}, nil
+	}
+	var blocks []AnthropicContentBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return nil, fmt.Errorf("content must be a string or array of content blocks: %w", err)
+	}
+	return blocks, nil
+}
+
+// HasAnthropicCacheControl checks whether any content block in the request
+// carries a cache_control directive.
+func (r *AnthropicMessagesRequest) HasCacheControl() bool {
+	for _, msg := range r.Messages {
+		blocks, err := ParseAnthropicContentBlocks(msg.Content)
+		if err != nil {
+			continue
+		}
+		for _, b := range blocks {
+			if b.CacheControl != nil {
+				return true
+			}
+		}
+	}
+	for _, tool := range r.Tools {
+		if tool.CacheControl != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// HasAnthropicVision checks whether any message contains an image content block.
+func (r *AnthropicMessagesRequest) HasVision() bool {
+	for _, msg := range r.Messages {
+		blocks, err := ParseAnthropicContentBlocks(msg.Content)
+		if err != nil {
+			continue
+		}
+		for _, b := range blocks {
+			if b.Type == "image" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// HasAnthropicThinking checks whether the request enables extended thinking.
+func (r *AnthropicMessagesRequest) HasThinking() bool {
+	return r.Thinking != nil && (r.Thinking.Type == "enabled" || r.Thinking.Type == "adaptive")
+}
+
+// PromptText extracts a plain-text representation of the prompt for moderation.
+func (r *AnthropicMessagesRequest) PromptText() string {
+	var parts []string
+	// System prompt
+	if len(r.System) > 0 {
+		if text := AnthropicMessageContentText(r.System); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	// Messages
+	for _, msg := range r.Messages {
+		if text := AnthropicMessageContentText(msg.Content); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/aigateway/types/messages_test.go
+++ b/aigateway/types/messages_test.go
@@ -1,0 +1,326 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnthropicMessagesRequestValidate(t *testing.T) {
+	t.Run("valid request", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			Model:     "claude-3",
+			MaxTokens: 1024,
+			Messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"hello"`)},
+			},
+		}
+		assert.NoError(t, req.Validate())
+	})
+
+	t.Run("missing model", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			MaxTokens: 1024,
+			Messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"hello"`)},
+			},
+		}
+		err := req.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "model is required")
+	})
+
+	t.Run("missing max_tokens", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			Model: "claude-3",
+			Messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"hello"`)},
+			},
+		}
+		err := req.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "max_tokens")
+	})
+
+	t.Run("empty messages", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			Model:     "claude-3",
+			MaxTokens: 1024,
+		}
+		err := req.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "messages")
+	})
+}
+
+func TestAnthropicMessagesRequestUnmarshalJSON(t *testing.T) {
+	raw := `{
+		"model": "claude-3",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "hello"}],
+		"temperature": 0.7,
+		"stream": true,
+		"custom_field": "custom_value"
+	}`
+
+	var req AnthropicMessagesRequest
+	err := json.Unmarshal([]byte(raw), &req)
+	require.NoError(t, err)
+
+	assert.Equal(t, "claude-3", req.Model)
+	assert.Equal(t, 1024, req.MaxTokens)
+	assert.True(t, req.Stream)
+	assert.NotNil(t, req.Temperature)
+	assert.Equal(t, 0.7, *req.Temperature)
+	assert.Len(t, req.Messages, 1)
+
+	// Unknown fields preserved
+	require.Contains(t, req.ExtraFields, "custom_field")
+	var customVal string
+	require.NoError(t, json.Unmarshal(req.ExtraFields["custom_field"], &customVal))
+	assert.Equal(t, "custom_value", customVal)
+}
+
+func TestAnthropicMessagesRequestMarshalJSON(t *testing.T) {
+	temp := 0.7
+	req := AnthropicMessagesRequest{
+		Model:     "claude-3",
+		MaxTokens: 1024,
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+		},
+		Temperature: &temp,
+		Stream:      true,
+		ExtraFields: map[string]json.RawMessage{
+			"custom_field": json.RawMessage(`"custom_value"`),
+		},
+	}
+
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	assert.Equal(t, "claude-3", m["model"])
+	assert.Equal(t, "custom_value", m["custom_field"])
+	assert.Equal(t, true, m["stream"])
+}
+
+func TestParseAnthropicContentBlocks(t *testing.T) {
+	t.Run("string content", func(t *testing.T) {
+		blocks, err := ParseAnthropicContentBlocks(json.RawMessage(`"hello world"`))
+		require.NoError(t, err)
+		require.Len(t, blocks, 1)
+		assert.Equal(t, "text", blocks[0].Type)
+		assert.Equal(t, "hello world", blocks[0].Text)
+	})
+
+	t.Run("array of blocks", func(t *testing.T) {
+		raw := `[{"type":"text","text":"hello"},{"type":"text","text":"world"}]`
+		blocks, err := ParseAnthropicContentBlocks(json.RawMessage(raw))
+		require.NoError(t, err)
+		require.Len(t, blocks, 2)
+		assert.Equal(t, "hello", blocks[0].Text)
+		assert.Equal(t, "world", blocks[1].Text)
+	})
+
+	t.Run("null content", func(t *testing.T) {
+		blocks, err := ParseAnthropicContentBlocks(json.RawMessage(`null`))
+		require.NoError(t, err)
+		assert.Nil(t, blocks)
+	})
+
+	t.Run("empty content", func(t *testing.T) {
+		blocks, err := ParseAnthropicContentBlocks(json.RawMessage(``))
+		require.NoError(t, err)
+		assert.Nil(t, blocks)
+	})
+
+	t.Run("invalid content", func(t *testing.T) {
+		_, err := ParseAnthropicContentBlocks(json.RawMessage(`123`))
+		assert.Error(t, err)
+	})
+}
+
+func TestAnthropicMessageContentText(t *testing.T) {
+	t.Run("string content", func(t *testing.T) {
+		text := AnthropicMessageContentText(json.RawMessage(`"hello"`))
+		assert.Equal(t, "hello", text)
+	})
+
+	t.Run("array content", func(t *testing.T) {
+		raw := `[{"type":"text","text":"hello"},{"type":"text","text":"world"}]`
+		text := AnthropicMessageContentText(json.RawMessage(raw))
+		assert.Equal(t, "hello\nworld", text)
+	})
+
+	t.Run("mixed content types", func(t *testing.T) {
+		raw := `[{"type":"image","source":{"type":"base64"}},{"type":"text","text":"describe this"}]`
+		text := AnthropicMessageContentText(json.RawMessage(raw))
+		assert.Equal(t, "describe this", text)
+	})
+}
+
+func TestAnthropicMessagesRequestHasCacheControl(t *testing.T) {
+	t.Run("with cache_control on content block", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			Messages: []AnthropicMessage{
+				{
+					Role: "user",
+					Content: json.RawMessage(`[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]`),
+				},
+			},
+		}
+		assert.True(t, req.HasCacheControl())
+	})
+
+	t.Run("without cache_control", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			Messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"hello"`)},
+			},
+		}
+		assert.False(t, req.HasCacheControl())
+	})
+
+	t.Run("with cache_control on tool", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			Messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"hello"`)},
+			},
+			Tools: []AnthropicTool{
+				{Name: "get_weather", InputSchema: json.RawMessage(`{}`), CacheControl: &AnthropicCacheControl{Type: "ephemeral"}},
+			},
+		}
+		assert.True(t, req.HasCacheControl())
+	})
+}
+
+func TestAnthropicMessagesRequestHasVision(t *testing.T) {
+	t.Run("with image", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			Messages: []AnthropicMessage{
+				{
+					Role: "user",
+					Content: json.RawMessage(`[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBOR..."}}]`),
+				},
+			},
+		}
+		assert.True(t, req.HasVision())
+	})
+
+	t.Run("without image", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			Messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"hello"`)},
+			},
+		}
+		assert.False(t, req.HasVision())
+	})
+}
+
+func TestAnthropicMessagesRequestHasThinking(t *testing.T) {
+	t.Run("thinking enabled", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			Thinking: &AnthropicThinking{Type: "enabled", BudgetTokens: 5000},
+		}
+		assert.True(t, req.HasThinking())
+	})
+
+	t.Run("thinking adaptive (Claude Code)", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			Thinking: &AnthropicThinking{Type: "adaptive"},
+		}
+		assert.True(t, req.HasThinking())
+	})
+
+	t.Run("thinking disabled", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			Thinking: &AnthropicThinking{Type: "disabled"},
+		}
+		assert.False(t, req.HasThinking())
+	})
+
+	t.Run("thinking nil", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{}
+		assert.False(t, req.HasThinking())
+	})
+}
+
+func TestAnthropicMessagesRequestPromptText(t *testing.T) {
+	t.Run("system string + messages", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			System: json.RawMessage(`"You are a helpful assistant"`),
+			Messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"What is 2+2?"`)},
+				{Role: "assistant", Content: json.RawMessage(`"4"`)},
+			},
+		}
+		text := req.PromptText()
+		assert.Contains(t, text, "You are a helpful assistant")
+		assert.Contains(t, text, "What is 2+2?")
+		assert.Contains(t, text, "4")
+	})
+
+	t.Run("system as content blocks", func(t *testing.T) {
+		req := &AnthropicMessagesRequest{
+			System: json.RawMessage(`[{"type":"text","text":"System prompt"}]`),
+			Messages: []AnthropicMessage{
+				{Role: "user", Content: json.RawMessage(`"hello"`)},
+			},
+		}
+		text := req.PromptText()
+		assert.Contains(t, text, "System prompt")
+		assert.Contains(t, text, "hello")
+	})
+
+t.Run("no system", func(t *testing.T) {
+			req := &AnthropicMessagesRequest{
+				Messages: []AnthropicMessage{
+					{Role: "user", Content: json.RawMessage(`"hello"`)},
+				},
+			}
+			text := req.PromptText()
+			assert.Equal(t, "hello", text)
+		})
+	}
+
+	func TestAnthropicToolUnmarshalJSON(t *testing.T) {
+		t.Run("native Anthropic format", func(t *testing.T) {
+			var tool AnthropicTool
+			err := json.Unmarshal([]byte(`{
+				"name": "get_weather",
+				"description": "Get the weather",
+				"input_schema": {"type": "object", "properties": {"city": {"type": "string"}}}
+			}`), &tool)
+			require.NoError(t, err)
+			assert.Equal(t, "get_weather", tool.Name)
+			assert.Equal(t, "Get the weather", tool.Description)
+			assert.JSONEq(t, `{"type":"object","properties":{"city":{"type":"string"}}}`, string(tool.InputSchema))
+		})
+
+		t.Run("OpenAI Chat format", func(t *testing.T) {
+			var tool AnthropicTool
+			err := json.Unmarshal([]byte(`{
+				"type": "function",
+				"function": {
+					"name": "write_file",
+					"description": "write",
+					"parameters": {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]}
+				}
+			}`), &tool)
+			require.NoError(t, err)
+			assert.Equal(t, "write_file", tool.Name)
+			assert.Equal(t, "write", tool.Description)
+			assert.JSONEq(t, `{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`, string(tool.InputSchema))
+		})
+
+		t.Run("empty name both formats", func(t *testing.T) {
+			var tool AnthropicTool
+			err := json.Unmarshal([]byte(`{"type": "unknown"}`), &tool)
+			require.NoError(t, err)
+			assert.Empty(t, tool.Name)
+		})
+	}

--- a/aigateway/types/protocol.go
+++ b/aigateway/types/protocol.go
@@ -1,0 +1,70 @@
+package types
+
+// Protocol identifies an LLM inference protocol supported by the AIGateway.
+type Protocol string
+
+const (
+	// ProtocolChat is the OpenAI Chat Completions API (/v1/chat/completions).
+	ProtocolChat Protocol = "chat"
+	// ProtocolResponses is the OpenAI Responses API (/v1/responses).
+	ProtocolResponses Protocol = "responses"
+	// ProtocolMessages is the Anthropic Messages API (/v1/messages).
+	ProtocolMessages Protocol = "messages"
+)
+
+// ProtocolCapability describes the feature set of a protocol implementation.
+// It is used by the routing layer to decide whether a request can be served
+// natively (protocol match) or via an adapter, and to reject requests that
+// require unsupported capabilities rather than silently dropping parameters.
+type ProtocolCapability struct {
+	Protocol         Protocol
+	Streaming        bool
+	Tools            bool
+	Vision           bool
+	Thinking         bool // extended thinking / reasoning
+	PromptCaching    bool // Anthropic cache_control or equivalent
+	StructuredOutput bool // JSON schema / response_format
+}
+
+// DefaultProtocolCapabilities returns the built-in capability profile for each
+// protocol.  These defaults can be overridden at runtime by upstream metadata
+// (see handler/protocol/adapt.go).
+var DefaultProtocolCapabilities = map[Protocol]ProtocolCapability{
+ProtocolChat: {
+			Protocol:         ProtocolChat,
+			Streaming:        true,
+			Tools:            true,
+			Vision:           true,
+			Thinking:         true, // support via reasoning_effort translation
+			PromptCaching:    false,
+			StructuredOutput: true,
+		},
+	ProtocolResponses: {
+		Protocol:         ProtocolResponses,
+		Streaming:        true,
+		Tools:            true,
+		Vision:           true,
+		Thinking:         true,
+		PromptCaching:    false,
+		StructuredOutput: true,
+	},
+	ProtocolMessages: {
+		Protocol:         ProtocolMessages,
+		Streaming:        true,
+		Tools:            true,
+		Vision:           true,
+		Thinking:         true,
+		PromptCaching:    true,
+		StructuredOutput: false,
+	},
+}
+
+// CapabilityFor returns the default capability for the given protocol.
+// If the protocol is unknown, a zero-value capability is returned.
+func CapabilityFor(p Protocol) ProtocolCapability {
+	cap, ok := DefaultProtocolCapabilities[p]
+	if !ok {
+		return ProtocolCapability{Protocol: p}
+	}
+	return cap
+}

--- a/aigateway/types/protocol_test.go
+++ b/aigateway/types/protocol_test.go
@@ -1,0 +1,62 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProtocolString(t *testing.T) {
+	tests := []struct {
+		protocol Protocol
+		expected string
+	}{
+		{ProtocolChat, "chat"},
+		{ProtocolResponses, "responses"},
+		{ProtocolMessages, "messages"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.protocol), func(t *testing.T) {
+			assert.Equal(t, tt.expected, string(tt.protocol))
+		})
+	}
+}
+
+func TestDefaultProtocolCapabilities(t *testing.T) {
+	t.Run("chat capabilities", func(t *testing.T) {
+		cap := CapabilityFor(ProtocolChat)
+		assert.True(t, cap.Streaming)
+		assert.True(t, cap.Tools)
+		assert.True(t, cap.Vision)
+		assert.True(t, cap.Thinking)
+		assert.False(t, cap.PromptCaching)
+		assert.True(t, cap.StructuredOutput)
+	})
+
+	t.Run("responses capabilities", func(t *testing.T) {
+		cap := CapabilityFor(ProtocolResponses)
+		assert.True(t, cap.Streaming)
+		assert.True(t, cap.Tools)
+		assert.True(t, cap.Vision)
+		assert.True(t, cap.Thinking)
+		assert.False(t, cap.PromptCaching)
+		assert.True(t, cap.StructuredOutput)
+	})
+
+	t.Run("messages capabilities", func(t *testing.T) {
+		cap := CapabilityFor(ProtocolMessages)
+		assert.True(t, cap.Streaming)
+		assert.True(t, cap.Tools)
+		assert.True(t, cap.Vision)
+		assert.True(t, cap.Thinking)
+		assert.True(t, cap.PromptCaching)
+		assert.False(t, cap.StructuredOutput)
+	})
+}
+
+func TestCapabilityForUnknownProtocol(t *testing.T) {
+	cap := CapabilityFor(Protocol("unknown"))
+	assert.Equal(t, Protocol("unknown"), cap.Protocol)
+	assert.False(t, cap.Streaming)
+	assert.False(t, cap.Tools)
+}

--- a/aigateway/types/request_plan.go
+++ b/aigateway/types/request_plan.go
@@ -1,0 +1,140 @@
+package types
+
+import (
+	"net/http"
+
+	commonType "opencsg.com/csghub-server/common/types"
+)
+
+// RequestMetadata describes "what this request is" via lightweight parsing.
+// It is produced by the ExtractMetadata phase and does not involve any
+// business logic (no DB / Redis queries).
+type RequestMetadata struct {
+	// Protocol identifies the client protocol: "chat", "messages", "responses", ...
+	Protocol string
+	// Task is the high-level task type: "chat", "messages", "text-to-image", ...
+	Task string
+	// Model is the raw model field from the request body (before resolution).
+	Model string
+	// TenantID is the namespace UUID (nsUUID).
+	TenantID string
+	// UserID is the username.
+	UserID string
+	// APIKeyID is the API key identifier.
+	APIKeyID string
+	// Streaming indicates whether the client requested a streaming response.
+	Streaming bool
+	// Headers are the HTTP request headers.
+	Headers http.Header
+	// ParsedBody holds the protocol-specific parsed request body
+	// (e.g. *AnthropicMessagesRequest).  The Planner and Execute phase
+	// type-assert this field to access protocol-specific fields.
+	ParsedBody any
+}
+
+// PromptTextProvider is implemented by protocol-specific request types that
+// can extract a plain-text representation of the user's prompt for
+// sensitive-content checking.  Each protocol's request type (e.g.
+// AnthropicMessagesRequest) implements PromptText() so the Planner can
+// obtain the text without type-switching on concrete types.
+type PromptTextProvider interface {
+	PromptText() string
+}
+
+// PromptText returns the prompt text from the parsed request body if it
+// implements PromptTextProvider, otherwise an empty string.  This allows
+// the Planner to perform sensitive-content checks without knowing the
+// concrete protocol type.
+func (m *RequestMetadata) PromptText() string {
+	if m == nil || m.ParsedBody == nil {
+		return ""
+	}
+	if p, ok := m.ParsedBody.(PromptTextProvider); ok {
+		return p.PromptText()
+	}
+	return ""
+}
+
+// RequestPlan describes "how this request should be handled".  It is the
+// output of the Plan phase and the input to the Adapt and Execute phases.
+type RequestPlan struct {
+	// ModelTarget is the resolved upstream model target.
+	ModelTarget *ModelTarget
+	// BackendURL is the URL to proxy the request to.
+	BackendURL string
+	// RouteMode is the routing decision: "native", "adapter", or "disabled".
+	RouteMode string
+	// AdapterKind identifies which adapter to use when RouteMode == "adapter".
+	AdapterKind string
+	// UpstreamProtocol is the detected protocol of the upstream endpoint.
+	UpstreamProtocol string
+	// UpstreamCap describes the capabilities of the upstream protocol.
+	UpstreamCap ProtocolCapability
+	// BalanceOK indicates whether the balance check passed.
+	BalanceOK bool
+	// Safety holds the sensitive-content check result.  nil means no check
+	// was performed.
+	Safety *SafetyDecision
+	// UsageLimitOK indicates whether the usage-limit check passed.
+	UsageLimitOK bool
+	// ErrorCode categorizes a Plan-phase error so the protocol handler can
+	// choose the appropriate error response format.  It is only meaningful
+	// when Plan returns an error.  See PlanErrorCategory constants.
+	ErrorCode PlanErrorCategory
+}
+
+// PlanErrorCategory categorizes Plan-phase errors.
+type PlanErrorCategory int
+
+const (
+	PlanErrUnknown PlanErrorCategory = iota
+	PlanErrModelNotFound
+	PlanErrModelUnavailable
+	PlanErrInsufficientBalance
+	PlanErrUsageLimitExceeded
+	PlanErrDisabled
+	PlanErrSensitive
+	PlanErrInternal
+)
+
+// ModelTarget is the protocol-agnostic model target information produced by
+// the Planner.  It mirrors handler.resolvedModelTarget but lives in the types
+// package so it can be shared across handler subpackages without circular
+// dependencies.
+type ModelTarget struct {
+	Model          *Model
+	Upstream       commonType.UpstreamConfig
+	Target         string
+	Host           string
+	ModelName      string
+	AttemptTargets []commonType.UpstreamConfig
+}
+
+// SafetyDecision describes the result of a sensitive-content check.
+type SafetyDecision struct {
+	// IsSensitive is true when the input was flagged by the moderation policy.
+	IsSensitive bool
+	// Message is the block message to present to the client.
+	Message string
+}
+
+// AdaptResult is the output of the Adapt phase.  It carries the transformed
+// request body and the response writer that will intercept the upstream
+// response for protocol conversion and usage extraction.
+type AdaptResult struct {
+	// Body is the marshalled request body to send to the upstream.
+	Body []byte
+	// Writer is the response writer that wraps the gin writer.  It must
+	// implement http.ResponseWriter and http.Flusher.  It may optionally
+	// implement Usage() (int64, int64) and Finalize() error for usage
+	// extraction and response finalization.
+	Writer HTTPResponseWriter
+}
+
+// HTTPResponseWriter is the minimal interface the reverse proxy needs to
+// write responses.  It is satisfied by gin.ResponseWriter and by the
+// protocol-specific adapter response writers.
+type HTTPResponseWriter interface {
+	http.ResponseWriter
+	http.Flusher
+}


### PR DESCRIPTION
Summary:
- Adds the `/v1/messages` endpoint to AIGateway, enabling clients using the Anthropic SDK to connect without modifying their code.
- Introduces a layered handler architecture with a protocol router (`adapt.go`) that automatically selects the execution mode (Native passthrough, Adapter conversion, or Reject) based on client and upstream protocols.
- Implements full request/response translation (streaming and non-streaming) between Messages and existing OpenAI Chat/Responses formats, including support for tool use, thinking/reasoning, and image inputs.