### PR TITLE
deps: bump GitPython to 3.1.61 in space base requirements

### DIFF
--- a/docker/spaces/space/base_requirements.txt
+++ b/docker/spaces/space/base_requirements.txt
@@ -26,7 +26,7 @@ filelock==3.20.1
 frozenlist==1.8.0
 fsspec==2025.12.0
 gitdb==4.0.12
-GitPython==3.1.58
+GitPython==3.1.61
 gradio==6.2.0
 gradio_client==2.0.2
 groovy==0.1.2


### PR DESCRIPTION
Updates `GitPython` to address PYSEC-2026-3785, PYSEC-2026-3786, PYSEC-2026-3787, PYSEC-2026-3788.

Evidence:
- `docker/spaces/space/base_requirements.txt` referenced `GitPython==3.1.58`
- osv-scanner reported PYSEC-2026-3785, PYSEC-2026-3786, PYSEC-2026-3787, PYSEC-2026-3788 before the update
- updated version: `3.1.61`

Validation:
- osv-scanner no longer reports those advisories after the update
- `pip install GitPython==3.1.61` and `import git` succeed

Scope: dependency update only.
