### PR TITLE
ci: update checkout and setup-go to current majors in test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
-      - uses: actions/checkout@v4
+          go-version: "1.26"
+      - uses: actions/checkout@v7
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
@@ -30,15 +30,15 @@ jobs:
     name: swagger-gen
     strategy:
       matrix:
-        go: ["1.25"]
+        go: ["1.26"]
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go
         with:
           go-version: ${{ matrix.go }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v7
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: Gen
         run: |
@@ -48,15 +48,15 @@ jobs:
     name: test
     strategy:
       matrix:
-        go: ["1.25"]
+        go: ["1.26"]
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go
         with:
           go-version: ${{ matrix.go }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v7
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: Test
         run: go test ./...


### PR DESCRIPTION
Updates the Go test workflow to current action majors and pins Go 1.26.

Changes:
- `actions/checkout` v2/v4 to v7
- `actions/setup-go` v2/v5 to v7
- Go matrix and lint go-version: 1.25 to 1.26

Reason for the 1.26 pin: go.mod requires go 1.26.0, and the previous green runs relied on the old setup-go default GOTOOLCHAIN=auto downloading go 1.26 on top of the pinned 1.25. setup-go v6+ defaults to GOTOOLCHAIN=local, which surfaced the mismatch. Pinning 1.26 keeps the workflow on the toolchain the builds were already using.

Validation:
- YAML parses cleanly (python yaml.safe_load)
- Last green run on main used go1.26.0 via toolchain auto-download (run 33597053965 logs)

Scope: `.github/workflows/test.yaml` only. The publish and moderation workflows are untouched.