### PR TITLE
Fix PaddleOCR-VL pipeline selection and add doc preprocessing + embedded images to OCR

### DIFF
--- a/.specs/paddle-ocr/paddlex_vl.md
+++ b/.specs/paddle-ocr/paddlex_vl.md
@@ -95,15 +95,22 @@ PaddleX registers the PaddleOCR-VL series as independent top-level pipelines. Th
 | `PaddleOCR-VL-1.5` | `PP-DocLayoutV3` | `PaddleOCR-VL-1.5-0.9B` |
 | `PaddleOCR-VL-1.6` | `PP-DocLayoutV3` | `PaddleOCR-VL-1.6-0.9B` |
 
-The runtime derives the pipeline from the downloaded repository basename:
+The runtime reads the canonical recognition name from `Global.model_name` in the downloaded repository's `inference.yml`. Repository paths and CSGHub-imported names whose source namespace is flattened into an underscore prefix are storage identities only and do not participate in pipeline selection.
 
-| Model basename pattern | Selected pipeline |
+| `inference.yml` model name | Selected pipeline |
 | --- | --- |
-| `PaddleOCR-VL-1.6*` | `PaddleOCR-VL-1.6` |
-| `PaddleOCR-VL-1.5*` | `PaddleOCR-VL-1.5` |
-| `PaddleOCR-VL*` | `PaddleOCR-VL` |
+| `PaddleOCR-VL-0.9B` | `PaddleOCR-VL` |
+| `PaddleOCR-VL-<version>-0.9B` | `PaddleOCR-VL-<version>` |
 
-The most specific patterns must be evaluated first. Names outside the PaddleOCR-VL family fail startup. The broad base-family fallback supports existing base-repository naming variants; a new version must receive an explicit mapping and validation before it is declared supported.
+For the currently supported repositories this produces:
+
+| Metadata model name | Selected pipeline |
+| --- | --- |
+| `PaddleOCR-VL-0.9B` | `PaddleOCR-VL` |
+| `PaddleOCR-VL-1.5-0.9B` | `PaddleOCR-VL-1.5` |
+| `PaddleOCR-VL-1.6-0.9B` | `PaddleOCR-VL-1.6` |
+
+Missing or invalid metadata and names outside the PaddleOCR-VL family fail startup. The discovered metadata value is written to `VLRecognition.model_name`, while the downloaded repository directory is written to `VLRecognition.model_dir`. PaddleX's pipeline-config lookup remains the final validation that the derived pipeline version exists in the pinned runtime.
 
 The pipeline version, rather than custom CSGHub logic, selects `PP-DocLayoutV2` or `PP-DocLayoutV3`. `gen_pipeline.py` patches only `SubModules.VLRecognition`; it must not replace `SubModules.LayoutDetection`.
 
@@ -138,6 +145,7 @@ The main implementation seams are:
 | Runtime registration | `configs/inference/paddleocr-vl.json` |
 | Runtime image | `docker/inference/Dockerfile.paddleocr` |
 | Repository download | `docker/inference/paddleocr/entry.py` |
+| Model metadata parsing | `docker/inference/paddleocr/model_metadata.py` |
 | Framework and pipeline selection | `docker/inference/paddleocr/serve.sh` |
 | Generated-config patching | `docker/inference/paddleocr/gen_pipeline.py` |
 | Adapter registry and shared contract | `aigateway/component/adapter/ocr/adapter.go` |
@@ -198,9 +206,11 @@ paddlex --get_pipeline_config PaddleOCR-VL-1.6 \
 
 PaddleX deterministically writes `PaddleOCR-VL-1.6.yaml`. The runtime removes a stale generated copy first because `/workspace` can persist across restarts and the PaddleX CLI otherwise prompts before overwriting.
 
-`gen_pipeline.py` then updates only the selected recognition module:
+`gen_pipeline.py` points the selected recognition module at the downloaded repository and enables the optional document-preprocessor sub-pipeline so its models are available at request time:
 
 ```yaml
+use_doc_preprocessor: true
+
 SubModules:
   LayoutDetection:
     model_name: PP-DocLayoutV3
@@ -209,9 +219,14 @@ SubModules:
   VLRecognition:
     model_name: PaddleOCR-VL-1.6-0.9B
     model_dir: /workspace/<REPO_ID>
+
+SubPipelines:
+  DocPreprocessor:
+    use_doc_orientation_classify: true
+    use_doc_unwarping: true
 ```
 
-Leaving the layout `model_dir` unset is intentional: it activates PaddleX's established submodel-resolution behavior, which is also used by classic OCR detection and optional preprocessing models.
+This initializes `PP-LCNet_x1_0_doc_ori` and `UVDoc` when the service starts but does not require either operation to run for every request. Leaving their model directories and the layout `model_dir` unset is intentional: it activates PaddleX's established submodel-resolution behavior, which is also used by classic OCR detection. A local-only or explicitly supplied pipeline configuration owns its complete model layout and must initialize the same preprocessing capabilities if it accepts these request options.
 
 ## Model Source Strategy
 
@@ -292,8 +307,13 @@ Optional fields:
 | `use_doc_unwarping` | forwarded | forwarded |
 | `use_textline_orientation` | forwarded | rejected |
 | `return_image` | maps to upstream `visualize` | maps to upstream `visualize` |
-| `raw_response` | includes raw result | includes raw result and requests Markdown images |
+| `raw_response` | includes raw result | includes raw result |
 | `page_ranges` | rejected when non-empty | rejected when non-empty |
+
+For `paddleocr-vl`, `return_image` additionally requests upstream Markdown
+images (`returnMarkdownImages=true`) and surfaces them in `pages[].images` as
+base64. `raw_response` only controls whether the complete upstream response is
+echoed in `raw_result`.
 
 ### PaddleX VL upstream request
 
@@ -303,12 +323,19 @@ AIGateway converts the multipart upload to PaddleX JSON:
 {
   "file": "<base64 file bytes>",
   "fileType": 1,
+  "useDocOrientationClassify": false,
+  "useDocUnwarping": false,
   "visualize": false,
   "returnMarkdownImages": false
 }
 ```
 
-`fileType` is `1` for images and `0` for PDFs. `returnMarkdownImages` is enabled only when `raw_response=true`, because the normalized response has no stable contract for provider-specific embedded image payloads.
+`fileType` is `1` for images and `0` for PDFs. The adapter always sends both preprocessing booleans: omitted client options become `false`, while explicit values are preserved. This keeps preprocessing off for ordinary requests even though the models are initialized. `returnMarkdownImages` is enabled when `return_image=true`, so the upstream `markdown.images` mapping is populated and the normalized response can carry it in `pages[].images`.
+
+Compatibility note: before this change, `raw_response=true` implicitly requested
+`returnMarkdownImages=true`, so `raw_result` carried `markdown.images`. Clients
+that relied on that must now pass `return_image=true` explicitly; `raw_response`
+only controls whether the complete upstream response is echoed in `raw_result`.
 
 The adapter proxies this request to `/layout-parsing`. A model-level endpoint path may override the adapter's default endpoint.
 
@@ -326,7 +353,13 @@ The adapter proxies this request to `/layout-parsing`. A model-level endpoint pa
       "index": 0,
       "text": "page plain text",
       "markdown": "page markdown",
-      "lines": []
+      "lines": [],
+      "images": [
+        {
+          "name": "imgs/img_in_image_box_755_185_1522_685.jpg",
+          "content": "<base64 image bytes>"
+        }
+      ]
     }
   ],
   "usage": {
@@ -342,15 +375,16 @@ Response mapping:
 | --- | --- |
 | `layoutParsingResults[i].markdown.text` | `pages[i].markdown` |
 | `layoutParsingResults[i].prunedResult.parsing_res_list[].block_content` | joined into `pages[i].text` |
+| `layoutParsingResults[i].markdown.images` | `pages[i].images`, only with `return_image=true` |
 | all page text | joined into top-level `text` |
 | number of layout parsing results | `usage.pages` |
 | complete PaddleX response | `raw_result`, only with `raw_response=true` |
 
-The upstream `markdown` field is an object, while `OCRPage.Markdown` is deliberately a string. Only `markdown.text` is placed in the normalized page. The complete Markdown object, including `markdown.images`, remains available through `raw_result` when requested.
+The upstream `markdown` field is an object, while `OCRPage.Markdown` is deliberately a string. Only `markdown.text` is placed in the normalized page. The `markdown.images` mapping (filename -> base64) is normalized into `pages[i].images` with a stable filename order when `return_image=true`; it is omitted otherwise.
 
-`outputImages` and `markdown.images` must not be mapped to `pages[].image_url`: PaddleX may return base64 data rather than stable URLs. AIGateway does not upload these payloads to object storage in this version.
+`outputImages` and `markdown.images` must not be mapped to `pages[].image_url`: PaddleX may return base64 data rather than stable URLs, and AIGateway does not upload these payloads to object storage in this version. `pages[].images` carries the raw base64 content so clients can resolve the Markdown references themselves.
 
-The normalized Markdown is not guaranteed to be self-contained when PaddleX emits relative image references. Clients that need provider-specific Markdown assets must request `raw_response=true` and consume the complete `markdown.images` mapping from `raw_result`.
+The normalized Markdown is not guaranteed to be self-contained when PaddleX emits relative image references. Clients that need these assets request `return_image=true` and resolve the Markdown references against `pages[].images`; the complete `markdown.images` mapping also remains available in `raw_result` with `raw_response=true`.
 
 VL results use Markdown and page text rather than classic `OCRLine` values. Tables, formulas, and layout blocks remain in Markdown or `raw_result` instead of being represented as ordinary OCR lines.
 
@@ -399,7 +433,7 @@ Runtime model downloads use the deployment access token. AIGateway applies the r
 | --- | --- |
 | Missing or unknown image runtime-mode argument | Container startup fails |
 | Unknown PaddleOCR model source | Container startup fails |
-| Model basename outside the PaddleOCR-VL family | Container startup fails |
+| Missing or unsupported `inference.yml` model identity | Container startup fails |
 | Missing offline pipeline bundle | Container startup fails |
 | PaddleX fails to generate the selected pipeline config | Container startup fails |
 | PDF sent to classic OCR | AIGateway returns a client error |
@@ -413,11 +447,12 @@ Runtime model downloads use the deployment access token. AIGateway applies the r
 ### Runtime
 
 - Verify all three supported PaddleOCR-VL pipeline names generate the expected YAML filename.
-- Verify each model basename selects its matching pipeline.
+- Verify each `inference.yml` model identity selects its matching pipeline.
 - Verify the base pipeline retains `PP-DocLayoutV2`.
 - Verify the 1.5 and 1.6 pipelines retain `PP-DocLayoutV3`.
-- Verify generated patching changes only `VLRecognition`.
-- Verify layout submodels download through the configured model source in hub mode.
+- Verify generated patching preserves layout-model selection, points only `VLRecognition` at the deployed repository, and enables `DocPreprocessor`.
+- Verify layout and preprocessing submodels download through the configured model source in hub mode.
+- Verify `PP-LCNet_x1_0_doc_ori` and `UVDoc` initialize before serving becomes ready.
 - Verify a complete local-only bundle starts without network access.
 - Verify missing local-only submodels fail clearly.
 - Verify missing or unknown image runtime modes and non-PaddleOCR-VL model names fail startup.
@@ -430,11 +465,16 @@ Runtime model downloads use the deployment access token. AIGateway applies the r
 - Multi-page PDF parsing and correct page count.
 - Reading-order, table, and formula fixtures.
 - Image/PDF `fileType` mapping.
+- Omitted preprocessing options serialize upstream as explicit `false` values.
+- Orientation and unwarping opt-ins independently preserve explicit `true` values.
 - Unsupported classic PDF and VL text-line-orientation errors.
 - Rejection of non-empty `page_ranges`.
 - `markdown.text` string normalization.
-- Populated, missing, and null `markdown.images` inside raw results.
+- Populated, missing, and null `markdown.images` become `pages[].images` only
+  with `return_image=true`, in stable filename order.
 - Complete raw-response gating.
+- `return_image=true` requests upstream `returnMarkdownImages` and surfaces
+  base64 images in the normalized response.
 - Upstream HTTP-error passthrough and invalid-success-response handling.
 - OCR usage and trace metadata.
 

--- a/aigateway/component/adapter/ocr/paddlex_vl.go
+++ b/aigateway/component/adapter/ocr/paddlex_vl.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -44,8 +45,8 @@ func (a *PaddleXVLAdapter) EndpointPath(_ *types.Model) string {
 type paddleXVLRequest struct {
 	File                      string `json:"file"`
 	FileType                  int    `json:"fileType"`
-	UseDocOrientationClassify *bool  `json:"useDocOrientationClassify,omitempty"`
-	UseDocUnwarping           *bool  `json:"useDocUnwarping,omitempty"`
+	UseDocOrientationClassify bool   `json:"useDocOrientationClassify"`
+	UseDocUnwarping           bool   `json:"useDocUnwarping"`
 	Visualize                 bool   `json:"visualize"`
 	ReturnMarkdownImages      bool   `json:"returnMarkdownImages"`
 }
@@ -63,8 +64,8 @@ func (a *PaddleXVLAdapter) BuildUpstreamRequest(in *UpstreamInput) ([]byte, erro
 	return json.Marshal(paddleXVLRequest{
 		File:                      base64.StdEncoding.EncodeToString(in.FileBytes),
 		FileType:                  in.FileType,
-		UseDocOrientationClassify: in.UseDocOrientationClassify,
-		UseDocUnwarping:           in.UseDocUnwarping,
+		UseDocOrientationClassify: in.UseDocOrientationClassify != nil && *in.UseDocOrientationClassify,
+		UseDocUnwarping:           in.UseDocUnwarping != nil && *in.UseDocUnwarping,
 		Visualize:                 in.Visualize,
 		ReturnMarkdownImages:      in.ReturnMarkdownImages,
 	})
@@ -95,7 +96,10 @@ type paddleXVLParsingResult struct {
 }
 
 type paddleXVLMarkdown struct {
-	Text   *string         `json:"text"`
+	Text *string `json:"text"`
+	// Images is the upstream filename -> base64 mapping for embedded figures.
+	// The upstream contract is a JSON object or null; raw JSON is kept so an
+	// unexpected shape degrades to absent images instead of failing the page.
 	Images json.RawMessage `json:"images"`
 }
 
@@ -138,12 +142,16 @@ func (a *PaddleXVLAdapter) TransformResponse(respBody []byte, opts *ResponseOpti
 		}
 		pageText := strings.Join(blocks, "\n")
 		pageTexts = append(pageTexts, pageText)
-		resp.Pages = append(resp.Pages, types.OCRPage{
+		page := types.OCRPage{
 			Index:    i,
 			Text:     pageText,
 			Markdown: *result.Markdown.Text,
 			Lines:    []types.OCRLine{},
-		})
+		}
+		if opts != nil && opts.ReturnImage {
+			page.Images = ocrImagesFromMarkdown(markdownImages(result.Markdown.Images))
+		}
+		resp.Pages = append(resp.Pages, page)
 	}
 
 	resp.Text = strings.Join(pageTexts, "\n")
@@ -155,4 +163,36 @@ func (a *PaddleXVLAdapter) TransformResponse(respBody []byte, opts *ResponseOpti
 		}
 	}
 	return resp, nil
+}
+
+// markdownImages decodes the upstream markdown.images mapping. Non-object
+// values (arrays, strings, numbers) are treated as absent so a changed
+// upstream contract never fails the whole OCR response.
+func markdownImages(raw json.RawMessage) map[string]string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var images map[string]string
+	if err := json.Unmarshal(raw, &images); err != nil {
+		return nil
+	}
+	return images
+}
+
+// ocrImagesFromMarkdown converts the upstream markdown.images map
+// (filename -> base64) into the normalized OCRImage list with a stable order.
+func ocrImagesFromMarkdown(images map[string]string) []types.OCRImage {
+	if len(images) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(images))
+	for name := range images {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]types.OCRImage, 0, len(names))
+	for _, name := range names {
+		out = append(out, types.OCRImage{Name: name, Content: images[name]})
+	}
+	return out
 }

--- a/aigateway/component/adapter/ocr/paddlex_vl_test.go
+++ b/aigateway/component/adapter/ocr/paddlex_vl_test.go
@@ -3,6 +3,7 @@ package ocr
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,9 +38,40 @@ func TestPaddleXVLAdapter_BuildUpstreamRequest(t *testing.T) {
 	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("pdf-bytes")), got["file"])
 	assert.EqualValues(t, FileTypePDF, got["fileType"])
 	assert.Equal(t, true, got["useDocOrientationClassify"])
+	assert.Equal(t, false, got["useDocUnwarping"])
 	assert.Equal(t, true, got["visualize"])
 	assert.Equal(t, true, got["returnMarkdownImages"])
-	assert.NotContains(t, got, "useDocUnwarping")
+}
+
+func TestPaddleXVLAdapter_PreprocessingDefaultsAndOptIn(t *testing.T) {
+	tests := []struct {
+		name            string
+		orientation     *bool
+		unwarping       *bool
+		wantOrientation bool
+		wantUnwarping   bool
+	}{
+		{name: "defaults disabled"},
+		{name: "orientation enabled", orientation: boolPtr(true), wantOrientation: true},
+		{name: "unwarping enabled", unwarping: boolPtr(true), wantUnwarping: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := NewPaddleXVLAdapter().BuildUpstreamRequest(&UpstreamInput{
+				FileBytes:                 []byte("image"),
+				FileType:                  FileTypeImage,
+				UseDocOrientationClassify: tt.orientation,
+				UseDocUnwarping:           tt.unwarping,
+			})
+			require.NoError(t, err)
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(body, &got))
+			assert.Equal(t, tt.wantOrientation, got["useDocOrientationClassify"])
+			assert.Equal(t, tt.wantUnwarping, got["useDocUnwarping"])
+		})
+	}
 }
 
 func TestPaddleXVLAdapter_RejectsClassicTextlineOption(t *testing.T) {
@@ -80,7 +112,7 @@ const paddleXVLSuccessBody = `{
 
 func TestPaddleXVLAdapter_TransformResponse(t *testing.T) {
 	a := NewPaddleXVLAdapter()
-	resp, err := a.TransformResponse([]byte(paddleXVLSuccessBody), &ResponseOptions{ModelID: "owner/vl:1"})
+	resp, err := a.TransformResponse([]byte(paddleXVLSuccessBody), &ResponseOptions{ModelID: "owner/vl:1", ReturnImage: true})
 	require.NoError(t, err)
 
 	assert.Equal(t, "owner/vl:1", resp.Model)
@@ -89,10 +121,39 @@ func TestPaddleXVLAdapter_TransformResponse(t *testing.T) {
 	assert.Equal(t, "Title\nFirst paragraph", resp.Pages[0].Text)
 	assert.Equal(t, "# Title\n\nFirst paragraph", resp.Pages[0].Markdown)
 	assert.Empty(t, resp.Pages[0].Lines)
+	require.Len(t, resp.Pages[0].Images, 1)
+	assert.Equal(t, types.OCRImage{Name: "imgs/figure_1.jpg", Content: "aW1hZ2U="}, resp.Pages[0].Images[0])
 	assert.Equal(t, "| A | B |\n|---|---|", resp.Pages[1].Markdown)
+	assert.Empty(t, resp.Pages[1].Images)
 	assert.Equal(t, 2, resp.Usage.Pages)
 	assert.Equal(t, 1, resp.Usage.Images)
 	assert.Nil(t, resp.RawResult)
+}
+
+func TestPaddleXVLAdapter_TransformResponseOmitsImagesWithoutReturnImage(t *testing.T) {
+	resp, err := NewPaddleXVLAdapter().TransformResponse([]byte(paddleXVLSuccessBody), &ResponseOptions{ModelID: "owner/vl:1"})
+	require.NoError(t, err)
+
+	require.Len(t, resp.Pages, 2)
+	assert.Empty(t, resp.Pages[0].Images)
+	assert.Empty(t, resp.Pages[1].Images)
+}
+
+func TestPaddleXVLAdapter_TransformResponseToleratesUnexpectedMarkdownImages(t *testing.T) {
+	for _, imagesValue := range []string{`[]`, `"unexpected"`, `{"imgs/figure_1.jpg": 123}`} {
+		body := fmt.Sprintf(`{
+		  "errorCode": 0,
+		  "result": {"layoutParsingResults": [{
+		    "prunedResult": {"parsing_res_list": [{"block_content": "page text"}]},
+		    "markdown": {"text": "# Page text", "images": %s}
+		  }]}
+		}`, imagesValue)
+		resp, err := NewPaddleXVLAdapter().TransformResponse([]byte(body), &ResponseOptions{ReturnImage: true})
+		require.NoError(t, err, imagesValue)
+		require.Len(t, resp.Pages, 1, imagesValue)
+		assert.Equal(t, "# Page text", resp.Pages[0].Markdown, imagesValue)
+		assert.Empty(t, resp.Pages[0].Images, imagesValue)
+	}
 }
 
 func TestPaddleXVLAdapter_TransformResponseRawResult(t *testing.T) {

--- a/aigateway/handler/openai_ocr.go
+++ b/aigateway/handler/openai_ocr.go
@@ -54,8 +54,8 @@ var ocrAllowedContentTypes = map[string]struct{}{
 // @Param        use_doc_orientation_classify formData bool false "Enable document orientation classification"
 // @Param        use_doc_unwarping formData bool false "Enable document unwarping"
 // @Param        use_textline_orientation formData bool false "Enable text line orientation classification"
-// @Param        return_image formData bool false "Ask upstream to visualize results (images surface only in raw_result)"
-// @Param        raw_response formData bool false "Include the raw upstream OCR result in the response"
+// @Param        return_image formData bool false "Return embedded document images in pages[].images (base64)"
+// @Param        raw_response formData bool false "Include the raw upstream OCR result in the response (does not request embedded markdown images; pass return_image=true for those)"
 // @Success      200  {object}  types.OCRResponse "OK"
 // @Failure      400  {object}  error "Bad request"
 // @Failure      404  {object}  error "Model not found"
@@ -160,7 +160,7 @@ func (h *OpenAIHandlerImpl) OCR(c *gin.Context) {
 		UseDocUnwarping:           ocrReq.UseDocUnwarping,
 		UseTextlineOrientation:    ocrReq.UseTextlineOrientation,
 		Visualize:                 ocrReq.ReturnImage,
-		ReturnMarkdownImages:      ocrReq.RawResponse,
+		ReturnMarkdownImages:      ocrReq.ReturnImage,
 	})
 	if err != nil {
 		if errors.Is(err, ocr.ErrUnsupportedOption) {

--- a/aigateway/handler/openai_ocr_test.go
+++ b/aigateway/handler/openai_ocr_test.go
@@ -302,6 +302,8 @@ func TestOpenAIHandler_OCRPaddleXVLPDF(t *testing.T) {
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(gotBody, &payload))
 	assert.EqualValues(t, 0, payload["fileType"])
+	assert.Equal(t, false, payload["useDocOrientationClassify"])
+	assert.Equal(t, false, payload["useDocUnwarping"])
 	assert.Equal(t, false, payload["returnMarkdownImages"])
 
 	require.Equal(t, http.StatusOK, w.Code)
@@ -311,6 +313,119 @@ func TestOpenAIHandler_OCRPaddleXVLPDF(t *testing.T) {
 	require.Len(t, resp.Pages, 1)
 	assert.Equal(t, "# Page text", resp.Pages[0].Markdown)
 	assert.Empty(t, resp.Pages[0].Lines)
+	wg.Wait()
+}
+
+func TestOpenAIHandler_OCRPaddleXVLReturnImages(t *testing.T) {
+	tester, c, w := setupTest(t)
+
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+          "errorCode": 0,
+          "result": {"layoutParsingResults": [{
+            "prunedResult": {"parsing_res_list": [{"block_content": "page text"}]},
+            "markdown": {
+              "text": "# Page text",
+              "images": {"imgs/figure_1.jpg": "aW1hZ2U="}
+            }
+          }]}
+        }`))
+	}))
+	defer upstream.Close()
+
+	c.Request = withCancelableContext(t, newMultipartOCRRequest(t, "model1", "pdf-bytes", "application/pdf", map[string]string{
+		"return_image": "true",
+	}, 1))
+	model := ocrTestModelWithRuntime("model1", "paddleocr-vl-model", upstream.URL, "paddleocr-vl")
+	tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").Return(model, nil).Once()
+	tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	tester.mocks.openAIComp.EXPECT().
+		RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, "paddleocr-vl-model", mock.MatchedBy(func(usage *token.Usage) bool {
+			return usage != nil && usage.DataType == string(commontypes.DataTypeOCR) && usage.CompletionRC == 1
+		}), mock.Anything).
+		RunAndReturn(func(context.Context, string, *types.Model, string, *token.Usage, string) error {
+			wg.Done()
+			return nil
+		}).Once()
+
+	tester.handler.OCR(c)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &payload))
+	assert.Equal(t, true, payload["returnMarkdownImages"])
+	assert.Equal(t, true, payload["visualize"])
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp types.OCRResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Pages, 1)
+	require.Len(t, resp.Pages[0].Images, 1)
+	assert.Equal(t, types.OCRImage{Name: "imgs/figure_1.jpg", Content: "aW1hZ2U="}, resp.Pages[0].Images[0])
+	wg.Wait()
+}
+
+func TestOpenAIHandler_OCRPaddleXVLRawResponseOmitsMarkdownImages(t *testing.T) {
+	tester, c, w := setupTest(t)
+
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+          "errorCode": 0,
+          "result": {"layoutParsingResults": [{
+            "prunedResult": {"parsing_res_list": [{"block_content": "page text"}]},
+            "markdown": {
+              "text": "# Page text",
+              "images": {"imgs/figure_1.jpg": "aW1hZ2U="}
+            }
+          }]}
+        }`))
+	}))
+	defer upstream.Close()
+
+	c.Request = withCancelableContext(t, newMultipartOCRRequest(t, "model1", "pdf-bytes", "application/pdf", map[string]string{
+		"raw_response": "true",
+	}, 1))
+	model := ocrTestModelWithRuntime("model1", "paddleocr-vl-model", upstream.URL, "paddleocr-vl")
+	tester.mocks.openAIComp.EXPECT().GetModelByID(mock.Anything, "testuser", "model1").Return(model, nil).Once()
+	tester.mocks.openAIComp.EXPECT().CheckBalance(mock.Anything, "testuuid").Return(nil).Once()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	tester.mocks.openAIComp.EXPECT().
+		RecordUsageFromTokenUsage(mock.Anything, "testuuid", model, "paddleocr-vl-model", mock.MatchedBy(func(usage *token.Usage) bool {
+			return usage != nil && usage.DataType == string(commontypes.DataTypeOCR) && usage.CompletionRC == 1
+		}), mock.Anything).
+		RunAndReturn(func(context.Context, string, *types.Model, string, *token.Usage, string) error {
+			wg.Done()
+			return nil
+		}).Once()
+
+	tester.handler.OCR(c)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &payload))
+	assert.Equal(t, false, payload["returnMarkdownImages"])
+	assert.Equal(t, false, payload["visualize"])
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp types.OCRResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.RawResult)
+	rawJSON, err := json.Marshal(resp.RawResult)
+	require.NoError(t, err)
+	assert.Contains(t, string(rawJSON), "imgs/figure_1.jpg")
+	require.Len(t, resp.Pages, 1)
+	assert.Empty(t, resp.Pages[0].Images)
 	wg.Wait()
 }
 

--- a/aigateway/types/ocr.go
+++ b/aigateway/types/ocr.go
@@ -41,11 +41,20 @@ type OCRResponse struct {
 
 // OCRPage is the recognized content of a single page or image.
 type OCRPage struct {
-	Index    int       `json:"index"`
-	Text     string    `json:"text"`
-	Markdown string    `json:"markdown,omitempty"`
-	Lines    []OCRLine `json:"lines"`
-	ImageURL string    `json:"image_url,omitempty"`
+	Index    int        `json:"index"`
+	Text     string     `json:"text"`
+	Markdown string     `json:"markdown,omitempty"`
+	Lines    []OCRLine  `json:"lines"`
+	ImageURL string     `json:"image_url,omitempty"`
+	Images   []OCRImage `json:"images,omitempty"`
+}
+
+// OCRImage is one embedded image extracted from a page. Name matches the
+// reference used in Markdown (for example imgs/img_in_image_box_*.jpg) and
+// Content carries the base64-encoded image bytes.
+type OCRImage struct {
+	Name    string `json:"name"`
+	Content string `json:"content"`
 }
 
 // OCRLine is one recognized text line with its confidence and bounding box.

--- a/docker/inference/paddleocr/gen_pipeline.py
+++ b/docker/inference/paddleocr/gen_pipeline.py
@@ -1,9 +1,12 @@
-"""Patch a PaddleX OCR pipeline config to use the downloaded repo's weights.
+"""Patch PaddleX OCR pipeline configs for downloaded model repositories.
 
 The CSGHub repo is a single recognition model (e.g. PP-OCRv6_small_rec):
 TextRecognition is pointed at the local weights and TextDetection is switched
 to the matching-tier det model name (still resolved from the model sources).
 Language-prefixed rec repos (latin_/korean_/eslav_) map to the unprefixed det.
+
+PaddleOCR-VL points VLRecognition at the local repository and initializes the
+optional document-preprocessor models for per-request opt-in use.
 """
 
 import argparse
@@ -34,6 +37,28 @@ def patch_paddleocr_vl(cfg, model_name, model_dir):
     vl_recognition = sub_modules.get("VLRecognition")
     if vl_recognition is None:
         raise ValueError("PaddleOCR-VL pipeline config has no SubModules.VLRecognition")
+
+    sub_pipelines = cfg.get("SubPipelines", {})
+    doc_preprocessor = sub_pipelines.get("DocPreprocessor")
+    if doc_preprocessor is None:
+        raise ValueError(
+            "PaddleOCR-VL pipeline config has no SubPipelines.DocPreprocessor"
+        )
+
+    doc_preprocessor_modules = doc_preprocessor.get("SubModules", {})
+    required_modules = {"DocOrientationClassify", "DocUnwarping"}
+    missing_modules = required_modules - doc_preprocessor_modules.keys()
+    if missing_modules:
+        missing = ", ".join(sorted(missing_modules))
+        raise ValueError(
+            f"PaddleOCR-VL DocPreprocessor is missing required modules: {missing}"
+        )
+
+    # Load optional preprocessing models at startup; requests still decide
+    # whether either operation runs.
+    cfg["use_doc_preprocessor"] = True
+    doc_preprocessor["use_doc_orientation_classify"] = True
+    doc_preprocessor["use_doc_unwarping"] = True
 
     vl_recognition["model_name"] = model_name
     vl_recognition["model_dir"] = model_dir

--- a/docker/inference/paddleocr/model_metadata.py
+++ b/docker/inference/paddleocr/model_metadata.py
@@ -1,0 +1,22 @@
+import argparse
+
+import yaml
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("metadata_path")
+    args = parser.parse_args()
+
+    with open(args.metadata_path) as metadata_file:
+        metadata = yaml.safe_load(metadata_file) or {}
+
+    model_name = metadata.get("Global", {}).get("model_name")
+    if not isinstance(model_name, str) or not model_name.strip():
+        raise SystemExit(f"ERROR: {args.metadata_path} has no Global.model_name")
+
+    print(model_name.strip())
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/inference/paddleocr/serve.sh
+++ b/docker/inference/paddleocr/serve.sh
@@ -59,22 +59,25 @@ if [ -z "${PIPELINE}" ]; then
     echo "The model repo must be a PaddleX pipeline bundle (pipeline.yaml + local model_dir subdirs)." >&2
     exit 1
   elif [ "${RUNTIME_MODE}" = "paddleocr-vl" ]; then
-    MODEL_NAME="$(basename "${REPO_ID}")"
-    case "${MODEL_NAME}" in
-      PaddleOCR-VL-1.6*)
-        PIPELINE_NAME="PaddleOCR-VL-1.6"
-        ;;
-      PaddleOCR-VL-1.5*)
-        PIPELINE_NAME="PaddleOCR-VL-1.5"
-        ;;
-      PaddleOCR-VL*)
-        PIPELINE_NAME="PaddleOCR-VL"
-        ;;
-      *)
-        echo "ERROR: unsupported PaddleOCR-VL model '${MODEL_NAME}'" >&2
-        exit 1
-        ;;
-    esac
+    # Repository names may contain flattened namespace prefixes, so use the
+    # model's own metadata as the authoritative identity for pipeline selection.
+    MODEL_METADATA="${MODEL_DIR}/inference.yml"
+    [ -f "${MODEL_METADATA}" ] || {
+      echo "ERROR: PaddleOCR-VL model metadata not found at ${MODEL_METADATA}" >&2
+      exit 1
+    }
+    MODEL_NAME="$(python /etc/csghub/model_metadata.py "${MODEL_METADATA}")" || {
+      echo "ERROR: failed to read model metadata from ${MODEL_METADATA}" >&2
+      exit 1
+    }
+    if [ "${MODEL_NAME}" = "PaddleOCR-VL-0.9B" ]; then
+      PIPELINE_NAME="PaddleOCR-VL"
+    elif [[ "${MODEL_NAME}" =~ ^(PaddleOCR-VL-[0-9]+(\.[0-9]+)*)-0\.9B$ ]]; then
+      PIPELINE_NAME="${BASH_REMATCH[1]}"
+    else
+      echo "ERROR: unsupported PaddleOCR-VL model '${MODEL_NAME}' from ${MODEL_METADATA}" >&2
+      exit 1
+    fi
     GEN_DIR="${MODEL_DIR}/.csghub"
     PIPELINE="${GEN_DIR}/${PIPELINE_NAME}.yaml"
     rm -f "${PIPELINE}"


### PR DESCRIPTION
Summary:
- Fixed PaddleOCR-VL-1.6 deployment failures by replacing hardcoded model names with dynamic pipeline selection based on `inference.yml` metadata.
- Added optional document preprocessing (orientation classification and unwarping) to improve OCR results for complex scanned documents.
- Enabled embedded image extraction in OCR responses by parsing upstream markdown images into a new `images` field when `return_image=true` is requested.