### PR TITLE
fix(api): reject invalid mirror metadata source URL

### DIFF
--- a/api/handler/mirror.go
+++ b/api/handler/mirror.go
@@ -60,7 +60,9 @@ func (h *MirrorHandler) CreateMirrorRepo(ctx *gin.Context) {
 	m, err := h.mirror.CreateMirrorRepo(ctx.Request.Context(), req)
 	if err != nil {
 		slog.ErrorContext(ctx.Request.Context(), "failed to create mirror repo", slog.Any("error", err))
-		if errors.Is(err, errorx.ErrMirrorSourceRepoAuthInvalid) || errors.Is(err, errorx.ErrBadRequest) {
+		if errors.Is(err, errorx.ErrMirrorSourceRepoAuthInvalid) ||
+			errors.Is(err, errorx.ErrMirrorSourceURLInvalid) ||
+			errors.Is(err, errorx.ErrBadRequest) {
 			httpbase.BadRequestWithExt(ctx, err)
 			return
 		}

--- a/api/handler/mirror_test.go
+++ b/api/handler/mirror_test.go
@@ -212,7 +212,7 @@ func TestMirrorHandler_CreateMirrorRepoBadRequest(t *testing.T) {
 	})
 }
 
-// TestMirrorHandler_CreateMirrorRepoUnsupportedMetadataSource verifies unsupported MCP and skill sources return HTTP 400.
+// TestMirrorHandler_CreateMirrorRepoUnsupportedMetadataSource verifies an unconfigured non-OpenCSG source returns HTTP 400.
 func TestMirrorHandler_CreateMirrorRepoUnsupportedMetadataSource(t *testing.T) {
 	tester := NewMirrorTester(t).WithHandleFunc(func(h *MirrorHandler) gin.HandlerFunc {
 		return h.CreateMirrorRepo
@@ -225,17 +225,17 @@ func TestMirrorHandler_CreateMirrorRepoUnsupportedMetadataSource(t *testing.T) {
 		ForkNamespace:     "target-ns",
 		ForkName:          "reviewer",
 	})
-	badRequestErr := errorx.BadRequest(
-		errors.New("mirror_source_id with a configured info_api_url is required for non-OpenCSG skill sources"),
+	sourceURLErr := errorx.MirrorSourceURLInvalid(
+		errors.New(`source host "github.com" is neither a configured mirror source nor OpenCSG SaaS`),
 		errorx.Ctx(),
 	)
-	tester.mocks.mirror.EXPECT().CreateMirrorRepo(tester.Ctx(), mock.Anything).Return(nil, badRequestErr)
+	tester.mocks.mirror.EXPECT().CreateMirrorRepo(tester.Ctx(), mock.Anything).Return(nil, sourceURLErr)
 
 	tester.Execute()
 
 	tester.ResponseEqSimple(t, 400, gin.H{
-		"code": "REQ-ERR-0",
-		"msg":  "REQ-ERR-0: mirror_source_id with a configured info_api_url is required for non-OpenCSG skill sources",
+		"code": "MIRROR-ERR-8",
+		"msg":  `MIRROR-ERR-8: source host "github.com" is neither a configured mirror source nor OpenCSG SaaS`,
 	})
 }
 

--- a/common/errorx/error_mirror.go
+++ b/common/errorx/error_mirror.go
@@ -11,6 +11,7 @@ const (
 	mirrorSourceRepoAuthInvalid
 	sourceNamespaceMappingExists
 	sourceNamespaceMappingNotFound
+	mirrorSourceURLInvalid
 )
 
 var (
@@ -117,6 +118,19 @@ var (
 	//
 	// zh-HK: 源命名空間映射關係不存在。
 	ErrSourceNamespaceMappingNotFound error = CustomError{prefix: errMirrorPrefix, code: sourceNamespaceMappingNotFound}
+
+	// ErrMirrorSourceURLInvalid indicates that the mirror source URL is invalid or unsupported.
+	//
+	// Description: The mirror source URL is invalid or unsupported.
+	//
+	// Description_ZH: 镜像源地址无效或不受支持。
+	//
+	// en-US: The mirror source URL is invalid or unsupported.
+	//
+	// zh-CN: 镜像源地址无效或不受支持。
+	//
+	// zh-HK: 鏡像源地址無效或不受支持。
+	ErrMirrorSourceURLInvalid error = CustomError{prefix: errMirrorPrefix, code: mirrorSourceURLInvalid}
 )
 
 // MirrorSourceConflict wraps a mirror source conflict with optional context.
@@ -162,4 +176,9 @@ func SourceNamespaceMappingExists(err error, ctx context) error {
 // SourceNamespaceMappingNotFound wraps a missing source namespace mapping with optional context.
 func SourceNamespaceMappingNotFound(err error, ctx context) error {
 	return CustomError{prefix: errMirrorPrefix, context: ctx, err: err, code: int(sourceNamespaceMappingNotFound)}
+}
+
+// MirrorSourceURLInvalid wraps an invalid or unsupported mirror source URL with optional context.
+func MirrorSourceURLInvalid(err error, ctx context) error {
+	return CustomError{prefix: errMirrorPrefix, context: ctx, err: err, code: int(mirrorSourceURLInvalid)}
 }

--- a/common/errorx/errorx_test.go
+++ b/common/errorx/errorx_test.go
@@ -290,6 +290,16 @@ func Test_Err_SourceNamespaceMappingNotFound(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrSourceNamespaceMappingNotFound))
 }
 
+func Test_Err_MirrorSourceURLInvalid(t *testing.T) {
+	err := MirrorSourceURLInvalid(
+		errors.New("mirror source URL is invalid"),
+		Ctx().Set("source_url", "https://example.com/repo.git"),
+	)
+
+	assert.Equal(t, "MIRROR-ERR-8", ErrMirrorSourceURLInvalid.(CustomError).Code())
+	assert.True(t, errors.Is(err, ErrMirrorSourceURLInvalid))
+}
+
 func Test_Err_ChangePathBlocked(t *testing.T) {
 	err := ChangePathBlocked(
 		errors.New("cannot change path: the following dependent entities exist: deploy tasks, mirrors. Please remove them first"),

--- a/common/i18n/en-US/err_mirror.json
+++ b/common/i18n/en-US/err_mirror.json
@@ -22,5 +22,8 @@
     },
     "error.MIRROR-ERR-7": {
         "other": "The source namespace mapping does not exist."
+    },
+    "error.MIRROR-ERR-8": {
+        "other": "The mirror source URL is invalid or unsupported."
     }
 }

--- a/common/i18n/zh-CN/err_mirror.json
+++ b/common/i18n/zh-CN/err_mirror.json
@@ -22,5 +22,8 @@
     },
     "error.MIRROR-ERR-7": {
         "other": "源命名空间映射关系不存在。"
+    },
+    "error.MIRROR-ERR-8": {
+        "other": "镜像源地址无效或不受支持。"
     }
 }

--- a/common/i18n/zh-HK/err_mirror.json
+++ b/common/i18n/zh-HK/err_mirror.json
@@ -22,5 +22,8 @@
     },
     "error.MIRROR-ERR-7": {
         "other": "源命名空間映射關係不存在。"
+    },
+    "error.MIRROR-ERR-8": {
+        "other": "鏡像源地址無效或不受支持。"
     }
 }

--- a/component/mirror_repo.go
+++ b/component/mirror_repo.go
@@ -333,9 +333,13 @@ func (m *mirrorComponentImpl) resolveMirrorMetadataEndpoint(ctx context.Context,
 			if isOpenCSGSaaS {
 				return openCSGSaaSMetadataEndpoint, nil
 			}
-			return "", errorx.BadRequest(
-				fmt.Errorf("mirror source %d does not configure an info_api_url required for %s metadata", req.MirrorSourceID, req.RepoType),
-				errorx.Ctx().Set("mirror source id", req.MirrorSourceID).Set("repo type", req.RepoType),
+			return "", errorx.MirrorSourceURLInvalid(
+				fmt.Errorf("source host %q is neither configured by mirror source %d nor OpenCSG SaaS", parsedURL.Hostname(), req.MirrorSourceID),
+				errorx.Ctx().
+					Set("mirror source id", req.MirrorSourceID).
+					Set("repo type", req.RepoType).
+					Set("source host", parsedURL.Hostname()).
+					Set("source url", req.SourceGitCloneUrl),
 			)
 		}
 		endpoint, err := normalizeMirrorMetadataEndpoint(source.InfoAPIUrl)
@@ -352,9 +356,12 @@ func (m *mirrorComponentImpl) resolveMirrorMetadataEndpoint(ctx context.Context,
 		return openCSGSaaSMetadataEndpoint, nil
 	}
 
-	return "", errorx.BadRequest(
-		fmt.Errorf("mirror_source_id with a configured info_api_url is required for non-OpenCSG %s sources", req.RepoType),
-		errorx.Ctx().Set("repo type", req.RepoType).Set("source host", parsedURL.Hostname()),
+	return "", errorx.MirrorSourceURLInvalid(
+		fmt.Errorf("source host %q is neither a configured mirror source nor OpenCSG SaaS", parsedURL.Hostname()),
+		errorx.Ctx().
+			Set("repo type", req.RepoType).
+			Set("source host", parsedURL.Hostname()).
+			Set("source url", req.SourceGitCloneUrl),
 	)
 }
 

--- a/component/mirror_repo_test.go
+++ b/component/mirror_repo_test.go
@@ -3,7 +3,6 @@ package component
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -1482,18 +1481,21 @@ func TestMirrorComponent_CreateMirrorRepoRejectsUnsupportedMetadataSources(t *te
 		mirrorSource     *database.MirrorSource
 		mirrorSourceErr  error
 		wantErrorMessage string
+		wantError        error
 	}{
 		{
 			name:             "GitHub skill without mirror source",
 			repoType:         types.SkillRepo,
 			sourceURL:        "https://github.com/upstream/reviewer.git",
-			wantErrorMessage: "mirror_source_id with a configured info_api_url is required",
+			wantErrorMessage: "neither a configured mirror source nor OpenCSG SaaS",
+			wantError:        errorx.ErrMirrorSourceURLInvalid,
 		},
 		{
 			name:             "GitLab MCP without mirror source",
 			repoType:         types.MCPServerRepo,
 			sourceURL:        "https://gitlab.com/upstream/server.git",
-			wantErrorMessage: "mirror_source_id with a configured info_api_url is required",
+			wantErrorMessage: "neither a configured mirror source nor OpenCSG SaaS",
+			wantError:        errorx.ErrMirrorSourceURLInvalid,
 		},
 		{
 			name:             "missing mirror source",
@@ -1502,6 +1504,7 @@ func TestMirrorComponent_CreateMirrorRepoRejectsUnsupportedMetadataSources(t *te
 			mirrorSourceID:   51,
 			mirrorSourceErr:  sql.ErrNoRows,
 			wantErrorMessage: "mirror source 51 does not exist",
+			wantError:        errorx.ErrBadRequest,
 		},
 		{
 			name:           "mirror source without info API URL",
@@ -1511,7 +1514,8 @@ func TestMirrorComponent_CreateMirrorRepoRejectsUnsupportedMetadataSources(t *te
 			mirrorSource: &database.MirrorSource{
 				ID: 52,
 			},
-			wantErrorMessage: "does not configure an info_api_url",
+			wantErrorMessage: "neither configured by mirror source 52 nor OpenCSG SaaS",
+			wantError:        errorx.ErrMirrorSourceURLInvalid,
 		},
 		{
 			name:           "mirror source with invalid info API URL",
@@ -1523,6 +1527,7 @@ func TestMirrorComponent_CreateMirrorRepoRejectsUnsupportedMetadataSources(t *te
 				InfoAPIUrl: "ftp://community.example.com",
 			},
 			wantErrorMessage: "invalid info_api_url for mirror source 53",
+			wantError:        errorx.ErrBadRequest,
 		},
 	}
 
@@ -1556,7 +1561,7 @@ func TestMirrorComponent_CreateMirrorRepoRejectsUnsupportedMetadataSources(t *te
 			got, err := mc.CreateMirrorRepo(ctx, req)
 			require.Error(t, err)
 			require.ErrorContains(t, err, tt.wantErrorMessage)
-			require.True(t, errors.Is(err, errorx.ErrBadRequest))
+			require.ErrorIs(t, err, tt.wantError)
 			require.Nil(t, got)
 			require.Empty(t, fakeStore.inputs)
 		})

--- a/docs/error_codes_en.md
+++ b/docs/error_codes_en.md
@@ -1018,6 +1018,14 @@ This document lists all the custom error codes defined in the project, categoriz
 - **Error Name:** `sourceNamespaceMappingNotFound`
 - **Description:** The source namespace mapping does not exist.
 
+---
+
+### `MIRROR-ERR-8`
+
+- **Error Code:** `MIRROR-ERR-8`
+- **Error Name:** `mirrorSourceURLInvalid`
+- **Description:** The mirror source URL is invalid or unsupported.
+
 ## Moderation Errors
 
 ### `MOD-ERR-0`
@@ -1817,4 +1825,3 @@ This document lists all the custom error codes defined in the project, categoriz
 - **Error Code:** `USER-ERR-20`
 - **Error Name:** `namespaceAlreadyExists`
 - **Description:** The namespace already exists in the system.
-

--- a/docs/error_codes_zh.md
+++ b/docs/error_codes_zh.md
@@ -1018,6 +1018,14 @@
 - **错误名:** `sourceNamespaceMappingNotFound`
 - **描述:** 源命名空间映射关系不存在。
 
+---
+
+### `MIRROR-ERR-8`
+
+- **错误代码:** `MIRROR-ERR-8`
+- **错误名:** `mirrorSourceURLInvalid`
+- **描述:** 镜像源地址无效或不受支持。
+
 ## Moderation 错误
 
 ### `MOD-ERR-0`
@@ -1817,4 +1825,3 @@
 - **错误代码:** `USER-ERR-20`
 - **错误名:** `namespaceAlreadyExists`
 - **描述:** 命名空间已存在于系统中。
-


### PR DESCRIPTION
Summary:
- Reject invalid mirror metadata source URLs for MCP/skill syncs, restricting them to the allowed SaaS domain (opencsg.com)
- Replaced the generic "Bad Request" error with a specific i18n-friendly error message